### PR TITLE
feat(storybook): allow to switch themes

### DIFF
--- a/config/storybook/main.js
+++ b/config/storybook/main.js
@@ -24,6 +24,7 @@ module.exports = {
     },
     '@storybook/addon-a11y',
     '@storybook/addon-docs',
+    'storybook-addon-themes',
   ],
   webpackFinal: async config => {
     // Add support for TS path mapping

--- a/config/storybook/package.json
+++ b/config/storybook/package.json
@@ -22,6 +22,7 @@
     "@storybook/react": "5.3.17",
     "babel-loader": "8.1.0",
     "find-up": "4.1.0",
+    "storybook-addon-themes": "5.4.1",
     "tsconfig-paths-webpack-plugin": "3.2.0"
   }
 }

--- a/config/storybook/preview.js
+++ b/config/storybook/preview.js
@@ -1,4 +1,30 @@
-import { addDecorator } from '@storybook/react';
+import { addDecorator, addParameters } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
+import { withThemes } from 'storybook-addon-themes/react';
 
+import React from 'react';
+import { MarigoldProvider } from '@marigold/system';
+import b2bTheme from '@marigold/theme-b2b';
+import unicornTheme from '@marigold/theme-unicorn';
+
+// A11y
 addDecorator(withA11y);
+
+// Theme Switch
+const themes = {
+  b2b: b2bTheme,
+  unicorn: unicornTheme,
+};
+
+addDecorator(withThemes);
+addParameters({
+  themes: {
+    Decorator: ({ themeName, children }) => (
+      <MarigoldProvider theme={themes[themeName]}>{children}</MarigoldProvider>
+    ),
+    list: Object.keys(themes).map(name => ({
+      name,
+      color: themes[name].colors.primary,
+    })),
+  },
+});

--- a/packages/components/src/Label/Label.stories.mdx
+++ b/packages/components/src/Label/Label.stories.mdx
@@ -1,7 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
-import { MarigoldProvider } from '@marigold/system';
 import { Label } from './Label';
-import theme from '@marigold/theme-b2b';
 
 <Meta title="Components/Label" />
 
@@ -31,10 +29,8 @@ import { Label } from '@marigold/components';
 
 <Preview>
   <Story name="label">
-    <MarigoldProvider theme={theme}>
-      <Label variant="label" htmlFor="labelId">
-        I am a Label!
-      </Label>
-    </MarigoldProvider>
+    <Label variant="label" htmlFor="labelId">
+      I am a Label!
+    </Label>
   </Story>
 </Preview>

--- a/packages/components/src/Text/Text.stories.mdx
+++ b/packages/components/src/Text/Text.stories.mdx
@@ -1,7 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
-import { MarigoldProvider } from '@marigold/system';
 import { Text } from './Text';
-import theme from '@marigold/theme-b2b';
 
 <Meta title="Components/Text" />
 
@@ -32,20 +30,16 @@ import { Text } from '@marigold/components';
 
 <Preview>
   <Story name="text">
-    <MarigoldProvider theme={theme}>
-      <Text as="p" variant="body">
-        I am just Text
-      </Text>
-    </MarigoldProvider>
+    <Text as="p" variant="body">
+      I am just Text
+    </Text>
   </Story>
 </Preview>
 
 <Preview>
   <Story name="text2">
-    <MarigoldProvider theme={theme}>
-      <Text as="h1" variant="heading">
-        I am just a headline
-      </Text>
-    </MarigoldProvider>
+    <Text as="h1" variant="heading">
+      I am just a headline
+    </Text>
   </Story>
 </Preview>

--- a/themes/theme-unicorn/src/index.ts
+++ b/themes/theme-unicorn/src/index.ts
@@ -18,11 +18,11 @@ const theme: BaseTheme = {
     heading: 1.5,
   },
   colors: {
-    text: '#ffe6f7',
-    background: '#b30077',
-    primary: '#00b300',
-    secondary: '#e6b800',
-    muted: '#99994d',
+    text: '#070708',
+    background: '#fdfcfd',
+    primary: '#b30077',
+    secondary: '#ffdaf3',
+    muted: '#e9e7eb',
   },
   text: {
     body: {
@@ -37,7 +37,7 @@ const theme: BaseTheme = {
       fontSize: 5,
       lineHeight: 'heading',
       fontWeight: 'heading',
-      color: 'text',
+      color: 'primary',
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,6 +2340,19 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
+"@storybook/addons@^5.3.14":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.18.tgz#5cbba6407ef7a802041c5ee831473bc3bed61f64"
+  integrity sha512-ZQjDgTUDFRLvAiBg2d8FgPgghfQ+9uFyXQbtiGlTBLinrPCeQd7J86qiUES0fcGoohCCw0wWKtvB0WF2z1XNDg==
+  dependencies:
+    "@storybook/api" "5.3.18"
+    "@storybook/channels" "5.3.18"
+    "@storybook/client-logger" "5.3.18"
+    "@storybook/core-events" "5.3.18"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/api@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.17.tgz#1c0dad3309afef6b0a5585cb59c65824fb4d2721"
@@ -2352,6 +2365,32 @@
     "@storybook/csf" "0.0.1"
     "@storybook/router" "5.3.17"
     "@storybook/theming" "5.3.17"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    react "^16.8.3"
+    semver "^6.0.0"
+    shallow-equal "^1.1.0"
+    store2 "^2.7.1"
+    telejson "^3.2.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/api@5.3.18":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.18.tgz#95582ab90d947065e0e34ed603650a3630dcbd16"
+  integrity sha512-QXaccNCARHzPWOuxYndiebGWBZmwiUvRgB9ji0XTJBS3y8K0ZPb5QyuqiKPaEWUj8dBA8rzdDtkW3Yt95Namaw==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/channels" "5.3.18"
+    "@storybook/client-logger" "5.3.18"
+    "@storybook/core-events" "5.3.18"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "5.3.18"
+    "@storybook/theming" "5.3.18"
     "@types/reach__router" "^1.2.3"
     core-js "^3.0.1"
     fast-deep-equal "^2.0.1"
@@ -2381,6 +2420,13 @@
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.17.tgz#74eccb10c2395499da6a290bcd0272d6d6c7c5b2"
   integrity sha512-5hlBRbyk+YxC4KgecYG8wWwB2v1BzRJXhSlemFDOQk9wx37gVpne+rBydEtNFO4InmaZf6tKbBcpH0wBFLdWYA==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/channels@5.3.18":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.18.tgz#490c9eaa8292b0571c0f665052b12addf7c35f21"
+  integrity sha512-scP/6td/BJSEOgfN+qaYGDf3E793xye7tIw6W+sYqwg+xdMFO39wVXgVZNpQL6sLEwpJZTaPywCjC6p6ksErqQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2414,6 +2460,13 @@
   dependencies:
     core-js "^3.0.1"
 
+"@storybook/client-logger@5.3.18", "@storybook/client-logger@^5.3.14":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.18.tgz#27c9d09d788965db0164be6e168bc3f03adbf88f"
+  integrity sha512-RZjxw4uqZX3Yk27IirbB/pQG+wRsQSSRlKqYa8KQ5bSanm4IrcV9VA1OQbuySW9njE+CexAnakQJ/fENdmurNg==
+  dependencies:
+    core-js "^3.0.1"
+
 "@storybook/components@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.17.tgz#287430fc9c5f59b1d3590b50b3c7688355b22639"
@@ -2441,10 +2494,44 @@
     simplebar-react "^1.0.0-alpha.6"
     ts-dedent "^1.1.0"
 
+"@storybook/components@^5.3.14":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.18.tgz#528f6ab1660981e948993a04b407a6fad7751589"
+  integrity sha512-LIN4aVCCDY7klOwtuqQhfYz4tHaMADhXEzZpij+3r8N68Inck6IJ1oo9A9umXQPsTioQi8e6FLobH1im90j/2A==
+  dependencies:
+    "@storybook/client-logger" "5.3.18"
+    "@storybook/theming" "5.3.18"
+    "@types/react-syntax-highlighter" "11.0.4"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.9.1"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    popper.js "^1.14.7"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-dom "^16.8.3"
+    react-focus-lock "^2.1.0"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.8.3"
+    react-syntax-highlighter "^11.0.2"
+    react-textarea-autosize "^7.1.0"
+    simplebar-react "^1.0.0-alpha.6"
+    ts-dedent "^1.1.0"
+
 "@storybook/core-events@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.17.tgz#698ce0a36c29fe8fa04608f56ccca53aa1d31638"
   integrity sha512-DOeX9fpeGW4o9Gocxa4VW9wAlAyfIVNDTzq0wVvvMBthTTo9u58NmndglEMDgDa2Cq6iAIPh7vz2bRJCNexzLw==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@5.3.18", "@storybook/core-events@^5.3.14":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.18.tgz#e5d335f8a2c7dd46502b8f505006f1e111b46d49"
+  integrity sha512-uQ6NYJ5WODXK8DJ7m8y3yUAtWB3n+6XtYztjY+tdkCsLYvTYDXNS+epV+f5Hu9+gB+/Dm+b5Su4jDD+LZB2QWA==
   dependencies:
     core-js "^3.0.1"
 
@@ -2606,6 +2693,21 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
+"@storybook/router@5.3.18":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.18.tgz#8ab22f1f2f7f957e78baf992030707a62289076e"
+  integrity sha512-6B2U2C75KTSVaCuYYgcubeJGcCSnwsXuEf50hEd5mGqWgHZfojCtGvB7Ko4X+0h8rEC+eNA4p7YBOhlUv9WNrQ==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/csf" "0.0.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/source-loader@5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-5.3.17.tgz#f407aed52bc758b2c0c760d28b4525b8337e6944"
@@ -2641,6 +2743,24 @@
     "@emotion/core" "^10.0.20"
     "@emotion/styled" "^10.0.17"
     "@storybook/client-logger" "5.3.17"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    resolve-from "^5.0.0"
+    ts-dedent "^1.1.0"
+
+"@storybook/theming@5.3.18", "@storybook/theming@^5.3.14":
+  version "5.3.18"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.18.tgz#35e78de79d9cf8f1248af0dd1c7fa60555761312"
+  integrity sha512-lfFTeLoYwLMKg96N3gn0umghMdAHgJBGuk2OM8Ll84yWtdl9RGnzfiI1Fl7Cr5k95dCF7drLJlJCao1VxUkFSA==
+  dependencies:
+    "@emotion/core" "^10.0.20"
+    "@emotion/styled" "^10.0.17"
+    "@storybook/client-logger" "5.3.18"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -13431,6 +13551,21 @@ store2@^2.7.1:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.11.0.tgz#307636a239014ef4d8f1c8b47afe903509484fc8"
   integrity sha512-WeIZ5+c/KzBSutSqOjUCAkk1qTLVBcYUuvrhNx8ndjLZKdZRfP6Vv7AOxlynuL6tVU/6zt6e2CTHwWI5KE+fKg==
+
+storybook-addon-themes@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/storybook-addon-themes/-/storybook-addon-themes-5.4.1.tgz#de61b7f243eb80bfd6699eadca351f669d43593e"
+  integrity sha512-pSMiaXxe022Aq9pa2Xx97N0d49ihpgo6+dzlZOj9Vtz3ygoN5M8arnNSppp430lbhpOKfGSK3p8WPNMkfNBnWQ==
+  dependencies:
+    "@storybook/addons" "^5.3.14"
+    "@storybook/client-logger" "^5.3.14"
+    "@storybook/components" "^5.3.14"
+    "@storybook/core-events" "^5.3.14"
+    "@storybook/theming" "^5.3.14"
+    core-js "^2.6.5"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    util-deprecate "^1.0.2"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
- Use `storybook-addon-themes` to add a theme switch inside storybook
- Update `theme-unicorn` to be more fancy
- Remove all `<MarigoldProvider>` from stories, because it is added globally now!

Closes #154