### PR TITLE
chore: Remove `.dependabot`

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: 'javascript'
-    directory: '/'
-    update_schedule: 'weekly'


### PR DESCRIPTION
We have the integration enabled anyway.