### PR TITLE
feat: improve and cleanup <Button>

### DIFF
--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -13,10 +13,9 @@ Custom CSS styles can be added with the CSS prop.
 
 ## Properties
 
-| Property              | Type                                                                                                 | Default         |
-| :-------------------- | :--------------------------------------------------------------------------------------------------- | :-------------- |
-| `variant` (optional)  | `primary.small`, `primary.large`, `secondary.small`, `secondary.large`, `ghost.small`, `ghost.large` | `primary.large` |
-| `disabled` (optional) | boolean                                                                                              | `false`         |
+| Property             | Type                                                                                                 | Default         |
+| :------------------- | :--------------------------------------------------------------------------------------------------- | :-------------- |
+| `variant` (optional) | `primary.small`, `primary.large`, `secondary.small`, `secondary.large`, `ghost.small`, `ghost.large` | `primary.large` |
 
 ## Import
 

--- a/packages/components/src/Button/Button.stories.mdx
+++ b/packages/components/src/Button/Button.stories.mdx
@@ -3,22 +3,20 @@ import { Button } from './Button';
 
 <Meta title="Components/Button" />
 
-# Button-Component
+# Button
 
 ## Description
 
 With the Button component you can render a `button` element.
-By adding the `themeSection` prop you can change to another themeSection. `button` is the default section.
-The variant in your section can be added with the variant prop. E.g. `variant="primary.large"` or `variant="secondary.small"`.
-Specific css style prop can also be added.
+The style variant and size of the button can be added with the variant prop and is composed like `variant.size`.
+Custom CSS styles can be added with the CSS prop.
 
 ## Properties
 
-| Property       | Type        | Default    |
-| :------------- | :---------- | :--------- |
-| `themeSection` | `string`    | `'button'` |
-| `variant`      | `string`    | `''`       |
-| `css`          | `css props` |            |
+| Property              | Type                                                                                                 | Default         |
+| :-------------------- | :--------------------------------------------------------------------------------------------------- | :-------------- |
+| `variant` (optional)  | `primary.small`, `primary.large`, `secondary.small`, `secondary.large`, `ghost.small`, `ghost.large` | `primary.large` |
+| `disabled` (optional) | boolean                                                                                              | `false`         |
 
 ## Import
 
@@ -37,28 +35,8 @@ import { Button } from '@marigold/components';
   <Story name="secondary.large">
     <Button variant="secondary.large">Secondary</Button>
   </Story>
-  <Story name="disabled.large">
-    <Button variant="disabled.large">Disabled</Button>
-  </Story>
   <Story name="ghost.large">
     <Button variant="ghost.large">Ghost</Button>
-  </Story>
-  <Story name="ghostDisabled.large">
-    <Button variant="ghostDisabled.large">Ghost Disabled</Button>
-  </Story>
-</Preview>
-
-### Large Hovered
-
-<Preview>
-  <Story name="primaryHovered.large">
-    <Button variant="primaryHovered.large">Primary</Button>
-  </Story>
-  <Story name="secondaryHovered.large">
-    <Button variant="secondaryHovered.large">Secondary</Button>
-  </Story>
-  <Story name="ghostHovered.large">
-    <Button variant="ghostHovered.large">Ghost</Button>
   </Story>
 </Preview>
 
@@ -71,13 +49,27 @@ import { Button } from '@marigold/components';
   <Story name="secondary.small">
     <Button variant="secondary.small">Secondary</Button>
   </Story>
-  <Story name="disabled.small">
-    <Button variant="disabled.small">Disabled</Button>
-  </Story>
   <Story name="ghost.small">
     <Button variant="ghost.small">Ghost</Button>
   </Story>
-  <Story name="ghostDisabled.small">
-    <Button variant="ghostDisabled.small">Ghost Disabled</Button>
+</Preview>
+
+### Disabled
+
+<Preview>
+  <Story name="primary.large.disabled">
+    <Button variant="primary.large" disabled>
+      Primary Large Disabled
+    </Button>
+  </Story>
+  <Story name="secondary.large.disabled">
+    <Button variant="secondary.large" disabled>
+      Secondary Large Disabled
+    </Button>
+  </Story>
+  <Story name="ghost.large.disabled">
+    <Button variant="ghost.large" disabled>
+      Ghost Large Disabled
+    </Button>
   </Story>
 </Preview>

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Box, system } from '@marigold/system';
 
-type ButtonProps = {};
+type ButtonProps = {
+  disabled?: boolean;
+};
 
 export const Button = system<ButtonProps, 'button'>(
-  ({ variant = '', children, ...props }) => {
+  ({ variant = 'primary.large', disabled, children, ...props }) => {
     return (
-      <Box {...props} as="button" themeSection="button" variant={variant}>
+      <Box
+        {...props}
+        as="button"
+        themeSection="button"
+        variant={variant}
+        disabled={disabled}
+      >
         {children}
       </Box>
     );

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
 import { Box, system } from '@marigold/system';
 
-type ButtonProps = {
-  disabled?: boolean;
-};
+type ButtonProps = {};
 
 export const Button = system<ButtonProps, 'button'>(
-  ({ variant = 'primary.large', disabled, children, ...props }) => {
+  ({ variant = 'primary.large', children, ...props }) => {
     return (
-      <Box
-        {...props}
-        as="button"
-        themeSection="button"
-        variant={variant}
-        disabled={disabled}
-      >
+      <Box {...props} as="button" themeSection="button" variant={variant}>
         {children}
       </Box>
     );

--- a/themes/theme-b2b/src/index.ts
+++ b/themes/theme-b2b/src/index.ts
@@ -6,6 +6,7 @@ const button = {
     fontFamily: 'body',
     fontSize: 1,
     fontWeight: 400,
+    border: 'none',
     borderRadius: '2px',
   },
   large: {
@@ -19,33 +20,45 @@ const button = {
   primary: {
     color: 'background',
     bg: 'primary',
+    ':hover': {
+      color: 'background',
+      bg: '#f8ac67',
+      cursor: 'pointer',
+    },
+    ':disabled': {
+      color: '#cccccc',
+      bg: '#f3f3f3',
+      cursor: 'not-allowed',
+    },
   },
   secondary: {
     color: 'background',
     bg: 'secondary',
-  },
-  disabled: {
-    color: '#cccccc',
-    bg: '#f3f3f3',
+    ':hover': {
+      color: 'background',
+      bg: '#6d6d6d',
+      cursor: 'pointer',
+    },
+    ':disabled': {
+      color: '#cccccc',
+      bg: '#f3f3f3',
+      cursor: 'not-allowed',
+    },
   },
   ghost: {
     color: 'secondary',
-  },
-  ghostDisabled: {
-    color: '#e3e3e3',
-  },
-  primaryHovered: {
-    color: 'background',
-    bg: '#f8ac67',
-  },
-  secondaryHovered: {
-    color: 'background',
-    bg: '#6d6d6d',
-  },
-  ghostHovered: {
-    color: 'secondary',
-    border: '1px solid #4b4b4b',
-    bg: '#e3e3e3',
+    ':hover': {
+      color: 'secondary',
+      outline: '1px solid #4b4b4b',
+      bg: '#e3e3e3',
+      cursor: 'pointer',
+    },
+    ':disabled': {
+      color: '#cccccc',
+      bg: '#f3f3f3',
+      cursor: 'not-allowed',
+      outline: 'none',
+    },
   },
 };
 
@@ -125,18 +138,6 @@ const theme: BaseTheme = {
         ...button.large,
       },
     },
-    disabled: {
-      small: {
-        ...button.root,
-        ...button.disabled,
-        ...button.small,
-      },
-      large: {
-        ...button.root,
-        ...button.disabled,
-        ...button.large,
-      },
-    },
     ghost: {
       small: {
         ...button.root,
@@ -146,39 +147,6 @@ const theme: BaseTheme = {
       large: {
         ...button.root,
         ...button.ghost,
-        ...button.large,
-      },
-    },
-    ghostDisabled: {
-      small: {
-        ...button.root,
-        ...button.ghostDisabled,
-        ...button.small,
-      },
-      large: {
-        ...button.root,
-        ...button.ghostDisabled,
-        ...button.large,
-      },
-    },
-    primaryHovered: {
-      large: {
-        ...button.root,
-        ...button.primaryHovered,
-        ...button.large,
-      },
-    },
-    secondaryHovered: {
-      large: {
-        ...button.root,
-        ...button.secondaryHovered,
-        ...button.large,
-      },
-    },
-    ghostHovered: {
-      large: {
-        ...button.root,
-        ...button.ghostHovered,
         ...button.large,
       },
     },


### PR DESCRIPTION
- rearranged theme order: added hover and disabled as pseudo classes to the variants `primary`, `secondary` and `ghost`
- added `disabled` as a property
- updated stories, properly filled in the property table