### PR TITLE
chore: ignore icons in jest

### DIFF
--- a/config/jest/index.js
+++ b/config/jest/index.js
@@ -30,6 +30,7 @@ module.exports = (overrides = {}) => {
       '!**/node_modules/**',
       '!**/dist/**',
       '!**/themes/**',
+      '!**/icons/**',
     ],
 
     // plugins


### PR DESCRIPTION
#192

This is why Icons are just using the SVG-component which is tested seperate