### PR TITLE
refa: make <Select> use `useStyles` hook instead of <Box>

### DIFF
--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -66,3 +66,16 @@ test('variant styles cannot be overridden with CSS prop', () => {
   expect(select).not.toHaveStyle(`font-family: Oswald Regular`);
   expect(select).toHaveStyle(`font-family: Inter`);
 });
+
+test('accepts custom styles prop className', () => {
+  render(
+    <ThemeProvider theme={theme}>
+      <Select className="custom-class-name" title="select">
+        <option>1</option>
+      </Select>
+    </ThemeProvider>
+  );
+  const select = screen.getByTitle(/select/);
+
+  expect(select.className).toMatch('custom-class-name');
+});

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { MarigoldProvider } from '@marigold/system';
+import { ThemeProvider } from '@marigold/system';
 import { Select } from '@marigold/components';
 
 const theme = {
@@ -16,11 +16,11 @@ const theme = {
 
 test('supports default variant and themeSection', () => {
   render(
-    <MarigoldProvider theme={theme}>
+    <ThemeProvider theme={theme}>
       <Select title="select">
         <option>1</option>
       </Select>
-    </MarigoldProvider>
+    </ThemeProvider>
   );
   const select = screen.getByTitle(/select/);
 
@@ -29,11 +29,11 @@ test('supports default variant and themeSection', () => {
 
 test('accepts other variant than default', () => {
   render(
-    <MarigoldProvider theme={theme}>
+    <ThemeProvider theme={theme}>
       <Select title="select" variant="other">
         <option>1</option>
       </Select>
-    </MarigoldProvider>
+    </ThemeProvider>
   );
   const select = screen.getByTitle(/select/);
 
@@ -42,11 +42,11 @@ test('accepts other variant than default', () => {
 
 test('renders correct HTML element', () => {
   render(
-    <MarigoldProvider theme={theme}>
+    <ThemeProvider theme={theme}>
       <Select title="select">
         <option>1</option>
       </Select>
-    </MarigoldProvider>
+    </ThemeProvider>
   );
   const select = screen.getByTitle(/select/);
 
@@ -55,11 +55,11 @@ test('renders correct HTML element', () => {
 
 test('variant styles cannot be overridden with CSS prop', () => {
   render(
-    <MarigoldProvider theme={theme}>
+    <ThemeProvider theme={theme}>
       <Select title="select" css={{ fontFamily: 'Oswald Regular' }}>
         <option>1</option>
       </Select>
-    </MarigoldProvider>
+    </ThemeProvider>
   );
   const select = screen.getByTitle(/select/);
 

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
-import { Box, system } from '@marigold/system';
+import { system, useStyles } from '@marigold/system';
 import { ArrowDown } from '@marigold/icons';
 
 type SelectProps = {};
 
 export const Select = system<SelectProps, 'select'>(
-  ({ variant = 'select', ref, ...props }) => {
+  ({ variant = 'select', className, ref, ...props }) => {
+    const selectStyles = useStyles(
+      {
+        variant: `form.${variant}`,
+      },
+      className
+    );
+    const iconStyles = useStyles({
+      alignSelf: 'center',
+      pointerEvents: 'none',
+      ml: '-28px',
+    });
+
     return (
-      <Box css={{ display: 'flex' }}>
-        <Box
-          as="select"
-          ref={ref}
-          themeSection="form"
-          variant={variant}
-          {...props}
-        />
-        <ArrowDown
-          ml={'-28px'}
-          css={{
-            alignSelf: 'center',
-            pointerEvents: 'none',
-          }}
-        />
-      </Box>
+      <div className={useStyles({ display: 'flex' })}>
+        <select ref={ref} {...props} className={selectStyles} />
+        <ArrowDown className={iconStyles} />
+      </div>
     );
   }
 );


### PR DESCRIPTION
closes #562 
closes #361 