### PR TITLE
feat: Make `ComponentWithAs` and HTMLProps more awesome

### DIFF
--- a/packages/components/src/Alert/Alert.tsx
+++ b/packages/components/src/Alert/Alert.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { HTMLProps } from '@marigold/types';
+import { ComponentProps } from '@marigold/types';
 import { Box } from '../Box';
 
 type AlertProps = {
   variant?: string;
-} & HTMLProps<'div'>;
+} & ComponentProps<'div'>;
 
 export const Alert: React.FC<AlertProps> = ({
   variant = 'info',

--- a/packages/components/src/Badge/Badge.tsx
+++ b/packages/components/src/Badge/Badge.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { HTMLProps } from '@marigold/types';
+import { ComponentProps } from '@marigold/types';
 import { Box } from '../Box';
 
 type BadgeProps = {
   variant?: string;
-} & HTMLProps<'div'>;
+} & ComponentProps<'div'>;
 
 export const Badge: React.FC<BadgeProps> = ({
   variant = 'badge',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  ComponentPropsWithRef,
-  ElementType,
-  ReactElement,
-  ValidationMap,
-  WeakValidationMap,
-} from 'react';
+import React from 'react';
 
 /**
  * Get values of an `array` as literals.
@@ -12,43 +6,64 @@ import {
 export type ValueOf<T> = T[keyof T];
 
 /**
- * Get HTML props for a certain element.
+ * Get props without supporting `ref` and strip the `style` prop.
+ *
+ * @example <caption>Will contain all HTML attributes of a regular button element, minus "style"</caption>
+ * type ButtonProps = ComponentProps<'button'>
  */
-export type HTMLProps<Tag extends keyof JSX.IntrinsicElements> = Omit<
-  JSX.IntrinsicElements[Tag],
+export type ComponentProps<T extends React.ElementType> = Omit<
+  React.ComponentPropsWithoutRef<T>,
   'style'
 >;
 
 /**
- * Typings are based on [Reach UI](https://github.com/reach/reach-ui/blob/4cb497f530b0f83f80c6f6f2da46ab55b1160cb6/packages/utils/src/types.tsx).
- */
-/**
- * SystemProps support the `as` and `variant` prop. The former
- * is used to changed the rendered root element of a component.
+ * Get props with supporting `ref` and strip the `style` prop.
  *
- * These props also infer additional allowed props based on the
- * value of the `as` prop. For example, setting `as="button"` will
- * allow to use HTMLButtonAttributes on the component.
+ * @example <caption>Will contain all HTML attributes of a regular button element, minus "style"</caption>
+ * type ButtonProps = ComponentProps<'button'>
  */
-export type AsProps<P, T extends ElementType> = P &
+export type ComponentPropsWithRef<T extends React.ElementType> = Omit<
+  React.ComponentPropsWithRef<T>,
+  'style'
+>;
+
+/**********************************************/
+/*                                            */
+/*     COMPONENT SUPPORTING THE "AS" PROP     */
+/*                                            */
+/**********************************************/
+
+// Remove call signature from `ForwardRefExoticComponent` so we can override it
+type ForwardRefComponent<P> = Pick<
+  React.ForwardRefExoticComponent<P>,
+  keyof React.ForwardRefExoticComponent<any>
+>;
+
+/**
+ * Props containing the generic `as` prop and supporting `ref`.
+ */
+export type AsProps<P, T extends React.ElementType> = P &
   Omit<ComponentPropsWithRef<T>, 'as' | keyof P> & {
     as?: T;
   };
 
 /**
- * Enhanced version of `React.FunctionComponent` that accepts `SystemProps`
- * and infers allowed properties based on the `as` prop.
+ * Component that supports the `as` prop. Meaning, the component allows to change
+ * the element that renders. This is convenient to create components like `<Text>`
+ * that can render as different text elements like `h1`, `h2`, `p` and so on.
+ *
+ * **Note that you should use React's `forwardRef` with this type.**
+ *
+ * @example
+ * const Component: ComponentWithAs<{ foo?: string; }, 'div'>
+ *   = forwardRef((props, ref) => <div>p{rops.children}</div>);
  */
-export interface ComponentWithAs<P, T extends ElementType> {
-  /**
-   * These types are a bit of a hack, but cover us in cases where the `as` prop
-   * is not a JSX string type. Makes the compiler happy so 🤷‍♂️
-   */
-  <TT extends ElementType>(props: AsProps<P, TT>): ReactElement | null;
-  (props: AsProps<P, T>): ReactElement | null;
-
-  displayName?: string;
-  propTypes?: WeakValidationMap<AsProps<P, T>>;
-  contextTypes?: ValidationMap<any>;
-  defaultProps?: Partial<AsProps<P, T>>;
+export interface ComponentWithAs<P, T extends React.ElementType>
+  extends ForwardRefComponent<any> {
+  (
+    props: P & React.ComponentPropsWithRef<T> & { as?: never }
+  ): React.ReactElement<P> | null;
+  <As extends React.ElementType>(
+    props: AsProps<P, As>
+  ): React.ReactElement<P> | null;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -49,10 +49,12 @@ export type AsProps<P, T extends React.ElementType> = P &
 
 /**
  * Component that supports the `as` prop. Meaning, the component allows to change
- * the element that renders. This is convenient to create components like `<Text>`
- * that can render as different text elements like `h1`, `h2`, `p` and so on.
+ * the element that is bening renders.
  *
- * **Note that you should use React's `forwardRef` with this type.**
+ * This is convenient to create components like `<Text>` that can render as different
+ * text elements like `h1`, `h2`, `p` and so on.
+ *
+ * **Note: you should use React's `forwardRef` with this type.**
  *
  * @example
  * const Component: ComponentWithAs<{ foo?: string; }, 'div'>


### PR DESCRIPTION
Also HTMLProps have a different name now. Reason: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#componentprops

Closes #794