### PR TITLE
add as prop to Heading

### DIFF
--- a/packages/components/src/Heading/Heading.stories.mdx
+++ b/packages/components/src/Heading/Heading.stories.mdx
@@ -11,9 +11,10 @@ Use the Heading component for headings of texts. Predefined variants are `h1`, `
 
 ## Properties
 
-| Property  | Type     | Default |
-| :-------- | :------- | :------ |
-| `variant` | `string` | `h2`    |
+| Property  | Type                               | Default |
+| :-------- | :--------------------------------- | :------ |
+| `as`      | `h1`, `h2`, `h3`, `h4`, `h5`, `h6` | `h2`    |
+| `variant` | `string`                           | `h2`    |
 
 ## Import
 
@@ -26,7 +27,9 @@ import { Heading } from '@marigold/components';
 <Canvas>
   <Story name="Headings">
     <div>
-      <Heading variant="h1">H1 amazing heading</Heading>
+      <Heading as="h2" variant="h1">
+        H1 amazing heading
+      </Heading>
       <Text as="p" variant="heading">
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
         eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -42,7 +45,9 @@ import { Heading } from '@marigold/components';
         clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit
         amet.
       </Text>
-      <Heading variant="h3">H3 amazing heading</Heading>
+      <Heading as="h3" variant="h3">
+        H3 amazing heading
+      </Heading>
       <Text as="p" variant="heading">
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
         eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -50,7 +55,9 @@ import { Heading } from '@marigold/components';
         clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit
         amet.
       </Text>
-      <Heading variant="h4">H4 amazing heading</Heading>
+      <Heading as="h4" variant="h4">
+        H4 amazing heading
+      </Heading>
       <Text as="p" variant="heading">
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
         eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -58,7 +65,9 @@ import { Heading } from '@marigold/components';
         clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit
         amet.
       </Text>
-      <Heading variant="h5">H5 amazing heading</Heading>
+      <Heading as="h5" variant="h5">
+        H5 amazing heading
+      </Heading>
       <Text as="p" variant="heading">
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
         eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
@@ -66,7 +75,9 @@ import { Heading } from '@marigold/components';
         clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit
         amet.
       </Text>
-      <Heading variant="h6">H6 amazing heading</Heading>
+      <Heading as="h6" variant="h6">
+        H6 amazing heading
+      </Heading>
       <Text as="p" variant="heading">
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
         eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam

--- a/packages/components/src/Heading/Heading.test.tsx
+++ b/packages/components/src/Heading/Heading.test.tsx
@@ -38,12 +38,26 @@ test('accepts other variant than default', () => {
   expect(heading).toHaveStyle(`font-family: Roboto`);
 });
 
-test('renders correct HTML element', () => {
+test('supports default as prop', () => {
+  render(<Heading title="default">Default</Heading>);
+  const heading = screen.getByTitle(/default/);
+
+  expect(heading.tagName).toEqual('H2');
+});
+
+test('accepts other as prop than default', () => {
   render(
-    <ThemeProvider theme={theme}>
-      <Heading title="default">Default</Heading>
-    </ThemeProvider>
+    <Heading as="h3" title="default" variant="h3">
+      Default
+    </Heading>
   );
+  const heading = screen.getByTitle(/default/);
+
+  expect(heading.tagName).toEqual('H3');
+});
+
+test('renders correct HTML element', () => {
+  render(<Heading title="default">Default</Heading>);
   const heading = screen.getByTitle(/default/);
 
   expect(heading instanceof HTMLHeadingElement).toBeTruthy();

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -3,15 +3,17 @@ import { ComponentProps } from '@marigold/types';
 import { Box } from '../Box';
 
 type HeadingProps = {
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   variant?: string;
 } & ComponentProps<'h1'>;
 
 export const Heading: React.FC<HeadingProps> = ({
+  as = 'h2',
   variant = 'h2',
   children,
   ...props
 }) => (
-  <Box {...props} as="h2" variant={`text.${variant}`}>
+  <Box {...props} as={as} variant={`text.${variant}`}>
     {children}
   </Box>
 );


### PR DESCRIPTION
closes #802

We could also write that default as = variant. Then you only have to type one prop. 
I think users only pass variant and then you have different variant and as.
@sebald 