### PR TITLE
chore: cleanup package deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.2.8",
     "@changesets/cli": "2.14.1",
-    "@emotion/css": "11.1.3",
     "@marigold/eslint-config": "*",
     "@marigold/jest-config": "*",
     "@marigold/prettier-config": "*",
@@ -24,7 +23,6 @@
     "@testing-library/react": "11.2.5",
     "@testing-library/react-hooks": "5.1.0",
     "@types/node": "14.14.32",
-    "eslint-config-react-app": "6.0.0",
     "husky": "5.1.3",
     "prettier": "2.2.1",
     "pretty-quick": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17868,7 +17868,6 @@ fsevents@^1.2.7:
   dependencies:
     "@changesets/changelog-github": 0.2.8
     "@changesets/cli": 2.14.1
-    "@emotion/css": 11.1.3
     "@marigold/eslint-config": "*"
     "@marigold/jest-config": "*"
     "@marigold/prettier-config": "*"
@@ -17879,7 +17878,6 @@ fsevents@^1.2.7:
     "@testing-library/react": 11.2.5
     "@testing-library/react-hooks": 5.1.0
     "@types/node": 14.14.32
-    eslint-config-react-app: 6.0.0
     husky: 5.1.3
     prettier: 2.2.1
     pretty-quick: 3.1.0


### PR DESCRIPTION
- @emotion/css was there by accident
- eslint-config-react-app was there because of a hoisting issue with yarn 1.x