### PR TITLE
fix(comp): inline-flex to Inline Box

### DIFF
--- a/.changeset/dull-waves-turn.md
+++ b/.changeset/dull-waves-turn.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix(comp): inline-flex to Inline Box

--- a/packages/components/src/Inline/Inline.tsx
+++ b/packages/components/src/Inline/Inline.tsx
@@ -31,7 +31,9 @@ export const Inline: React.FC<InlineProps> = ({
     {Children.map(
       flattenChildren(children) as unknown as React.ReactElement,
       (child: React.ReactElement) => (
-        <Box>{React.cloneElement(child, {}, child.props.children)}</Box>
+        <Box display="inline-flex">
+          {React.cloneElement(child, {}, child.props.children)}
+        </Box>
       )
     )}
   </Box>


### PR DESCRIPTION
wrong since the last Inline comp change.

from this:
![image](https://user-images.githubusercontent.com/59875255/146545057-d6250987-0951-4905-a4ee-2d1a2ba9e0ef.png)

to this: 
![image](https://user-images.githubusercontent.com/59875255/146545092-5d731b61-d6b9-4e55-a54b-5457142d6f32.png)

same for ActionGroup