### PR TITLE
feat(docs): navigate to installation to fix bug

### DIFF
--- a/.changeset/afraid-buses-travel.md
+++ b/.changeset/afraid-buses-travel.md
@@ -1,0 +1,5 @@
+---
+"@marigold/docs": patch
+---
+
+feat(docs): navigate to installation to fix bug

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -11,14 +11,3 @@ exports.onCreateWebpackConfig = ({ stage, actions }) => {
     },
   });
 };
-
-exports.createPages = ({ actions }) => {
-  const { createRedirect } = actions;
-
-  createRedirect({
-    fromPath: '/',
-    toPath: '/guides/installation',
-    redirectInBrowser: true,
-    isPermanent: true,
-  });
-};

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
+import { useEffect } from 'react';
+import { navigate } from 'gatsby';
 
 export default function LandingPage() {
-  return <em>Currently not in use!</em>;
+  useEffect(() => {
+    navigate('/guides/installation');
+  }, []);
+
+  return null;
 }


### PR DESCRIPTION
mdx pages are shown "Navigated to ${page}" at the end of every page. This comes from gatsby-node (line 15). Detected with GIT bisect 🎉
This is our current solution and will be replaced with a good landing page in the future.