### PR TITLE
fix: use gatsby link in mdx

### DIFF
--- a/docs/src/mdx.tsx
+++ b/docs/src/mdx.tsx
@@ -6,6 +6,7 @@ import { Box, Text } from '@marigold/components';
 import { ComponentProps } from '@marigold/types';
 
 import { Preview } from './components/Preview';
+import { Link } from './components/Link';
 
 // Typography
 // ---------------
@@ -50,6 +51,8 @@ export const p: React.FC<ComponentProps<'p'>> = ({ children, ...props }) => (
     {children}
   </Text>
 );
+
+export const a = Link;
 
 // Code
 // ---------------


### PR DESCRIPTION
closes #1760