### PR TITLE
feat: extend svg fill prop to handle theme color

### DIFF
--- a/.changeset/plenty-tools-visit.md
+++ b/.changeset/plenty-tools-visit.md
@@ -1,0 +1,7 @@
+---
+"@marigold/components": minor
+"@marigold/icons": minor
+"@marigold/system": minor
+---
+
+feat: extend svg fill prop to handle theme color

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -116,7 +116,7 @@ test('add icon in button works as expected', () => {
   expect(button instanceof HTMLButtonElement).toBeTruthy();
   expect(button).toHaveStyle('display: inline-flex');
   expect(button.firstChild instanceof SVGElement).toBeTruthy();
-  expect(icon.getAttribute('fill')).toEqual('red');
+  expect(icon).toHaveStyle('fill: red');
   expect(icon.getAttribute('width')).toEqual('30');
 });
 

--- a/packages/icons/src/Icon.test.tsx
+++ b/packages/icons/src/Icon.test.tsx
@@ -6,7 +6,7 @@ test('supports default fill color', () => {
   render(<Facebook title="svg" />);
   const svg = screen.getByTitle(/svg/);
 
-  expect(svg.getAttribute('fill')).toEqual('currentcolor');
+  expect(svg).toHaveStyle('fill: currentcolor');
 });
 
 test('supports default size', () => {
@@ -27,5 +27,5 @@ test('supports fill prop', () => {
   render(<Facebook title="svg" fill="orange" />);
   const svg = screen.getByTitle(/svg/);
 
-  expect(svg.getAttribute('fill')).toEqual('orange');
+  expect(svg).toHaveStyle('fill: orange');
 });

--- a/packages/system/src/SVG.test.tsx
+++ b/packages/system/src/SVG.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { SVG } from './SVG';
+import { ThemeProvider } from './useTheme';
+
+const theme = {
+  colors: {
+    info: 'blue',
+  },
+};
 
 test('renders svg', () => {
   render(<SVG data-testid="svg" />);
@@ -23,7 +30,7 @@ test('supports default fill color', () => {
   );
   const svg = screen.getByTestId(/svg/);
 
-  expect(svg.getAttribute('fill')).toEqual('currentcolor');
+  expect(svg).toHaveStyle('fill: currentcolor');
 });
 
 test('supports default size', () => {
@@ -56,7 +63,20 @@ test('supports fill prop', () => {
   );
   const svg = screen.getByTestId(/svg/);
 
-  expect(svg.getAttribute('fill')).toEqual('#fafafa');
+  expect(svg).toHaveStyle('fill: #fafafa');
+});
+
+test('supports fill from theme', () => {
+  render(
+    <ThemeProvider theme={theme}>
+      <SVG data-testid="svg" fill="info">
+        <path d="M9.9 20.113V13.8415H14" />
+      </SVG>
+    </ThemeProvider>
+  );
+  const svg = screen.getByTestId(/svg/);
+
+  expect(svg).toHaveStyle('fill: blue');
 });
 
 test('accepts custom styles prop className', () => {

--- a/packages/system/src/SVG.tsx
+++ b/packages/system/src/SVG.tsx
@@ -2,23 +2,31 @@ import React from 'react';
 import { jsx } from '@emotion/react';
 import { ComponentProps } from '@marigold/types';
 import { getNormalizedStyles } from './normalize';
+import { useTheme } from './useTheme';
 
-const css = getNormalizedStyles('svg');
+const normalizedStyles = getNormalizedStyles('svg');
 
 export interface SVGProps extends ComponentProps<'svg'> {
   size?: number;
 }
 
-export const SVG: React.FC<SVGProps> = ({ size = 24, children, ...props }) =>
-  jsx(
+export const SVG: React.FC<SVGProps> = ({
+  size = 24,
+  fill = 'currentcolor',
+  children,
+  ...props
+}) => {
+  const { css } = useTheme();
+
+  return jsx(
     'svg',
     {
       width: size,
       height: size,
       viewBox: '0 0 24 24',
-      fill: 'currentcolor',
+      css: css({ fill: fill, ...normalizedStyles }),
       ...props,
-      css,
     },
     children
   );
+};


### PR DESCRIPTION
#1691 because in this issue i noticed that a svg should process the defined color values from a theme