### PR TITLE
feat: `<Button>` correctly pass through all native props and option to take full width

### DIFF
--- a/.changeset/tender-swans-fly.md
+++ b/.changeset/tender-swans-fly.md
@@ -1,0 +1,6 @@
+---
+"@marigold/components": minor
+"@marigold/theme-b2b": patch
+---
+
+feat: `<Button>` correctly pass through all native props and option to take full width

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -26,6 +26,13 @@ export default {
       },
       description: 'Size of the button',
     },
+    fullWidth: {
+      control: {
+        type: 'boolean',
+      },
+      description: 'Take availble width',
+      defaultValue: false,
+    },
     disabled: {
       control: {
         type: 'boolean',

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, ComponentStory } from '@storybook/react';
 import { Facebook } from '@marigold/icons';
 import { Button } from './Button';
@@ -50,7 +50,24 @@ export const WithIcon: ComponentStory<typeof Button> = ({
 );
 
 export const OnPress: ComponentStory<typeof Button> = args => (
-  <>
-    <Button {...args} onPress={(e: any) => console.log(e)} />
-  </>
+  <Button {...args} onPress={(e: any) => console.log(e)} />
 );
+
+export const AsProp: ComponentStory<typeof Button> = args => (
+  <Button {...args} as="a" href="https://reservix.net" />
+);
+
+export const PassThroughProps: ComponentStory<typeof Button> = args => {
+  const [isHovered, setHovered] = useState(false);
+  return (
+    <>
+      <Button
+        {...args}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+      <br />
+      state: {isHovered ? 'hovered' : 'not hovered'}
+    </>
+  );
+};

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -162,7 +162,7 @@ test('can be used as a "link button"', () => {
     </ThemeProvider>
   );
   const button = screen.getByTestId('button');
-  expect(button).toBeTruthy();
+  expect(button).toBeInstanceOf(HTMLAnchorElement);
 });
 
 test('can be used as a "link button" and has button styling', () => {
@@ -185,7 +185,7 @@ test('can be used as a "link button" and has button styling', () => {
 test('supports onPress', () => {
   const onPress = jest.fn();
   render(
-    <Button onPress={onPress} href={onPress} data-testid="button">
+    <Button onPress={onPress} data-testid="button">
       Some Button
     </Button>
   );
@@ -212,4 +212,13 @@ test('supports disabled prop', () => {
   const button = screen.getByText(/button/);
   expect(button).toHaveAttribute('disabled');
   expect(button).toHaveStyle('backgroundColor: #e3e3e3');
+});
+
+test('pass through native props', () => {
+  const spy = jest.fn();
+  render(<Button onMouseEnter={spy}>button</Button>);
+  const button = screen.getByText(/button/);
+
+  fireEvent.mouseEnter(button);
+  expect(spy).toHaveBeenCalledTimes(1);
 });

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -217,8 +217,15 @@ test('supports disabled prop', () => {
 test('pass through native props', () => {
   const spy = jest.fn();
   render(<Button onMouseEnter={spy}>button</Button>);
-  const button = screen.getByText(/button/);
 
+  const button = screen.getByText(/button/);
   fireEvent.mouseEnter(button);
   expect(spy).toHaveBeenCalledTimes(1);
+});
+
+test('allows to take full width', () => {
+  render(<Button fullWidth>button</Button>);
+
+  const button = screen.getByText(/button/);
+  expect(button).toHaveStyle('width: 100%');
 });

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -27,6 +27,7 @@ export interface ButtonOwnProps extends PressEvents, ComponentProps<'button'> {
   children?: ReactNode;
   variant?: string;
   size?: string;
+  fullWidth?: boolean;
 }
 
 export interface ButtonProps
@@ -49,6 +50,7 @@ export const Button: PolymorphicComponentWithRef<ButtonOwnProps, 'button'> =
         onPressEnd,
         onPressChange,
         onPressUp,
+        fullWidth,
         ...props
       }: Omit<ButtonProps, 'ref'>,
       ref
@@ -95,6 +97,7 @@ export const Button: PolymorphicComponentWithRef<ButtonOwnProps, 'button'> =
             alignItems: 'center',
             gap: '0.5ch',
             cursor: disabled ? 'not-allowed' : 'pointer',
+            width: fullWidth ? '100%' : undefined,
             '&:focus': {
               outline: 0,
             },

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -1,12 +1,8 @@
-import React, {
-  forwardRef,
-  ReactNode,
-  useImperativeHandle,
-  useRef,
-} from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import { useButton } from '@react-aria/button';
 import { useFocusRing } from '@react-aria/focus';
-import { mergeProps } from '@react-aria/utils';
+import { useHover } from '@react-aria/interactions';
+import { mergeProps, useObjectRef } from '@react-aria/utils';
 import { PressEvents } from '@react-types/shared';
 
 import {
@@ -16,6 +12,7 @@ import {
   useStateProps,
 } from '@marigold/system';
 import {
+  ComponentProps,
   PolymorphicComponentWithRef,
   PolymorphicPropsWithRef,
 } from '@marigold/types';
@@ -26,7 +23,7 @@ export interface ButtonThemeExtension extends ThemeExtension<'Button'> {}
 
 // Props
 // ---------------
-export interface ButtonOwnProps extends PressEvents {
+export interface ButtonOwnProps extends PressEvents, ComponentProps<'button'> {
   children?: ReactNode;
   variant?: string;
   size?: string;
@@ -46,37 +43,50 @@ export const Button: PolymorphicComponentWithRef<ButtonOwnProps, 'button'> =
         variant,
         size,
         disabled,
+        onClick,
+        onPress,
+        onPressStart,
+        onPressEnd,
+        onPressChange,
+        onPressUp,
         ...props
       }: Omit<ButtonProps, 'ref'>,
       ref
     ) => {
-      const buttonRef = useRef(null);
-      // FIXME
-      useImperativeHandle(ref, () => buttonRef.current);
-
+      const buttonRef = useObjectRef<HTMLButtonElement>(ref as any);
+      const { hoverProps, isHovered } = useHover({ isDisabled: disabled });
+      const { isFocusVisible, focusProps } = useFocusRing({
+        autoFocus: props.autoFocus,
+      });
       const { buttonProps, isPressed } = useButton(
         {
           /**
-           * `react-aria` only expected `Element` but our
-           * props are from `HTMLButtonElement` 🤫
+           * `react-aria` only expected `Element` but we casted
+           * it to a `HTMLButtonElement` internally.
            */
           ...(props as any),
+          onClick,
+          onPress,
+          onPressStart,
+          onPressEnd,
+          onPressChange,
+          onPressUp,
           elementType: typeof as === 'string' ? as : 'span',
           isDisabled: disabled,
         },
         buttonRef
       );
 
-      const { isFocusVisible, focusProps } = useFocusRing();
       const styles = useComponentStyles('Button', { variant, size });
       const stateProps = useStateProps({
         active: isPressed,
-        focus: isFocusVisible,
+        focusVisible: isFocusVisible,
+        hover: isHovered,
       });
 
       return (
         <Box
-          {...mergeProps(buttonProps, focusProps)}
+          {...mergeProps(buttonProps, focusProps, hoverProps, props)}
           {...stateProps}
           as={as}
           ref={buttonRef}
@@ -85,6 +95,9 @@ export const Button: PolymorphicComponentWithRef<ButtonOwnProps, 'button'> =
             alignItems: 'center',
             gap: '0.5ch',
             cursor: disabled ? 'not-allowed' : 'pointer',
+            '&:focus': {
+              outline: 0,
+            },
           }}
           css={styles}
         >

--- a/themes/theme-b2b/src/components/Button.style.ts
+++ b/themes/theme-b2b/src/components/Button.style.ts
@@ -9,7 +9,7 @@ export const Button: Theme['components']['Button'] = {
     px: 'large',
     outline: 'none',
 
-    '&[data-focus]': {
+    '&[data-focus-visible]': {
       outline: '1px solid',
       outlineColor: 'primary',
       outlineOffset: '1px',


### PR DESCRIPTION
Closes #2282 
Closes #2284 