### PR TITLE
fix: `Columns` work with complex and different children types

### DIFF
--- a/.changeset/young-readers-switch.md
+++ b/.changeset/young-readers-switch.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: `Columns` work with complex and different children types

--- a/packages/components/src/Columns/Columns.stories.tsx
+++ b/packages/components/src/Columns/Columns.stories.tsx
@@ -68,3 +68,14 @@ export const Basic: ComponentStory<typeof Columns> = args => (
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
   </Columns>
 );
+
+export const ComplexChildren: ComponentStory<typeof Columns> = args => (
+  <Columns {...args}>
+    <Box as="main" border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    <>
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </>
+    <Box as="aside" border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+  </Columns>
+);

--- a/packages/components/src/Columns/Columns.test.tsx
+++ b/packages/components/src/Columns/Columns.test.tsx
@@ -9,6 +9,8 @@ const theme = {
   },
 };
 
+const getColumnWrappers = (el: HTMLElement) => el.children!;
+
 test('supports default space prop', () => {
   render(
     <MarigoldProvider theme={theme}>
@@ -37,51 +39,68 @@ test('supports custom space prop', () => {
 
 test('supports default collapseAt prop', () => {
   render(
-    <Columns columns={[12]}>
+    <Columns columns={[12]} data-testid="columns">
       <Box>columnOne</Box>
     </Columns>
   );
-  const columnOne = screen.getByText(/columnOne/);
+  const [columnOne] = getColumnWrappers(screen.getByTestId(/columns/));
   expect(columnOne).toHaveStyle(`flexBasis : calc(( 40em - 100%) * 999)`);
 });
 
 test('supports custom collapseAt prop', () => {
   render(
-    <Columns columns={[12]} collapseAt="50em">
+    <Columns columns={[12]} collapseAt="50em" data-testid="columns">
       <Box>columnOne</Box>
     </Columns>
   );
-  const columnOne = screen.getByText(/columnOne/);
+  const [columnOne] = getColumnWrappers(screen.getByTestId(/columns/));
   expect(columnOne).toHaveStyle(`flexBasis : calc(( 50em - 100%) * 999)`);
 });
 
 test('supports columns with two values', () => {
   render(
-    <Columns columns={[2, 10]}>
+    <Columns columns={[2, 10]} data-testid="columns">
       <Box>columnOne</Box>
       <Box>columnTwo</Box>
     </Columns>
   );
-  const columnOne = screen.getByText(/columnOne/);
-  const columnTwo = screen.getByText(/columnTwo/);
+  const [columnOne, columnTwo] = getColumnWrappers(
+    screen.getByTestId(/columns/)
+  );
   expect(columnOne).toHaveStyle(`flexGrow : 2`);
   expect(columnTwo).toHaveStyle(`flexGrow : 10`);
 });
 
 test('supports columns with three values', () => {
   render(
-    <Columns columns={[2, 4, 6]}>
+    <Columns columns={[2, 4, 6]} data-testid="columns">
       <Box>columnOne</Box>
       <Box>columnTwo</Box>
       <Box>columnThree</Box>
     </Columns>
   );
-  const columnOne = screen.getByText(/columnOne/);
-  const columnTwo = screen.getByText(/columnTwo/);
-  const columnThree = screen.getByText(/columnThree/);
+  const [columnOne, columnTwo, columnThree] = getColumnWrappers(
+    screen.getByTestId(/columns/)
+  );
   expect(columnOne).toHaveStyle(`flexGrow : 2`);
   expect(columnTwo).toHaveStyle(`flexGrow : 4`);
   expect(columnThree).toHaveStyle(`flexGrow : 6`);
+});
+
+test('supports different types of children', () => {
+  render(
+    <Columns columns={[1, 1, 2]} data-testid="columns">
+      <main>columnOne</main>
+      <div>columnTwo</div>
+      <aside>columnThree</aside>
+    </Columns>
+  );
+  const [columnOne, columnTwo, columnThree] = getColumnWrappers(
+    screen.getByTestId(/columns/)
+  );
+  expect(columnOne).toHaveStyle(`flexGrow : 1`);
+  expect(columnTwo).toHaveStyle(`flexGrow : 1`);
+  expect(columnThree).toHaveStyle(`flexGrow : 2`);
 });
 
 test('throws error if columns length and children length are different', () => {

--- a/packages/components/src/Columns/Columns.test.tsx
+++ b/packages/components/src/Columns/Columns.test.tsx
@@ -9,6 +9,7 @@ const theme = {
   },
 };
 
+// eslint-disable-next-line testing-library/no-node-access
 const getColumnWrappers = (el: HTMLElement) => el.children!;
 
 test('supports default space prop', () => {

--- a/packages/components/src/Columns/Columns.tsx
+++ b/packages/components/src/Columns/Columns.tsx
@@ -1,4 +1,9 @@
-import React, { Children, ReactNode } from 'react';
+import React, {
+  Children,
+  cloneElement,
+  isValidElement,
+  ReactNode,
+} from 'react';
 
 import { ResponsiveStyleValue } from '@marigold/system';
 
@@ -27,32 +32,32 @@ export const Columns = ({
     );
   }
 
-  // create an array to get column widths
-  const getColumnWidths = columns.map((column, index) => {
-    return {
-      [`> :nth-of-type(${index + 1})`]: {
-        flexGrow: column,
-      },
-    };
-  });
-
   return (
     <Box
       display="flex"
-      css={Object.assign(
-        {
-          flexWrap: 'wrap',
-          gap: space,
-          '> *': {
-            // display breakpoint at collapseAt value
-            flexBasis: `calc(( ${collapseAt} - 100%) * 999)`,
-          },
+      css={{
+        flexWrap: 'wrap',
+        gap: space,
+        '> *': {
+          /**
+           * "Container Query": collapses at given width
+           * (https://heydonworks.com/article/the-flexbox-holy-albatross/)
+           */
+          flexBasis: `calc(( ${collapseAt} - 100%) * 999)`,
         },
-        ...getColumnWidths!
-      )}
+      }}
       {...props}
     >
-      {children}
+      {Children.map(children, (child, idx) => (
+        <Box
+          css={{
+            // Stretch each column to the given value
+            flexGrow: columns[idx],
+          }}
+        >
+          {isValidElement(child) ? cloneElement(child) : null}
+        </Box>
+      ))}
     </Box>
   );
 };


### PR DESCRIPTION
closes #2252