### PR TITLE
docs: set maxHeight for code demos

### DIFF
--- a/docs/src/theme/root.ts
+++ b/docs/src/theme/root.ts
@@ -20,5 +20,6 @@ export const root = {
     borderRadius: '10px',
     overflowX: 'auto',
     maxWidth: '100%',
+    maxHeight: '500px',
   },
 } as const;


### PR DESCRIPTION
Why: because the demo codes are getting very long (Tiles, Tables)  