### PR TITLE
Revert "feat: improve `&:hover` selector to adhere CSS specificity (#…

### DIFF
--- a/.changeset/rich-elephants-attend.md
+++ b/.changeset/rich-elephants-attend.md
@@ -1,5 +1,0 @@
----
-"@marigold/system": patch
----
-
-feat: improve `&:hover` selector to adhere CSS specificity

--- a/packages/system/src/components/Box/selector.test.ts
+++ b/packages/system/src/components/Box/selector.test.ts
@@ -23,7 +23,7 @@ describe('transform states', () => {
         '&:hover': {},
       },
       expected: {
-        '&:hover:enabled, &[data-hover]': {},
+        '&:hover, &[data-hover]': {},
       },
     },
     {
@@ -131,7 +131,7 @@ describe('transform states', () => {
         '&:hover-group': {},
       },
       expected: {
-        '[role=group]:hover:enabled &, [role=group][data-hover] &, [data-group]:hover:enabled &, [data-group][data-hover] &':
+        '[role=group]:hover &, [role=group][data-hover] &, [data-group]:hover &, [data-group][data-hover] &':
           {},
       },
     },
@@ -182,7 +182,7 @@ describe('transform states', () => {
       })
     ).toMatchInlineSnapshot(`
       {
-        "&:hover:enabled, &[data-hover]": {
+        "&:hover, &[data-hover]": {
           "&:focus, &[data-focus]": {
             "outline": "1px solid #228be6",
           },

--- a/packages/system/src/components/Box/selector.ts
+++ b/packages/system/src/components/Box/selector.ts
@@ -20,7 +20,7 @@ const selector = {
 
 const state = {
   none: [''],
-  hover: [':hover:enabled', '[data-hover]'],
+  hover: [':hover', '[data-hover]'],
   focus: [':focus', '[data-focus]'],
   focusVisible: [':focus-visible', '[data-focus-visible]'],
   active: [':active', '[data-active]'],


### PR DESCRIPTION
…2468)"

This reverts commit 7e7f338711fce4f76375baa71b147e4112593f12.