### PR TITLE
chore: change property names in breakout to alignX and alignY

### DIFF
--- a/.changeset/unlucky-papayas-tell.md
+++ b/.changeset/unlucky-papayas-tell.md
@@ -1,0 +1,6 @@
+---
+"@marigold/docs": patch
+"@marigold/components": patch
+---
+
+chore: change property names in breakout to alignX and AlignY

--- a/docs/src/demos/components/Breakout/basic-breakout.demo.tsx
+++ b/docs/src/demos/components/Breakout/basic-breakout.demo.tsx
@@ -10,7 +10,7 @@ export const BasicBreakout = () => (
         width: '100%',
       }}
     />
-    <Breakout verticalAlign="center">
+    <Breakout alignY="center">
       <Box
         css={{
           bg: '#e9ecef',

--- a/docs/src/demos/components/Breakout/horizontal-breakout.demo.tsx
+++ b/docs/src/demos/components/Breakout/horizontal-breakout.demo.tsx
@@ -10,7 +10,7 @@ export const HorizontalBreakout = () => (
         width: '100%',
       }}
     />
-    <Breakout horizontalAlign="right">
+    <Breakout alignX="right">
       <Box>BREAKOUT with right aligned content</Box>
     </Breakout>
     <Box

--- a/docs/src/demos/components/Breakout/vertical-breakout.demo.tsx
+++ b/docs/src/demos/components/Breakout/vertical-breakout.demo.tsx
@@ -10,7 +10,7 @@ export const VerticalAlignment = () => (
         width: '100%',
       }}
     />
-    <Breakout height="100px" verticalAlign="bottom">
+    <Breakout height="100px" alignY="bottom">
       <Box
         css={{
           bg: '#e9ecef',

--- a/docs/src/pages/components/breakout.mdx
+++ b/docs/src/pages/components/breakout.mdx
@@ -10,7 +10,7 @@ caption: Component that breaks out of a grid layout context.
 
 You need this component if you want to display something out of the context. It is also possible to put several components into the `<Breakout>`.
 
-You can use `horizontalAlign` or `verticalAlign` to place the items inside the `<Breakout>` element.
+You can use `alignX` or `alignY` to place the items inside the `<Breakout>` element.
 
 <Preview>
   <Container align="center">
@@ -22,7 +22,7 @@ You can use `horizontalAlign` or `verticalAlign` to place the items inside the `
         width: '100%',
       }}
     />
-    <Breakout horizontalAlign="center" height="150px" verticalAlign="center">
+    <Breakout alignX="center" height="150px" alignY="center">
       <Box
         css={{
           bg: '#e9ecef',
@@ -59,14 +59,14 @@ import { Breakout } from '@marigold/components';
 <PropsTable
   props={[
     {
-      property: 'horizontalAlign',
+      property: 'alignX',
       type: '"left" | "right" | "center"',
       description:
         'Horizontal alignment of the items inside the breakout element.',
       default: 'left',
     },
     {
-      property: 'verticalAlign',
+      property: 'alignY',
       type: '"top" | "bottom" | "center"',
       description:
         'Vertical alignment of the items inside the breakout element.',
@@ -85,7 +85,7 @@ import { Breakout } from '@marigold/components';
 
 ### Vertical alignment
 
-In this case the `height` prop is necessary, if you haven't set it, the `verticalAlign` has no impact.
+In this case the `height` prop is necessary, if you haven't set it, the `alignY` has no impact.
 
 ```tsx preview file=components/Breakout/vertical-breakout.demo.tsx
 
@@ -93,7 +93,7 @@ In this case the `height` prop is necessary, if you haven't set it, the `vertica
 
 ### Horizontal alignment
 
-Example to show how the `horizontalAlign` prop is to set. Options are `"left" | "center" | "right"`. The default value is `left`.
+Example to show how the `alignX` prop is to set. Options are `"left" | "center" | "right"`. The default value is `left`.
 
 ```tsx preview file=components/Breakout/horizontal-breakout.demo.tsx
 

--- a/packages/components/src/Breakout/Breakout.stories.tsx
+++ b/packages/components/src/Breakout/Breakout.stories.tsx
@@ -12,7 +12,7 @@ import { Breakout } from './Breakout';
 export default {
   title: 'Components/Breakout',
   argTypes: {
-    verticalAlign: {
+    alignY: {
       control: {
         type: 'select',
       },
@@ -24,7 +24,7 @@ export default {
         },
       },
     },
-    horizontalAlign: {
+    alignX: {
       control: {
         type: 'select',
       },
@@ -35,6 +35,12 @@ export default {
           summary: 'left',
         },
       },
+    },
+    height: {
+      control: {
+        type: 'text',
+      },
+      description: 'The height of the breakout',
     },
   },
 } as Meta;

--- a/packages/components/src/Breakout/Breakout.test.tsx
+++ b/packages/components/src/Breakout/Breakout.test.tsx
@@ -18,7 +18,7 @@ test('supports default horizontalAlign left', () => {
 
 test('supports horizontal center', () => {
   render(
-    <Breakout horizontalAlign="center" data-testid="breakout">
+    <Breakout alignX="center" data-testid="breakout">
       breakout
     </Breakout>
   );
@@ -28,7 +28,7 @@ test('supports horizontal center', () => {
 
 test('supports horizontalAlign right', () => {
   render(
-    <Breakout horizontalAlign="right" data-testid="breakout">
+    <Breakout alignX="right" data-testid="breakout">
       breakout
     </Breakout>
   );
@@ -44,7 +44,7 @@ test('supports default horizontalAlign top', () => {
 
 test('supports verticalAlign center', () => {
   render(
-    <Breakout verticalAlign="center" data-testid="breakout">
+    <Breakout alignY="center" data-testid="breakout">
       breakout
     </Breakout>
   );
@@ -54,7 +54,7 @@ test('supports verticalAlign center', () => {
 
 test('supports verticalAlign bottom', () => {
   render(
-    <Breakout verticalAlign="bottom" data-testid="breakout">
+    <Breakout alignY="bottom" data-testid="breakout">
       breakout
     </Breakout>
   );

--- a/packages/components/src/Breakout/Breakout.tsx
+++ b/packages/components/src/Breakout/Breakout.tsx
@@ -5,8 +5,8 @@ import { Box } from '../Box';
 
 export interface BreakoutProps extends ComponentProps<'div'> {
   children?: ReactNode;
-  verticalAlign?: 'top' | 'bottom' | 'center';
-  horizontalAlign?: 'left' | 'right' | 'center';
+  alignY?: 'top' | 'bottom' | 'center';
+  alignX?: 'left' | 'right' | 'center';
   height?: string;
 }
 
@@ -23,14 +23,14 @@ const useAlignment = (direction?: string) => {
 };
 
 export const Breakout = ({
-  horizontalAlign,
-  verticalAlign,
+  alignX,
+  alignY,
   height,
   children,
   ...props
 }: BreakoutProps) => {
-  const alignItems = useAlignment(verticalAlign);
-  const justifyContent = useAlignment(horizontalAlign);
+  const alignItems = useAlignment(alignY);
+  const justifyContent = useAlignment(alignX);
 
   return (
     <Box
@@ -38,7 +38,7 @@ export const Breakout = ({
       justifyContent={justifyContent}
       width="100%"
       height={height}
-      display={verticalAlign || horizontalAlign ? 'flex' : 'block'}
+      display={alignY || alignX ? 'flex' : 'block'}
       __baseCSS={{
         gridColumn: '1 / -1 !important',
       }}


### PR DESCRIPTION
Change horizontalAlign and verticalAlign to alignX and alignY for a better developer experience.