### PR TITLE
fix: allow `<NumberField>` with little width

### DIFF
--- a/.changeset/rare-bears-dance.md
+++ b/.changeset/rare-bears-dance.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: allow `<NumberField>` with little width

--- a/packages/components/src/NumberField/NumberField.tsx
+++ b/packages/components/src/NumberField/NumberField.tsx
@@ -136,7 +136,8 @@ export const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
             display: 'flex',
             alignItems: 'stretch',
             '> input': {
-              flexGrow: 1,
+              flex: 1,
+              minWidth: 0, // Override browser default
             },
           }}
           css={styles.group}


### PR DESCRIPTION
- before this fix, browsers will not let the input shrink below a certain threshold (<200px)