### PR TITLE
feat: `<Tiles>` can switch between responsive and static modes

### DIFF
--- a/.changeset/wicked-clocks-smoke.md
+++ b/.changeset/wicked-clocks-smoke.md
@@ -1,6 +1,6 @@
 ---
-"@marigold/docs": patch
-"@marigold/components": patch
+"@marigold/docs": major
+"@marigold/components": major
 ---
 
 feat: `<Tiles>` can now be used as a grid with fixed widths or fully respsonsive.

--- a/.changeset/wicked-clocks-smoke.md
+++ b/.changeset/wicked-clocks-smoke.md
@@ -1,0 +1,8 @@
+---
+"@marigold/docs": patch
+"@marigold/components": patch
+---
+
+feat: `<Tiles>` can now be used as a grid with fixed widths or fully respsonsive.
+
+BREAKING CHANGE: Renamed the whole API. Please checkout the documentation at https://marigold-ui.io/components/tiles/#props

--- a/docs/src/components/IconList/IconList.tsx
+++ b/docs/src/components/IconList/IconList.tsx
@@ -86,7 +86,7 @@ const IconListItem = ({ icon }: IconListItemProps) => {
 export const IconList = ({ icons }: IconListProps) => {
   return (
     <Box css={{ width: '100%' }}>
-      <Tiles space="medium-1" itemMinWidth="7.5rem">
+      <Tiles space="medium-1" tilesWidth="7.5rem">
         {icons.map(icon => (
           <IconListItem key={icon} icon={icon} />
         ))}

--- a/docs/src/demos/components/Tiles/index.ts
+++ b/docs/src/demos/components/Tiles/index.ts
@@ -1,4 +1,5 @@
 export * from './tiles-spacing.demo';
+export * from './tiles-stretch.demo';
 export * from './tiles-itemwidth.demo';
 export * from './tiles-complex.demo';
 export * from './tiles-autoRows.demo';

--- a/docs/src/demos/components/Tiles/tiles-autoRows.demo.tsx
+++ b/docs/src/demos/components/Tiles/tiles-autoRows.demo.tsx
@@ -1,7 +1,7 @@
 import { Box, Card, Image, Tiles, Text } from '@marigold/components';
 
 export const AutoRows = () => (
-  <Tiles space="xsmall" gridAutoRows>
+  <Tiles space="xsmall" tilesWidth="250px" equalHeight>
     <Box as={Card}>
       <Image
         src="https://www.pokewiki.de/images/6/63/Sugimori_004.png"

--- a/docs/src/demos/components/Tiles/tiles-complex.demo.tsx
+++ b/docs/src/demos/components/Tiles/tiles-complex.demo.tsx
@@ -8,7 +8,7 @@ import {
 } from '@marigold/components';
 
 export const ComplexTiles = () => (
-  <Tiles itemMinWidth="300px" space="small">
+  <Tiles tilesWidth="300px" space="small">
     <Card p="small">
       <Stack space="medium" alignX="center">
         <Image

--- a/docs/src/demos/components/Tiles/tiles-itemwidth.demo.tsx
+++ b/docs/src/demos/components/Tiles/tiles-itemwidth.demo.tsx
@@ -1,7 +1,7 @@
 import { Card, Image, Tiles } from '@marigold/components';
 
 export const ItemWidthTiles = () => (
-  <Tiles space="xsmall" itemMinWidth="100px">
+  <Tiles space="xsmall" tilesWidth="200px" stretch>
     <Card>
       <Image
         src="https://www.pokewiki.de/images/6/63/Sugimori_004.png"

--- a/docs/src/demos/components/Tiles/tiles-spacing.demo.tsx
+++ b/docs/src/demos/components/Tiles/tiles-spacing.demo.tsx
@@ -1,7 +1,7 @@
 import { Box, Tiles } from '@marigold/components';
 
 export const SpacingTiles = () => (
-  <Tiles space="large">
+  <Tiles tilesWidth="large" space="large">
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />

--- a/docs/src/demos/components/Tiles/tiles-stretch.demo.tsx
+++ b/docs/src/demos/components/Tiles/tiles-stretch.demo.tsx
@@ -1,0 +1,32 @@
+import { Box, Divider, Headline, Stack, Tiles } from '@marigold/components';
+
+export const StretchTiles = () => (
+  <Stack space="large">
+    <Headline>Without stretch:</Headline>
+    <Tiles tilesWidth="150px" space="large">
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+    <Divider />
+    <Tiles tilesWidth="150px" space="large">
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+    <Headline>With stretch:</Headline>
+    <Tiles tilesWidth="150px" space="large" stretch>
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+    <Divider />
+    <Tiles tilesWidth="150px" space="large" stretch>
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+  </Stack>
+);

--- a/docs/src/demos/concepts-layouts.demo.tsx
+++ b/docs/src/demos/concepts-layouts.demo.tsx
@@ -28,7 +28,7 @@ export const LayoutsDemo = () => (
         <Annotation>Columns</Annotation>
       </>
       <>
-        <Tiles space="small-1" itemMinWidth="32px">
+        <Tiles space="small-1" tilesWidth="32px">
           <Squirecle />
           <Squirecle />
           <Squirecle />

--- a/docs/src/pages/components/tiles.mdx
+++ b/docs/src/pages/components/tiles.mdx
@@ -13,7 +13,7 @@ It should be noted that `<Tiles>` is used for children with the same width. If y
 It's possible to display the children elements with some spacing or set a minimum width for all items inside `<Tiles>`.
 
 <Preview>
-  <Tiles space="small" itemMinWidth="200px">
+  <Tiles space="small" tilesWidth="200px">
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
     <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
@@ -44,16 +44,23 @@ import { Tiles } from '@marigold/components';
       default: 'none',
     },
     {
-      property: 'itemMinWidth',
+      property: 'tilesWidth',
       type: 'ResponsiveStyleValue<string>',
       description: 'Set minimum width for all items inside',
       default: '250px',
     },
     {
-      property: 'gridAutoRows',
+      property: 'equalHeight',
       type: 'boolean',
       description:
-        'If you set gridAutoRows, all items will have the size of the biggest item',
+        'If you set equalHeight, all items will have the size of the biggest item',
+      default: 'false',
+    },
+    {
+      property: 'stretch',
+      type: 'boolean',
+      description:
+        'Tiles will take stretch to available width and will distribute their width equally. Note that this can make them wider than the specified tiles width, but not smaller than the given "itemWidth". Basically this is full responsive mode.',
       default: 'false',
     },
   ]}
@@ -69,19 +76,27 @@ An example on how to use the `space` prop. The default is none. You can set it t
 
 ```
 
-### Tiles with itemMinWidth
+### Tiles with tilesWidth
 
-This Example shows how to use the `itemMinWidth` property on `<Tiles>`. The default value is `250px`.
+This Example shows how to use the `tilesWidth` property on `<Tiles>`.
 
 ```tsx preview file=components/Tiles/tiles-itemwidth.demo.tsx
 
 ```
 
-### Tiles with gridAutoRows
+### Tiles with equal Heights
 
-The Example shows how to use the `gidAutoRows` property, which is a boolean that can be used to size the items of the `<Tiles>`. You can see that all items have the size of the large Pikachu card. It is necessary if you want all items in the largest size of a child.
+The Example shows how to use the `equalHeight` property, which is a boolean that can be used to size the items of the `<Tiles>`. You can see that all items have the size of the large Pikachu card. It is necessary if you want all items in the largest size of a child.
 
 ```tsx preview file=components/Tiles/tiles-autoRows.demo.tsx
+
+```
+
+### Tiles with and without stretch
+
+Using the `stretch` property will make the tiles fully responsive. Meaning, they will distribute available width between them while not getting smaller then the given `tilesWidth`,
+
+```tsx preview file=components/Tiles/tiles-stretch.demo.tsx
 
 ```
 

--- a/packages/components/src/Card/Card.stories.tsx
+++ b/packages/components/src/Card/Card.stories.tsx
@@ -52,7 +52,7 @@ export const Basic: ComponentStory<typeof Card> = args => (
 );
 
 export const CoreCard: ComponentStory<typeof Card> = args => (
-  <Tiles itemMinWidth="300px" space="small">
+  <Tiles tilesWidth="300px" space="small">
     <Card {...args} p="xsmall">
       <Inline alignY="top">
         <Link href={'#'} target="blank">

--- a/packages/components/src/Tiles/Tiles.stories.tsx
+++ b/packages/components/src/Tiles/Tiles.stories.tsx
@@ -26,19 +26,21 @@ export default {
         },
       },
     },
-    itemMinWidth: {
+    tilesWidth: {
       control: {
         type: 'text',
       },
       description: 'Responsive Style Value',
-      defaultValue: '250px',
-      table: {
-        defaultValue: {
-          summary: '250px',
-        },
-      },
+      defaultValue: '300px',
     },
-    gridAutoRows: {
+    stretch: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        'Makes tiles take available width, instead of sticking to the tiles width',
+    },
+    equalHeight: {
       control: {
         type: 'boolean',
       },

--- a/packages/components/src/Tiles/Tiles.stories.tsx
+++ b/packages/components/src/Tiles/Tiles.stories.tsx
@@ -49,16 +49,23 @@ export default {
 } as Meta;
 
 export const Boxes: ComponentStory<typeof Tiles> = args => (
-  <Tiles {...args}>
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-    <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
-  </Tiles>
+  <>
+    <Tiles {...args}>
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+    <br />
+    <Tiles {...args}>
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+      <Box border="1px solid #ced4da" bg="#e9ecef" height="100px" />
+    </Tiles>
+  </>
 );
 
 export const DifferentHights: ComponentStory<typeof Tiles> = args => (

--- a/packages/components/src/Tiles/Tiles.test.tsx
+++ b/packages/components/src/Tiles/Tiles.test.tsx
@@ -3,70 +3,74 @@ import { render, screen } from '@testing-library/react';
 import { Box, Tiles, MarigoldProvider } from '@marigold/components';
 
 const theme = {
+  sizes: {
+    none: 0,
+    large: 340,
+  },
   space: {
     none: 0,
     large: 24,
   },
 };
 
-test('supports default space prop', () => {
+test('set tiles width via prop', () => {
   render(
     <MarigoldProvider theme={theme}>
-      <Tiles data-testid="tiles">
-        <Box>tiles</Box>
-      </Tiles>
-    </MarigoldProvider>
-  );
-  const tiles = screen.getByTestId(/tiles/);
-  expect(tiles).toHaveStyle(`display: grid`);
-  expect(tiles).toHaveStyle(`gap: 0`);
-});
-
-test('supports other space prop than default', () => {
-  render(
-    <MarigoldProvider theme={theme}>
-      <Tiles space="large" data-testid="tiles">
-        <Box>tiles</Box>
-      </Tiles>
-    </MarigoldProvider>
-  );
-  const tiles = screen.getByTestId(/tiles/);
-  expect(tiles).toHaveStyle(`display: grid`);
-  expect(tiles).toHaveStyle(`gap: 24px`);
-});
-
-test('supports default itemMinWidth prop', () => {
-  render(
-    <MarigoldProvider theme={theme}>
-      <Tiles data-testid="tiles">
+      <Tiles tilesWidth="200px" data-testid="tiles">
         <Box>tiles</Box>
       </Tiles>
     </MarigoldProvider>
   );
   const tiles = screen.getByTestId(/tiles/);
   expect(tiles).toHaveStyle(
-    `gridTemplateColumns: repeat(auto-fit, minmax(min(250px, 100%), 1fr))`
+    `gridTemplateColumns: repeat(auto-fit, min(200px, 100%))`
   );
 });
 
-test('supports other itemMinWidth prop than default', () => {
+test('supports setting tiles width with design tokens', () => {
   render(
     <MarigoldProvider theme={theme}>
-      <Tiles itemMinWidth="400px" data-testid="tiles">
+      <Tiles tilesWidth="large" data-testid="tiles">
         <Box>tiles</Box>
       </Tiles>
     </MarigoldProvider>
   );
   const tiles = screen.getByTestId(/tiles/);
   expect(tiles).toHaveStyle(
-    `gridTemplateColumns: repeat(auto-fit, minmax(min(400px, 100%), 1fr))`
+    `gridTemplateColumns: repeat(auto-fit, min(${theme.sizes.large}px, 100%))`
+  );
+});
+
+test('supports space prop', () => {
+  render(
+    <MarigoldProvider theme={theme}>
+      <Tiles tilesWidth="200px" space="large" data-testid="tiles">
+        <Box>tiles</Box>
+      </Tiles>
+    </MarigoldProvider>
+  );
+  const tiles = screen.getByTestId(/tiles/);
+  expect(tiles).toHaveStyle(`gap: ${theme.space.large}px`);
+});
+
+test('supports responsive grid via stretch prop', () => {
+  render(
+    <MarigoldProvider theme={theme}>
+      <Tiles tilesWidth="300px" stretch data-testid="tiles">
+        <Box>tiles</Box>
+      </Tiles>
+    </MarigoldProvider>
+  );
+  const tiles = screen.getByTestId(/tiles/);
+  expect(tiles).toHaveStyle(
+    `gridTemplateColumns: repeat(auto-fit, minmax(min(300px, 100%), 1fr))`
   );
 });
 
 test('supports gridAutoRows prop', () => {
   render(
     <MarigoldProvider theme={theme}>
-      <Tiles gridAutoRows data-testid="tiles">
+      <Tiles tilesWidth="400px" equalHeight data-testid="tiles">
         <Box>tiles</Box>
         <Box>tiles</Box>
         <Box>tiles</Box>

--- a/packages/components/src/Tiles/Tiles.tsx
+++ b/packages/components/src/Tiles/Tiles.tsx
@@ -5,32 +5,26 @@ import { ResponsiveStyleValue } from '@marigold/system';
 export interface TilesProps {
   children: ReactNode;
   space?: ResponsiveStyleValue<string>;
+  tilesWidth?: ResponsiveStyleValue<string>;
   itemMinWidth?: ResponsiveStyleValue<string>;
-  gridAutoRows?: boolean;
 }
 
 export const Tiles = React.forwardRef<HTMLDivElement, TilesProps>(
-  (
-    {
-      space = 'none',
-      itemMinWidth = '250px',
-      gridAutoRows,
-      children,
-      ...props
-    },
-    ref
-  ) => (
-    <Box
-      ref={ref}
-      display="grid"
-      __baseCSS={{
-        gap: space,
-        gridTemplateColumns: `repeat(auto-fit, minmax(min(${itemMinWidth}, 100%), 1fr))`,
-        gridAutoRows: gridAutoRows ? '1fr' : 'none',
-      }}
-      {...props}
-    >
-      {children}
-    </Box>
-  )
+  ({ space = 'none', itemMinWidth = '250px', children, ...props }, ref) => {
+    return (
+      <Box
+        ref={ref}
+        display="grid"
+        __baseCSS={{
+          gap: space,
+          gridTemplateColumns: `repeat(auto-fit, minmax(min(${itemMinWidth}, 100%), 1fr))`,
+          // Make height of all tiles equal
+          gridAutoRows: '1fr',
+        }}
+        {...props}
+      >
+        {children}
+      </Box>
+    );
+  }
 );

--- a/packages/components/src/Tiles/Tiles.tsx
+++ b/packages/components/src/Tiles/Tiles.tsx
@@ -1,30 +1,54 @@
 import React, { ReactNode } from 'react';
 import { Box } from '../Box';
-import { ResponsiveStyleValue } from '@marigold/system';
+import { ResponsiveStyleValue, useTheme } from '@marigold/system';
 
 export interface TilesProps {
   children: ReactNode;
+  tilesWidth: string;
   space?: ResponsiveStyleValue<string>;
-  tilesWidth?: ResponsiveStyleValue<string>;
-  itemMinWidth?: ResponsiveStyleValue<string>;
+  stretch?: boolean;
+  equalHeight?: boolean;
 }
 
-export const Tiles = React.forwardRef<HTMLDivElement, TilesProps>(
-  ({ space = 'none', itemMinWidth = '250px', children, ...props }, ref) => {
-    return (
-      <Box
-        ref={ref}
-        display="grid"
-        __baseCSS={{
-          gap: space,
-          gridTemplateColumns: `repeat(auto-fit, minmax(min(${itemMinWidth}, 100%), 1fr))`,
-          // Make height of all tiles equal
-          gridAutoRows: '1fr',
-        }}
-        {...props}
-      >
-        {children}
-      </Box>
-    );
+export const Tiles = ({
+  space = 'none',
+  stretch = false,
+  equalHeight = false,
+  tilesWidth,
+  children,
+  ...props
+}: TilesProps) => {
+  /**
+   * Allow to use design tokens for the tiles width.
+   */
+  const { css } = useTheme();
+  const { width } = css({ width: tilesWidth });
+
+  let column = `min(${typeof width === 'number' ? `${width}px` : width}, 100%)`;
+  /**
+   * Adding `minmax` with `1fr` will make the tiles distribute the
+   * availble width between each other and use the `tilesWidth` as
+   * breakpoint, e.g. when to move a tile into the next line.
+   */
+  if (stretch) {
+    column = `minmax(${column}, 1fr)`;
   }
-);
+
+  return (
+    <Box
+      {...props}
+      css={{
+        display: 'grid',
+        gap: space,
+        gridTemplateColumns: `repeat(auto-fit, ${column})`,
+        /**
+         * Make height of all tiles in each row
+         * match the heighest tile.
+         */
+        gridAutoRows: equalHeight ? '1fr' : undefined,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};


### PR DESCRIPTION
`<Tiles>` can now be used as a grid with fixed widths or fully respsonsive.

BREAKING CHANGE: Renamed the whole API. Please checkout the documentation at https://marigold-ui.io/components/tiles/#props

closes #2603