### PR TITLE
fix: Underlay Color and Backdrop for Docs

### DIFF
--- a/docs/theme/components/Underlay.styles.ts
+++ b/docs/theme/components/Underlay.styles.ts
@@ -1,5 +1,5 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const Underlay: ThemeComponent<'Underlay'> = cva(
-  'bg-secondary-500 blur-sm'
+  'bg-bg-underlay/50 backdrop-blur-sm'
 );

--- a/docs/theme/tokens.ts
+++ b/docs/theme/tokens.ts
@@ -39,6 +39,8 @@ export const colors = {
     body: '#fff',
     hover: tw.neutral[100],
 
+    underlay: tw.slate[500],
+
     // Status
     info: tw.sky[100],
     warning: tw.amber[100],

--- a/themes/theme-b2b/src/components/Underlay.styles.ts
+++ b/themes/theme-b2b/src/components/Underlay.styles.ts
@@ -3,7 +3,7 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const Underlay: ThemeComponent<'Underlay'> = cva('', {
   variants: {
     variant: {
-      modal: ' bg-bg-surface-underlay blur-[1]',
+      modal: ' bg-bg-surface-underlay backdrop-blur-sm',
     },
   },
 });


### PR DESCRIPTION
- previous color secondary was no token
- backdrop was missing