### PR TITLE
fix: `FieldBase` renders empty element when no label is given

### DIFF
--- a/packages/components/src/FieldBase/FieldBase.tsx
+++ b/packages/components/src/FieldBase/FieldBase.tsx
@@ -57,10 +57,12 @@ export const FieldBase = ({
       {...stateProps}
       className={cn('group/field', twWidth[width], classNames)}
     >
-      {label && (
+      {label ? (
         <Label variant={variant} size={size} {...labelProps}>
           {label}
         </Label>
+      ) : (
+        <span aria-hidden="true" />
       )}
 
       {children}

--- a/packages/components/src/FieldBase/_FieldBase.tsx
+++ b/packages/components/src/FieldBase/_FieldBase.tsx
@@ -57,9 +57,13 @@ const _FieldBase = <T extends ElementType>(
       className={cn('group/field', twWidth[width], classNames)}
       {...rest}
     >
-      <Label variant={variant} size={size}>
-        {label}
-      </Label>
+      {label ? (
+        <Label variant={variant} size={size}>
+          {label}
+        </Label>
+      ) : (
+        <span aria-hidden="true" />
+      )}
       {children}
       <HelpText
         variant={variant}


### PR DESCRIPTION
(to not mess up the layout)