### PR TITLE
fix: fix button again

### DIFF
--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -11,16 +11,21 @@ export interface ButtonProps extends Omit<RAC.ButtonProps, RemovedProps> {
   variant?: string;
   size?: string;
   fullWidth?: boolean;
+  className?: string;
   children?: ReactNode;
   disabled?: RAC.ButtonProps['isDisabled'];
 }
 
 const _Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, variant, size, disabled, fullWidth, ...props }, ref) => {
+  (
+    { children, variant, size, className, disabled, fullWidth, ...props },
+    ref
+  ) => {
     const classNames = useClassNames({
       component: 'Button',
       variant,
       size,
+      className,
     });
 
     return (

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -112,7 +112,7 @@ test('supports classnames', () => {
   const label = screen.getByText('Label');
   const button = screen.getByRole('button');
   expect(button.className).toMatchInlineSnapshot(
-    `"inline-flex items-center justify-center gap-[0.5ch]"`
+    `"inline-flex items-center justify-center gap-[0.5ch] absolute right-2 h-4 w-4 border-none bg-transparent p-0"`
   );
   expect(container?.className).toMatchInlineSnapshot(`"group/field w-full"`);
   expect(label.className).toMatchInlineSnapshot(


### PR DESCRIPTION
from our comment in code: // Button is currently only component accepting className because of internal use.

there was classNames allowed but forgot. to pass it on 👀

noticed by copy button in docs