### PR TITLE
chore: add data-required attribute for label

### DIFF
--- a/.changeset/odd-cats-design.md
+++ b/.changeset/odd-cats-design.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+chore: add data-required attribute for label

--- a/packages/components/src/FieldBase/_FieldBase.tsx
+++ b/packages/components/src/FieldBase/_FieldBase.tsx
@@ -1,17 +1,17 @@
-import { forwardRef } from 'react';
 import type {
   ComponentPropsWithRef,
   ElementType,
   ForwardedRef,
   ReactNode,
 } from 'react';
+import { forwardRef } from 'react';
 
-import { cn, width as twWidth, useClassNames } from '@marigold/system';
 import type { WidthProp } from '@marigold/system';
+import { cn, width as twWidth, useClassNames } from '@marigold/system';
 import type { DistributiveOmit, FixedForwardRef } from '@marigold/types';
 
-import { HelpText } from '../HelpText/_HelpText';
 import type { HelpTextProps } from '../HelpText/_HelpText';
+import { HelpText } from '../HelpText/_HelpText';
 import { Label } from '../Label';
 
 const fixedForwardRef = forwardRef as FixedForwardRef;
@@ -56,6 +56,7 @@ const _FieldBase = <T extends ElementType>(
     <Component
       ref={ref}
       className={cn('group/field', twWidth[width], classNames, className)}
+      data-required={props.isRequired ? true : undefined}
       {...rest}
     >
       {label ? (


### PR DESCRIPTION
For our form components we need the `data-required` attribute to switch the label to bold. To avoid using `useStateProps` the attribute `data-required` is set onto the component. This attribute depends on `isRequired`.