### PR TITLE
chore: fix core print demo example

### DIFF
--- a/.changeset/forty-numbers-sneeze.md
+++ b/.changeset/forty-numbers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@marigold/docs": patch
+---
+
+chore: fix core print demo example

--- a/docs/content/recipes/core-table-print.demo.tsx
+++ b/docs/content/recipes/core-table-print.demo.tsx
@@ -173,16 +173,17 @@ export default () => {
             ))}
           </Table.Body>
         </Table>
-        <Inline space={1}>
+        <Inline space={2}>
           <Select
             label="Sammelaktion"
             placeholder="Bitte wählen"
-            width={0}
+            width={'auto'}
             onChange={handleSelect}
           >
             <Select.Option key="choose">Bitte wählen</Select.Option>
             <Select.Option key="ticketprint">Ticket drucken</Select.Option>
           </Select>
+          <Split />
           <Button variant="secondary" disabled={state}>
             Ausführen
           </Button>


### PR DESCRIPTION
In docs the core print example has two overlapping elements. Fixed them with layout components.