### PR TITLE
chore[DST-238]: remove rounded borders from numberfield

### DIFF
--- a/themes/theme-b2b/src/components/NumberField.styles.ts
+++ b/themes/theme-b2b/src/components/NumberField.styles.ts
@@ -15,5 +15,5 @@ export const NumberField: ThemeComponent<'NumberField'> = {
     'border-border-light border-solid first-of-type:border-r',
     'border-border-light border-solid last-of-type:border-l ',
   ]),
-  input: cva(['border-none outline-offset-[0px]']),
+  input: cva(['rounded-none border-none outline-offset-[0px]']),
 };


### PR DESCRIPTION
When focusing the number field, the edges of the input are rounded off. I remove this css to have a uniform appearance.