### PR TITLE
[DSTSUP-4] accordion item do not collapse and hide after first click

### DIFF
--- a/.changeset/tricky-poems-relax.md
+++ b/.changeset/tricky-poems-relax.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+[DSTSUP-4] bugfix accordion item do not collapse and hide after first click

--- a/packages/components/src/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/Accordion/Accordion.stories.tsx
@@ -178,9 +178,9 @@ export const AccordionInsideAccordion: Story = {
 export const MultiSelect: Story = {
   render: args => (
     <Accordion
+      {...args}
       selectionMode="multiple"
       defaultExpandedKeys={['two', 'one']}
-      {...args}
     >
       {items.map(item => (
         <Accordion.Item key={item.key} title={item.title}>

--- a/packages/components/src/Accordion/AccordionItem.tsx
+++ b/packages/components/src/Accordion/AccordionItem.tsx
@@ -44,9 +44,10 @@ export const AccordionItem = ({
     // clear both default values and expanded also check if multiple or single mode
     if (defaultExpanded) {
       if (state.selectionManager.selectionMode === 'multiple') {
-        state.expandedKeys.forEach(key => {
-          state.selectionManager.select(key);
-        });
+        state.selectionManager.setSelectedKeys([
+          ...state.selectionManager.selectedKeys,
+          item.key,
+        ]);
       } else {
         state.expandedKeys.clear();
         state.selectionManager.toggleSelection(item.key);

--- a/packages/components/src/Accordion/AccordionItem.tsx
+++ b/packages/components/src/Accordion/AccordionItem.tsx
@@ -34,9 +34,9 @@ export const AccordionItem = ({
 }: AccordionItemProps) => {
   const ref = useRef<HTMLButtonElement>(null);
 
-  const defaultExpanded = state.expandedKeys.has(
-    item.key.toString().replace('.$', '')
-  );
+  const defaultExpanded = Array.from(state.expandedKeys).some(key => {
+    return key.toString() === item.key.toString().replace('.$', '');
+  });
 
   const expanded = state.selectionManager.isSelected(item.key);
 


### PR DESCRIPTION
Two bugfixes concerning the accordion component:

- fix selectionMode='multiple' - the correct keys are now selected
- allow also numeric values for prop **defaultExpandedKeys** to match the definition (export type Key = string | number;)