### PR TITLE
refa: remov cloning children in `<Columns>`

### DIFF
--- a/.changeset/ninety-onions-give.md
+++ b/.changeset/ninety-onions-give.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+refa: remov cloning children in `<Columns>`

--- a/packages/components/src/Columns/Columns.tsx
+++ b/packages/components/src/Columns/Columns.tsx
@@ -41,7 +41,7 @@ export const Columns = ({
           )}
           style={createVar({ collapseAt, columnSize: columns[idx] })}
         >
-          {isValidElement(child) ? cloneElement(child) : child}
+          {child}
         </div>
       ))}
     </div>

--- a/packages/components/src/Columns/Columns.tsx
+++ b/packages/components/src/Columns/Columns.tsx
@@ -1,4 +1,4 @@
-import { Children, ReactNode, cloneElement, isValidElement } from 'react';
+import { Children, ReactNode } from 'react';
 
 import { GapSpaceProp, cn, createVar, gapSpace } from '@marigold/system';
 


### PR DESCRIPTION
does not to seem to have any effect.