### PR TITLE
[DST-150]: adjust release workflow to  publish package with provenance

### DIFF
--- a/.changeset/dull-panthers-hang.md
+++ b/.changeset/dull-panthers-hang.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+[DST-150]: adjust release workflow to publish package with provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       # Setup
       - uses: actions/checkout@v4
@@ -31,7 +33,7 @@ jobs:
         uses: changesets/action@v1
         with:
           title: 'release: version packages'
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I adjust the release workflow according to https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions.

The last point shouldn't be necessary:

**If you are publishing a package for the first time you will also need to explicitly set access to public:

npm publish --provenance --access public**