### PR TITLE
fix([DSTSUP-31]): prevent immediately selection is Select/Combobox/Autocomplete

### DIFF
--- a/.changeset/calm-gifts-love.md
+++ b/.changeset/calm-gifts-love.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix([DSTSUP-31]): prevent immediately selection is Select/Combobox/Autocomplete

--- a/packages/components/src/ListBox/ListBox.tsx
+++ b/packages/components/src/ListBox/ListBox.tsx
@@ -31,6 +31,9 @@ const _ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
   ({ variant, size, ...props }, ref) => {
     const classNames = useClassNames({ component: 'ListBox', variant, size });
 
+    // RAC types are incorrect, this will be passed to the `useListBox` hook
+    const listBoxProps: any = { shouldSelectOnPressUp: false };
+
     return (
       <ListBoxContext.Provider value={{ classNames }}>
         <div className={classNames.container}>
@@ -41,6 +44,7 @@ const _ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
               classNames.list
             )}
             ref={ref as Ref<HTMLDivElement>}
+            {...listBoxProps}
           >
             {props.children}
           </ListBox>


### PR DESCRIPTION
[Kapture 2024-02-20 at 14.34.02.webm](https://github.com/marigold-ui/marigold/assets/985701/77b8a6a5-d64a-4e3a-8b28-da484d50a64a)
