### PR TITLE
feat: add `line-height` (browser default) to the core theme

### DIFF
--- a/.changeset/eighty-parents-burn.md
+++ b/.changeset/eighty-parents-burn.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-core": patch
+---
+
+feat: add `line-height` (browser default) to the core theme

--- a/themes/theme-core/src/root.ts
+++ b/themes/theme-core/src/root.ts
@@ -1,5 +1,5 @@
 import { Theme, cva } from '@marigold/system';
 
 export const root: Theme['root'] = cva(
-  'font-body text-text-base bg-bg-surface text-[13px]'
+  'font-body text-text-base bg-bg-surface text-[13px] leading-normal'
 );


### PR DESCRIPTION
This is mostly so it doesn't mess up the styles by external CSS (e.g. our own docs)