### PR TITLE
docs: Show fullscreen view button only on larger examples

### DIFF
--- a/docs/ui/mdx.tsx
+++ b/docs/ui/mdx.tsx
@@ -72,6 +72,8 @@ const typography = {
     className,
     ...props
   }: HTMLAttributes<HTMLPreElement> & { raw: string }) => {
+    const lines = raw.split(/\r\n|\r|\n/).length;
+
     return (
       <div className="relative">
         <pre
@@ -83,7 +85,9 @@ const typography = {
         >
           <div className="absolute right-5 flex justify-end gap-2">
             <CopyButton codeString={raw} />
-            <FullsizeView code={props.children} codeString={raw} />
+            {lines > 5 ? (
+              <FullsizeView code={props.children} codeString={raw} />
+            ) : null}
           </div>
           {props.children}
         </pre>


### PR DESCRIPTION
Current:
![image](https://github.com/marigold-ui/marigold/assets/985701/1ed6f344-4e35-4cd5-9fc9-8dc586d47e48)

PR:
![image](https://github.com/marigold-ui/marigold/assets/985701/02e33c6e-fd69-466e-a005-50c044bb3a72)
