### PR TITLE
docs: images with captions

### DIFF
--- a/docs/ui/Image.tsx
+++ b/docs/ui/Image.tsx
@@ -1,0 +1,43 @@
+import NextImage from 'next/image';
+import type { ImageProps as NextImageProps } from 'next/image';
+
+import { cn } from '@marigold/system';
+
+// Props
+// ---------------
+export interface ImageProps extends NextImageProps {
+  caption?: string;
+  /**
+   * Use to wrap the caption with a link to the resource for
+   * attributing the work.
+   */
+  attribution?: string;
+}
+
+// Component
+// ---------------
+export const Image = ({ caption, attribution, ...props }: ImageProps) => {
+  if (caption) {
+    return (
+      <figure className="mx-auto w-fit">
+        <NextImage {...props} />
+        <figcaption
+          className={cn(
+            'text-secondary-400 not-prose mt-0.5 text-right text-[10px]',
+            attribution && 'hover:text-secondary-500'
+          )}
+        >
+          {attribution ? (
+            <a href={attribution} target="_blank" rel="nofollow noreferrer">
+              {caption}
+            </a>
+          ) : (
+            caption
+          )}
+        </figcaption>
+      </figure>
+    );
+  }
+
+  return <NextImage {...props} />;
+};

--- a/docs/ui/mdx.tsx
+++ b/docs/ui/mdx.tsx
@@ -3,8 +3,6 @@
 import { useMDXComponent } from 'next-contentlayer/hooks';
 import { HTMLAttributes } from 'react';
 
-import Image from 'next/image';
-
 import { cn } from '@marigold/system';
 
 import { IconList } from '@/ui/IconList';
@@ -25,6 +23,7 @@ import { ColorTokenTable } from './ColorTokens';
 import { ComponentDemo } from './ComponentDemo';
 import { CopyButton } from './CopyButton';
 import { FullsizeView } from './FullsizeViewDemo';
+import { Image } from './Image';
 import { PropsTable } from './PropsTable';
 import { TeaserCard, TeaserList } from './TeaserCard';
 import { Toc } from './Toc';


### PR DESCRIPTION
Example:

```jsx
<Image
  src="/familiar.svg"
  width={500}
  height={300}
  alt="Man doubting, questioning, brainstorming"
  caption="Image by vectorjuice on Freepik"
  attribution="https://www.freepik.com/free-vector/self-management-life-coaching-man-doubting-questioning-brainstorming-identity-crisis-delirium-mental-confusion-confused-feelings-concept-pinkish-coral-bluevector-isolated-illustration_11664272.htm#query=think&position=1&from_view=author&uuid=5174f672-636e-482e-8976-6d54bd2b8180"
/>
```

Result:

![image](https://github.com/marigold-ui/marigold/assets/985701/4a06a15f-95c7-4ec9-b07e-b882ca3b61d9)
