### PR TITLE
chore: update renovate to weekly schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     ":semanticCommitTypeAll(chore)",
     ":rebaseStalePrs"
   ],
-  "schedule": ["before 3am on the first day of the month"],
+  "schedule": ["earlyMondays"],
   "packageRules": [
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
because to avoid long waits for updates