### PR TITLE
Orthography changes in Feedback Message demo

### DIFF
--- a/docs/content/patterns/feedback-messages/confirmation-dialog.demo.tsx
+++ b/docs/content/patterns/feedback-messages/confirmation-dialog.demo.tsx
@@ -13,11 +13,11 @@ export default () => (
     <Stack space={2}>
       <Inline alignY="center" space={2}>
         <Exclamation color="text-warning" />
-        <Headline level={3}>This page has unsaved changes!</Headline>
+        <Headline level={3}>This page has unsaved changes</Headline>
       </Inline>
       <Text>
         If you leave this page now, your changes will be lost. Would you like to
-        save your changes first?.
+        save your changes first?
       </Text>
       <Inline alignX="right">
         <Button variant="text">Leave without saving</Button>


### PR DESCRIPTION
Updated the dialog demo to remove a punctuation error and bring the content into conformity with the [Content Guidelines](https://www.marigold-ui.io/patterns/feedback-messages#content-guidelines) listed in the pattern.