### PR TITLE
docs: remove `style` from pops table

### DIFF
--- a/docs/scripts/build-component-props.mjs
+++ b/docs/scripts/build-component-props.mjs
@@ -11,7 +11,7 @@ const parser = docgen.withCustomConfig('./tsconfig.json', {
   shouldExtractValuesFromUnion: false,
   skipChildrenPropWithoutDoc: false,
   propFilter: {
-    skipPropsWithName: ['variant', 'size', 'key'],
+    skipPropsWithName: ['variant', 'size', 'key', 'style'],
   },
   customComponentTypes: [
     'AutocompleteComponent',


### PR DESCRIPTION
# Description

Make sure the `style` prop does not land in the documentation. This might happen sometimes because we extends from the RAC types.

[ ] This change requires a UI-Kit update - inform Alex Tirado

# What should be tested?

Can you find any `style` props in the tables? (e.g. Button had one)

# Reviewers:

Devs
