### PR TITLE
fix: correctly apply styles to `<Select>` icon

### DIFF
--- a/.changeset/lucky-plums-fix.md
+++ b/.changeset/lucky-plums-fix.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: correctly apply styles to `<Select>` icon

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -60,7 +60,7 @@ const theme: Theme = {
           size: { small: 'text-sm' },
         },
       }),
-      icon: cva(),
+      icon: cva('text-zinc-600'),
     },
     Underlay: cva(),
     ListBox: {
@@ -405,6 +405,23 @@ test('supports styling classnames with variants and sizes from theme', () => {
 
   expect(button.className).toContain('text-violet-500');
   expect(button.className).toContain('text-sm');
+});
+
+test('supports applying styles to the caret icon', () => {
+  render(
+    <Select label="Label" data-testid="select">
+      <Select.Section>
+        <Select.Option id="one">one</Select.Option>
+        <Select.Option id="two">two</Select.Option>
+      </Select.Section>
+    </Select>
+  );
+
+  const button = screen.getByRole('button');
+  // eslint-disable-next-line testing-library/no-node-access
+  const icon = button.querySelector('svg');
+
+  expect(icon).toHaveClass('text-zinc-600');
 });
 
 test('set width via props', () => {

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -140,7 +140,7 @@ const _Select = forwardRef<any, SelectProps<object>>(
           )}
         >
           <SelectValue />
-          <ChevronDown className="size-4" />
+          <ChevronDown className={cn('size-4', classNames.icon)} />
         </Button>
         <Popover>
           <ListBox items={items}>{props.children}</ListBox>


### PR DESCRIPTION
# Description

Styles for the icons from theme wasn't applied in the `<Select>` component.

# What should be tested?

Cant really tests it I guess, because we don't yet apply styles to it. Noticed it because I wanted to add some styles in the docs theme.

## Are they some special informations required to test something?

Nope.

# Reviewers:

@marigold-ui/developer