### PR TITLE
fix: pass down appearance props to `FieldBase` in `Select` and `TextField`

### DIFF
--- a/.changeset/two-wombats-work.md
+++ b/.changeset/two-wombats-work.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: pass down appearance props to `FieldBase` in `Switch` and `TextField`

--- a/.changeset/two-wombats-work.md
+++ b/.changeset/two-wombats-work.md
@@ -2,4 +2,4 @@
 "@marigold/components": patch
 ---
 
-fix: pass down appearance props to `FieldBase` in `Switch` and `TextField`
+fix: pass down appearance props to `FieldBase` in `Select` and `TextField`

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -132,7 +132,14 @@ const _Select = forwardRef<any, SelectProps<object>>(
     const classNames = useClassNames({ component: 'Select', variant, size });
 
     return (
-      <FieldBase isOpen as={Select} ref={ref} {...props}>
+      <FieldBase
+        isOpen
+        as={Select}
+        ref={ref}
+        variant={variant}
+        size={size}
+        {...props}
+      >
         <Button
           className={cn(
             'flex w-full items-center justify-between gap-1 overflow-hidden',

--- a/packages/components/src/TextField/TextField.tsx
+++ b/packages/components/src/TextField/TextField.tsx
@@ -90,18 +90,7 @@ export interface TextFieldProps
 // Component
 // ---------------
 const _TextField = forwardRef<HTMLInputElement, TextFieldProps>(
-  (
-    {
-      variant,
-      size,
-      required,
-      disabled,
-      readOnly,
-      error,
-      ...rest
-    }: TextFieldProps,
-    ref
-  ) => {
+  ({ required, disabled, readOnly, error, ...rest }: TextFieldProps, ref) => {
     const props: RAC.TextFieldProps = {
       isDisabled: disabled,
       isReadOnly: readOnly,


### PR DESCRIPTION
# Description

In `Select` and `TextField` the appearance props (`variant` and `size`) where not passed to the `FieldBase` also.


# What should be tested?

-

## Are they some special informations required to test something?

Nope.

# Reviewers:

Marigold Devs
