### PR TITLE
fix([DST-501]): Don't render helptext if there is no error and description.

### DIFF
--- a/.changeset/sixty-bears-double.md
+++ b/.changeset/sixty-bears-double.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix([DST-501]): Don't render helptext if there is no error and description.

--- a/packages/components/src/HelpText/HelpText.tsx
+++ b/packages/components/src/HelpText/HelpText.tsx
@@ -1,21 +1,9 @@
 import { useContext } from 'react';
-import type { PropsWithChildren, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { ValidationResult } from 'react-aria-components';
 import { FieldError, FieldErrorContext, Text } from 'react-aria-components';
 
 import { cn, useClassNames } from '@marigold/system';
-
-// Description
-// ---------------
-const Description = ({ children }: PropsWithChildren) => {
-  const ctx = useContext(FieldErrorContext);
-
-  if (ctx && ctx.isInvalid) {
-    return null;
-  }
-
-  return <Text slot="description">{children}</Text>;
-};
 
 // Icon
 // ---------------
@@ -59,6 +47,12 @@ export const HelpText = ({
     variant,
     size,
   });
+  const ctx = useContext(FieldErrorContext);
+
+  // Prevent rendering anything if no error/description should be shown.
+  if (!description && ctx && !ctx.isInvalid) {
+    return null;
+  }
 
   return (
     <div className={cn(classNames.container)}>
@@ -91,7 +85,9 @@ export const HelpText = ({
           );
         }}
       </FieldError>
-      <Description>{description}</Description>
+      {ctx && ctx.isInvalid ? null : (
+        <Text slot="description">{description}</Text>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Description

See DST-501.  Basically, because of `gap` there was some additional white space below the fields.

[ ] This change requires a UI-Kit update - inform Alex Tirado (@tirado-rx)

# What should be tested?

- Check if there is no whitespace, if no error and descritpion is given. 
- Still show error/description.

## Are they some special informations required to test something?

# Reviewers:

@marigold-ui/developer
