### PR TITLE
docs: select text when site menu is opened

### DIFF
--- a/docs/app/_components/SiteMenu.tsx
+++ b/docs/app/_components/SiteMenu.tsx
@@ -75,6 +75,7 @@ const CustomInput = ({
   onHandlePages,
 }: CustomInputProps) => {
   const slug = useCommandState(state => state.value);
+
   return (
     <Command.Input
       value={value}
@@ -88,6 +89,7 @@ const CustomInput = ({
           onHandlePages(slug);
         }
       }}
+      onFocus={e => e.target.select()}
     />
   );
 };


### PR DESCRIPTION
# Description

Whenever you switch between site you have to delete the latest search, this makes it easier.

[ ] This change requires a UI-Kit update - inform Alex Tirado (@tirado-rx)

# What should be tested?

1. cmd+k, search for something
2. go to a page
3. open cmdk again -> tada, text selected

## Are they some special informations required to test something?

nope

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
