### PR TITLE
docs: parse description in `PropsTable` as markdown

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "react-docgen-typescript": "2.2.2",
     "react-dom": "18.3.1",
     "react-hook-form": "7.51.2",
+    "react-markdown": "9.0.1",
     "react-use": "17.5.1",
     "react-use-clipboard": "1.0.9",
     "rehype-autolink-headings": "7.1.0",

--- a/docs/ui/PropsTable.tsx
+++ b/docs/ui/PropsTable.tsx
@@ -2,6 +2,7 @@ import componentProps from '@/registry/props.json';
 import { Card, Inline, Table, Text } from '@/ui';
 
 import { BlankCanvas } from './icons';
+import { Markdown } from './mdx';
 
 // Helper
 // ---------------
@@ -77,7 +78,13 @@ export const PropsTable = ({ component }: PropsTableProps) => {
                       {prop.defaultValue ? prop.defaultValue.value : '-'}
                     </code>
                   </Table.Cell>
-                  <Table.Cell>{prop.description}</Table.Cell>
+                  <Table.Cell>
+                    <Markdown
+                      // Reset <code> for now
+                      className="*:bg-transparent *:p-0 *:text-xs"
+                      contents={prop.description}
+                    />
+                  </Table.Cell>
                 </Table.Row>
               ))}
             </Table.Body>

--- a/docs/ui/PropsTable.tsx
+++ b/docs/ui/PropsTable.tsx
@@ -81,7 +81,7 @@ export const PropsTable = ({ component }: PropsTableProps) => {
                   <Table.Cell>
                     <Markdown
                       // Reset <code> for now
-                      className="*:bg-transparent *:p-0 *:text-xs"
+                      className="text-pretty *:bg-transparent *:p-0 *:text-xs"
                       contents={prop.description}
                     />
                   </Table.Cell>

--- a/docs/ui/mdx.tsx
+++ b/docs/ui/mdx.tsx
@@ -2,6 +2,8 @@
 
 import { useMDXComponent } from 'next-contentlayer2/hooks';
 import { HTMLAttributes } from 'react';
+import Md from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 import { cn } from '@marigold/system';
 
@@ -186,3 +188,20 @@ export const Mdx = ({ className, title, code }: MdxProps) => {
   const Component = useMDXComponent(code, { title });
   return <Component className={className} components={components as any} />;
 };
+
+export interface MarkdownProps {
+  className?: string;
+  contents: string;
+}
+
+export const Markdown = ({ className, contents }: MarkdownProps) => (
+  <Md
+    className={className}
+    remarkPlugins={[remarkGfm]}
+    components={components}
+    disallowedElements={['p']}
+    unwrapDisallowed
+  >
+    {contents}
+  </Md>
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
       react-hook-form:
         specifier: 7.51.2
         version: 7.51.2(react@18.3.1)
+      react-markdown:
+        specifier: 9.0.1
+        version: 9.0.1(@types/react@18.3.3)(react@18.3.1)
       react-use:
         specifier: 17.5.1
         version: 17.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6683,6 +6686,9 @@ packages:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
 
+  html-url-attributes@3.0.0:
+    resolution: {integrity: sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -8674,6 +8680,12 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-markdown@9.0.1:
+    resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -18030,6 +18042,8 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-url-attributes@3.0.0: {}
+
   html-void-elements@3.0.0: {}
 
   http-errors@2.0.0:
@@ -20510,6 +20524,23 @@ snapshots:
   react-is@18.2.0: {}
 
   react-is@18.3.1: {}
+
+  react-markdown@9.0.1(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/react': 18.3.3
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.0
+      html-url-attributes: 3.0.0
+      mdast-util-to-hast: 13.1.0
+      react: 18.3.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.0
+      unified: 11.0.4
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
# Description

We can no write markdown to describe props. yay! This is not perfect, but much better than randomly having markdown in our tables.

- [] This change requires a UI-Kit update - inform Alex Tirado (@tirado-rx)

# What should be tested?

Check out a PropsTable

## Are they some special informations required to test something?

No.

# Reviewers:

@marigold-ui/developer

