### PR TITLE
feat: add dedicated export for tokens to all themes

### DIFF
--- a/.changeset/lucky-bugs-repair.md
+++ b/.changeset/lucky-bugs-repair.md
@@ -1,0 +1,7 @@
+---
+"@marigold/theme-b2b": minor
+"@marigold/theme-core": minor
+"@marigold/theme-docs": minor
+---
+
+feat: add dedicated export for tokens to all themes (`@marigold/<theme-name>/tokens`)

--- a/themes/theme-b2b/package.json
+++ b/themes/theme-b2b/package.json
@@ -18,10 +18,10 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./preset": {
-      "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
-      "types": "./dist/preset.d.ts"
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.ts"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/themes/theme-b2b/src/tokens.ts
+++ b/themes/theme-b2b/src/tokens.ts
@@ -279,7 +279,7 @@ export const colors = {
       DEFAULT: blue[400],
     },
   },
-};
+} as const;
 
 // Shadow
 // ---------------
@@ -290,7 +290,7 @@ export const shadow = {
     overlay: boxShadow.lg,
     sunken: boxShadow.none,
   },
-};
+} as const;
 
 // Component Height
 // ---------------
@@ -300,4 +300,4 @@ export const height = {
     sm: '24px', // not used at all
     lg: '48px', // used in button
   },
-};
+} as const;

--- a/themes/theme-b2b/tsup.config.ts
+++ b/themes/theme-b2b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/preset.ts'],
+  entry: ['src/index.ts', 'src/preset.ts', 'src/tokens.ts'],
   format: ['esm', 'cjs'],
   tsconfig: './tsconfig.build.json',
   dts: true,

--- a/themes/theme-core/package.json
+++ b/themes/theme-core/package.json
@@ -18,10 +18,10 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./preset": {
-      "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
-      "types": "./dist/preset.d.ts"
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.ts"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/themes/theme-core/src/tokens.ts
+++ b/themes/theme-core/src/tokens.ts
@@ -277,7 +277,7 @@ export const colors = {
       DEFAULT: blue[500],
     },
   },
-};
+} as const;
 
 export const shadow = {
   surface: {
@@ -286,7 +286,7 @@ export const shadow = {
     overlay: boxShadow.md,
     sunken: boxShadow.none,
   },
-};
+} as const;
 
 export const height = {
   component: {
@@ -294,4 +294,4 @@ export const height = {
     sm: '16px',
     lg: '32px',
   },
-};
+} as const;

--- a/themes/theme-core/tsup.config.ts
+++ b/themes/theme-core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/preset.ts'],
+  entry: ['src/index.ts', 'src/preset.ts', 'src/tokens.ts'],
   format: ['esm', 'cjs'],
   tsconfig: './tsconfig.build.json',
   dts: true,

--- a/themes/theme-docs/package.json
+++ b/themes/theme-docs/package.json
@@ -18,10 +18,10 @@
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
-    "./preset": {
-      "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
-      "types": "./dist/preset.d.ts"
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.ts"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/themes/theme-docs/src/tokens.ts
+++ b/themes/theme-docs/src/tokens.ts
@@ -176,4 +176,4 @@ export const colors = {
     success: green[600],
     error: red[600],
   },
-};
+} as const;

--- a/themes/theme-docs/tsup.config.ts
+++ b/themes/theme-docs/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/preset.ts'],
+  entry: ['src/index.ts', 'src/preset.ts', 'src/tokens.ts'],
   format: ['esm', 'cjs'],
   tsconfig: './tsconfig.build.json',
   dts: true,


### PR DESCRIPTION
# Description

A dedicated `@marigold/<theme-name>/tokens` export allows to only export the tokens without all the baggage of the others exports with should only be used to configure the MarigoldProvider and tailwind.

# What should be tested?

You can try it out when checking this out locally, I guess.

## Are they some special informations required to test something?

I want this for the OG image, I cannot have "client only" exports there which sadly come when you import the system or preset package.

# Reviewers:

@marigold-ui/developer

