### PR TITLE
[DST-504]: Sorting indicator is always shown in table

### DIFF
--- a/.changeset/big-moons-pretend.md
+++ b/.changeset/big-moons-pretend.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+[DST-504]: Sorting indicator is always shown in table

--- a/.changeset/big-moons-pretend.md
+++ b/.changeset/big-moons-pretend.md
@@ -2,4 +2,4 @@
 "@marigold/components": patch
 ---
 
-[DST-504]: Sorting indicator is always shown in table
+[DST-504]: Sorting indicator is shown only on sorted column.

--- a/packages/components/src/Table/TableColumnHeader.tsx
+++ b/packages/components/src/Table/TableColumnHeader.tsx
@@ -8,8 +8,7 @@ import { mergeProps } from '@react-aria/utils';
 import { GridNode } from '@react-types/grid';
 
 import { SortDown, SortUp } from '@marigold/icons';
-import { cn, useStateProps } from '@marigold/system';
-import { width as twWidth } from '@marigold/system';
+import { cn, width as twWidth, useStateProps } from '@marigold/system';
 
 import { useTableContext } from './Context';
 import { ColumnProps } from './Table';
@@ -64,7 +63,9 @@ export const TableColumnHeader = ({
             <SortDown className="inline-block" />
           )
         ) : (
-          <SortDown className="inline-block" />
+          <span className="invisible">
+            <SortDown className="inline-block" />
+          </span>
         ))}
     </th>
   );


### PR DESCRIPTION
# Description

Currently the sorting indicator is always shown on all columns in table. Now the sorting indicator is only shown when a column header is pressed and `allowsSorting` is set onto this.

- [x] This change requires a UI-Kit update
- [ ] - inform Alex Tirado, Bobby

# What should be tested?

## Are they some special informations required to test something?

# Reviewers:

Which persons should review this PR? Add person with @mentions
@marigold-ui/developer
