### PR TITLE
docs: make Dos and Donts less prominent

### DIFF
--- a/docs/ui/DosAndDonts.tsx
+++ b/docs/ui/DosAndDonts.tsx
@@ -33,7 +33,7 @@ const Figure = ({ children }: PropsWithChildren) => (
 );
 
 const Description = ({ children }: PropsWithChildren) => (
-  <div className="group-data-[type=do]:bg-bg-success group-data-[type=dont]:bg-bg-error px-4 pb-4 [grid-area:description] *:m-0">
+  <div className="group-data-[type=do]:bg-bg-success group-data-[type=dont]:bg-bg-error px-4 pb-4 text-sm [grid-area:description] *:m-0 *:leading-relaxed">
     {children}
   </div>
 );
@@ -44,14 +44,12 @@ export const Do = ({ children }: PropsWithChildren) => (
   <Container variant="do">
     <Title>
       <svg
-        width="10px"
-        height="10px"
         viewBox="0 0 24 24"
-        className="size-5 flex-none rounded-full bg-green-600 fill-white p-1"
+        className="bg-border-success size-4 flex-none rounded-full fill-white p-1"
       >
         <path d="M8.17368 16.6154L3.19528 11.637L1.5 13.3204L8.17368 19.994L22.5 5.66772L20.8167 3.98437L8.17368 16.6154Z"></path>
       </svg>
-      <h5 className="m-0 font-bold uppercase">Do</h5>
+      <div className="m-0 text-sm font-bold uppercase">Do</div>
     </Title>
     {children}
   </Container>
@@ -66,14 +64,12 @@ export const Dont = ({ children }: PropsWithChildren) => (
   <Container variant="dont">
     <Title>
       <svg
-        width="10px"
-        height="10px"
         viewBox="0 0 24 24"
-        className="size-5 flex-none rounded-full bg-red-600 fill-white p-1"
+        className="bg-border-error size-4 flex-none rounded-full fill-white p-1"
       >
         <path d="M19.8281 5.74868L18.2513 4.17188L12 10.4232L5.74868 4.17188L4.17188 5.74868L10.4232 12L4.17188 18.2513L5.74868 19.8281L12 13.5768L18.2513 19.8281L19.8281 18.2513L13.5768 12L19.8281 5.74868Z"></path>
       </svg>
-      <h5 className="m-0 font-bold uppercase">Don't</h5>
+      <div className="m-0 text-sm font-bold uppercase">Don't</div>
     </Title>
     {children}
   </Container>

--- a/themes/theme-docs/src/tokens.ts
+++ b/themes/theme-docs/src/tokens.ts
@@ -34,8 +34,8 @@ const blue = {
   950: '#172554',
 };
 
-const green = {
-  50: '#f0fdf4',
+const lime = {
+  50: '#f7fee7',
   100: '#ecfccb',
   200: '#d9f99d',
   300: '#bef264',
@@ -160,7 +160,7 @@ export const colors = {
     },
 
     // Status
-    success: green[100],
+    success: lime[50],
     error: red[50],
     info: blue[50],
     warning: amber[50],
@@ -173,7 +173,7 @@ export const colors = {
     primary: slate[950],
 
     // status
-    success: green[600],
-    error: red[600],
+    success: lime[500],
+    error: red[400],
   },
 } as const;


### PR DESCRIPTION
# Description

If you have a page with lots of do/donts you dont see the actual  text anymore. This does hopfully improve the situation a bit.

# What should be tested?

Open the Table page. Compare to `main`.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
