### PR TITLE
docs: make CTA button more clean on smaller screens

### DIFF
--- a/docs/app/_components/SiteHeader.tsx
+++ b/docs/app/_components/SiteHeader.tsx
@@ -14,9 +14,11 @@ export const SiteHeader = () => (
       <SiteLogo />
       <SiteNavigation />
     </div>
-    <Link href="https://marigold-rapp.vercel.app/" variant="cta">
-      Discover new tutorials!
-    </Link>
+    <div className="hidden md:block">
+      <Link href="https://marigold-rapp.vercel.app/" variant="cta">
+        <span className="hidden xl:inline">Discover new </span>Tutorials!
+      </Link>
+    </div>
     <div className="flex flex-1 flex-col items-stretch md:block md:flex-initial">
       <SiteMenu />
     </div>


### PR DESCRIPTION
# Description

The link to the RAPP was not looking good on smaller screens. This fixes that.
