### PR TITLE
feat: add `as` prop to Text to render different elements

### DIFF
--- a/docs/ui/mdx.tsx
+++ b/docs/ui/mdx.tsx
@@ -50,7 +50,9 @@ import {
 // Typography
 // ---------------
 const typography = {
-  p: (props: HTMLAttributes<HTMLParagraphElement>) => <Text {...props} />,
+  p: (props: HTMLAttributes<HTMLParagraphElement>) => (
+    <Text {...props} as="p" />
+  ),
   h1: (props: HTMLAttributes<HTMLHeadingElement>) => (
     <Headline level={1} {...props} />
   ),

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -42,6 +42,13 @@ const meta = {
       },
       description: 'The font style of the text',
     },
+    as: {
+      control: {
+        type: 'select',
+      },
+      options: ['div', 'p', 'span'],
+      description: 'Element to render as Text',
+    },
     cursor: {
       control: {
         type: 'text',

--- a/packages/components/src/Text/Text.test.tsx
+++ b/packages/components/src/Text/Text.test.tsx
@@ -52,6 +52,20 @@ test('renders a <div> element by default', () => {
   expect(text instanceof HTMLDivElement).toBeTruthy();
 });
 
+test('renders a <p>/<span> element', () => {
+  render(
+    <ThemeProvider theme={theme}>
+      <Text as="p">paragraph</Text>
+      <Text as="span">span</Text>
+    </ThemeProvider>
+  );
+  const paragraph = screen.getByText(/paragraph/);
+  const span = screen.getByText(/span/);
+
+  expect(paragraph instanceof HTMLParagraphElement).toBeTruthy();
+  expect(span instanceof HTMLSpanElement).toBeTruthy();
+});
+
 test('style props override theme styles', () => {
   render(
     <ThemeProvider theme={theme}>

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -36,6 +36,11 @@ export interface TextProps
    * @default currentColor
    */
   color?: string;
+  /**
+   * Element to render
+   * @default "div"
+   */
+  as?: 'div' | 'p' | 'span';
   variant?: string;
   size?: string;
 }
@@ -52,6 +57,7 @@ const _Text = ({
   fontSize,
   fontStyle,
   children,
+  as = 'div',
   ...props
 }: TextProps) => {
   const theme = useTheme();
@@ -64,7 +70,7 @@ const _Text = ({
   return (
     <Text
       {...props}
-      elementType="div"
+      elementType={as}
       className={cn(
         'text-[--color] outline-[--outline]',
         classNames,


### PR DESCRIPTION
# Description

Makes it possible to render a `p` or `span` instead of a `div`. This control enables the text component to better fit different use cases.
