### PR TITLE
fix: fix SelectListItem layout

### DIFF
--- a/.changeset/twelve-eyes-boil.md
+++ b/.changeset/twelve-eyes-boil.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: fix SelectListItem layout

--- a/packages/components/src/SelectList/SelectList.tsx
+++ b/packages/components/src/SelectList/SelectList.tsx
@@ -48,9 +48,10 @@ const _SelectList = forwardRef<HTMLUListElement, SelectListProps>(
         <div className={classNames.container}>
           <SelectList
             {...props}
+            layout="grid"
             ref={ref as Ref<HTMLDivElement>}
             className={cn(
-              'overflow-y-auto sm:max-h-[75vh] lg:max-h-[45vh]',
+              'group/list overflow-y-auto sm:max-h-[75vh] lg:max-h-[45vh]',
               classNames.list
             )}
           >

--- a/packages/components/src/SelectList/SelectListItem.tsx
+++ b/packages/components/src/SelectList/SelectListItem.tsx
@@ -12,12 +12,16 @@ export interface SelectListItemProps
 const _SelectListItem = forwardRef<HTMLDivElement, SelectListItemProps>(
   ({ children, ...props }, ref) => {
     let textValue = typeof children === 'string' ? children : undefined;
+
     const { classNames } = useSelectListContext();
     return (
       <SelectListItem
         textValue={textValue}
         {...props}
-        className={cn('flex items-center', classNames?.option)}
+        className={cn(
+          'items-center group-data-[layout=grid]/list:flex-row',
+          classNames?.option
+        )}
         ref={ref as Ref<HTMLDivElement>}
       >
         {({ selectionMode }) => (


### PR DESCRIPTION
# Description

I noticed that the selectlist layout breaks with the new select feature of having descriptions. So I tried to fix it

# What should be tested?

Test if the selectbox works as expected, it looks broken in main

# Reviewers:

@marigold-ui/developer
