### PR TITLE
fix: fix DOM tree for empty tables

### DIFF
--- a/.changeset/proud-radios-joke.md
+++ b/.changeset/proud-radios-joke.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: fix DOM tree for empty tables

--- a/packages/components/src/Table/TableBody.tsx
+++ b/packages/components/src/Table/TableBody.tsx
@@ -22,15 +22,17 @@ export const TableBody = ({ children, emptyState }: TableBodyProps) => {
 
   if (state.collection.size === 0 && emptyState) {
     return (
-      <tr className={classNames?.row} role="row">
-        <td
-          className={classNames?.cell}
-          colSpan={state.collection.size}
-          role="rowheader"
-        >
-          {emptyState()}
-        </td>
-      </tr>
+      <tbody>
+        <tr className={classNames?.row} role="row">
+          <td
+            className={classNames?.cell}
+            colSpan={state.collection.size}
+            role="rowheader"
+          >
+            {emptyState()}
+          </td>
+        </tr>
+      </tbody>
     );
   }
 

--- a/packages/components/src/test.utils.tsx
+++ b/packages/components/src/test.utils.tsx
@@ -5,7 +5,7 @@ import { Theme, ThemeProvider, ThemeProviderProps } from '@marigold/system';
 export interface SetupProps<T extends Theme>
   extends Omit<ThemeProviderProps<T>, 'children'> {}
 
-export const setup = <T extends Theme>({ theme }: SetupProps<T>) => {
+export const setup: Function = <T extends Theme>({ theme }: SetupProps<T>) => {
   return {
     render: (element: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
       render(element, {


### PR DESCRIPTION
# Description

There was this error in tests `console.error
      Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.` I fix it with wrappig a `<tbody>` around the empty state

# Reviewers:
@marigold-ui/developer
