### PR TITLE
fix[DSTSUP-86]: adjust select and combobox styles for core theme

### DIFF
--- a/.changeset/spotty-tomatoes-cover.md
+++ b/.changeset/spotty-tomatoes-cover.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-core": patch
+---
+
+fix[DSTSUP-86]: adjust select and combobox styles for core theme

--- a/themes/theme-core/src/components/ComboBox.styles.ts
+++ b/themes/theme-core/src/components/ComboBox.styles.ts
@@ -1,5 +1,5 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const ComboBox: ThemeComponent<'ComboBox'> = cva([
-  'absolute right-2 size-4 border-none bg-transparent disabled:bg-transparent hover:bg-transparent overflow-hidden',
+  'absolute right-2 size-4 border-none p-0 bg-transparent disabled:bg-transparent hover:bg-transparent overflow-hidden',
 ]);

--- a/themes/theme-core/src/components/ComboBox.styles.ts
+++ b/themes/theme-core/src/components/ComboBox.styles.ts
@@ -1,5 +1,5 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
-export const ComboBox: ThemeComponent<'ComboBox'> = cva(
-  'absolute right-2 size-4 border-none bg-transparent p-0 hover:bg-transparent'
-);
+export const ComboBox: ThemeComponent<'ComboBox'> = cva([
+  'absolute right-2 size-4 border-none bg-transparent disabled:bg-transparent hover:bg-transparent overflow-hidden',
+]);

--- a/themes/theme-core/src/components/Input.styles.ts
+++ b/themes/theme-core/src/components/Input.styles.ts
@@ -4,7 +4,7 @@ export const inputHeight = 'h-component';
 export const inputBox = 'border rounded-sm border-border-inverted bg-white';
 export const inputSpacing = 'px-1';
 export const inputDisabled =
-  'disabled:bg-bg-inverted-disabled disabled:border-border-base-disabled disabled:text-text-base-disabled';
+  'disabled:bg-bg-inverted-disabled disabled:border-border-base-disabled disabled:text-text-base-disabled disabled:cursor-not-allowed';
 
 export const inputError = `data-[invalid]:border-border-error`;
 

--- a/themes/theme-core/src/components/Select.styles.ts
+++ b/themes/theme-core/src/components/Select.styles.ts
@@ -1,5 +1,11 @@
 import { ThemeComponent, cva } from '@marigold/system';
-import { inputBox, inputHeight, inputSpacing } from './Input.styles';
+import {
+  inputBox,
+  inputDisabled,
+  inputError,
+  inputHeight,
+  inputSpacing,
+} from './Input.styles';
 
 export const Select: ThemeComponent<'Select'> = {
   icon: cva(),
@@ -7,6 +13,8 @@ export const Select: ThemeComponent<'Select'> = {
     inputBox,
     inputHeight,
     inputSpacing,
+    inputError,
+    inputDisabled,
     '[&>[data-placeholder=true]]:text-text-inverted-disabled',
   ]),
 };


### PR DESCRIPTION
# Description

- fixed `<Select>` disabled styles
- fixed `<Combobox>` icon styles

# Reviewers:
@marigold-ui/developer
@marigold-ui/designer
