### PR TITLE
fix: adjust visibility for autocomplete clear button

### DIFF
--- a/.changeset/mean-trees-begin.md
+++ b/.changeset/mean-trees-begin.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix: adjust visibility for autocomplete clear button

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -49,7 +49,10 @@ const AutocompleteInput = ({
     <SearchInput
       ref={ref}
       className={{
-        action: cn(state?.inputValue === '' ? 'hidden' : undefined, classNames),
+        action: cn(
+          state?.inputValue === '' ? 'invisible' : 'visible',
+          classNames
+        ),
       }}
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === 'Escape') {
@@ -196,7 +199,7 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     };
 
     return (
-      <FieldBase as={ComboBox} {...props}>
+      <FieldBase as={ComboBox} ref={ref} {...props}>
         <AutocompleteInput onSubmit={onSubmit} onClear={onClear} ref={ref} />
         <Popover>
           <ListBox>{children}</ListBox>


### PR DESCRIPTION
# Description

Fixed the overflowing popover width in autocomplete -> reason was the visibility of the clearing button

# Reviewers:

@marigold-ui/developer
