### PR TITLE
fix: remove node_modules from tailwind config

### DIFF
--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -20,6 +20,7 @@ const config: Config = {
 
     // Marigold components
     '../packages/{components,system}/**/*.{tsx,ts}',
+    '!../../packages/{components,system}/node_modules/**/*.{tsx,ts}',
     '!../packages/{components,system}/**/*.{stories,test}.{tsx,ts}',
   ],
   presets: [preset],

--- a/themes/theme-b2b/tailwind.config.ts
+++ b/themes/theme-b2b/tailwind.config.ts
@@ -11,6 +11,7 @@ export default {
     'src/colors.ts',
     'src/**/*.*.ts',
     '../../packages/{components,system}/**/*.{tsx,ts}',
+    '!../../packages/{components,system}/node_modules/**/*.{tsx,ts}',
     '!../../packages/{components,system}/**/*.{stories,test}.{tsx,ts}',
   ],
   safelist: [{ pattern: /(bg|text|border|shadow)-./ }],

--- a/themes/theme-core/tailwind.config.ts
+++ b/themes/theme-core/tailwind.config.ts
@@ -11,6 +11,7 @@ export default {
     'src/root.ts',
     'src/**/*.*.ts',
     '../../packages/{components,system}/**/*.{tsx,ts}',
+    '!../../packages/{components,system}/node_modules/**/*.{tsx,ts}',
     '!../../packages/{components,system}/**/*.{stories,test}.{tsx,ts}',
   ],
   presets: [preset],

--- a/themes/theme-docs/tailwind.config.ts
+++ b/themes/theme-docs/tailwind.config.ts
@@ -5,6 +5,7 @@ export default {
   content: [
     'src/**/*.*.ts',
     '../../packages/{components,system}/**/*.{tsx,ts}',
+    '!../../packages/{components,system}/node_modules/**/*.{tsx,ts}',
     '!../../packages/{components,system}/**/*.{stories,test}.{tsx,ts}',
   ],
   presets: [preset],


### PR DESCRIPTION
# Description

when building our themes and docs this warning appears: 

`warn - Your `content` configuration includes a pattern which looks like it’s accidentally matching all of `node_modules` and can cause serious performance issues.
warn - Pattern: `../packages/system/**/*.ts`
warn - See our documentation for recommendations:
warn - https://tailwindcss.com/docs/content-configuration#pattern-recommendations`

So I thought I follow the warning

# What should be tested?

everything working correctly?

# Reviewers:

@marigold-ui/developer
