### PR TITLE
style(docs): Improve whitespace of `p`

### DIFF
--- a/.changeset/bright-sloths-jog.md
+++ b/.changeset/bright-sloths-jog.md
@@ -1,0 +1,7 @@
+---
+"@marigold/theme-docs": patch
+---
+
+style(docs): Improve whitespace of `p`
+
+Removed the top margin because this lead to some weird extra whitespace.

--- a/themes/theme-docs/src/components/Text.styles.ts
+++ b/themes/theme-docs/src/components/Text.styles.ts
@@ -1,15 +1,12 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
-export const Text: ThemeComponent<'Text'> = cva(
-  'leading-7 [&:not(:first-child)]:mt-6',
-  {
-    variants: {
-      variant: {
-        lead: 'text-muted-foreground text-xl',
-        large: 'text-lg font-semibold',
-        small: 'text-sm font-medium leading-none',
-        muted: 'text-muted-foreground text-sm',
-      },
+export const Text: ThemeComponent<'Text'> = cva('leading-7', {
+  variants: {
+    variant: {
+      lead: 'text-muted-foreground text-xl',
+      large: 'text-lg font-semibold',
+      small: 'text-sm font-medium leading-none',
+      muted: 'text-muted-foreground text-sm',
     },
-  }
-);
+  },
+});


### PR DESCRIPTION
Removed the top margin because this lead to some weird extra whitespace.

# Reviewers:

Examples:
@marigold-ui/developer
@marigold-ui/designer
