### PR TITLE
refa(listbox): Allow sections in Combobox + Autocomplete, adjust Section API

### DIFF
--- a/.changeset/bright-masks-love.md
+++ b/.changeset/bright-masks-love.md
@@ -5,14 +5,15 @@
 "@marigold/theme-b2b": patch
 ---
 
-refa(listbox): Allow sections in `Combobox` and `Autocomplete`, adjust Section API in `Select`, `Combobox` and `Autocomplete`.
+refa(listbox): Allow sections in `<Combobox>` and `<Autocomplete>`, adjust Section API in `<Select>`, `<Combobox>` and `<Autocomplete>`.
 
-- Added the possibility to use sections with `Combobox` and `Autocomplete`
-- Refactored the `Section` (from `Listbox`) to fit our API, no need for the extra `Header` anymore. Instead you can do `<Select.Section header="My header">`, same for the other components
-- Renamed `Item` to `Option` in `Combobox` and `Autocomplete` to align with `Select`
-- Updated the docs for `Select`, `Combobox` and `Autocomplete`
-- Updated Storybook for `Select`, `Combobox` and `Autocomplete` with section stories
-- Renamed the part of the `ListBox` accordingly (from `sectionTitle` to `header`)
+- Added the possibility to use sections with `<Combobox>` and `<Autocomplete>`
+- Refactored the `<Section>` (from `<Listbox>`) to fit our API, no need for the extra `<Header>` anymore. Instead you can do `<Select.Section header="My header">`, same for the other components
+- Renamed `<Item>` to `<Option>` in `<Combobox>` and `<Autocomplete>` to align with `<Select>`
+- Updated the docs for `<Select>`, `<Combobox>` and `<Autocomplete>`
+- Updated Storybook for `<Select>`, `<Combobox>` and `<Autocomplete>` with section stories
+- Renamed the part of the `<ListBox>` accordingly (from `sectionTitle` to `header`)
 
-  **BREAKING CHANGE:** We changed the API of the `Section` component that is used in `Select`, `Combobox` and `Autocomplete`. It is no longer necessary to add a `Header` within the `Section`.
-  Use the newly added `header` prop instead. Additionally, to unify the APIs all choices of  `Select`, `Combobox` and `Autocomplete` are now called `Option` instead of `Item`.
+  **BREAKING CHANGE:** We changed the API of the `<Section>` component that is used in `<Select>`, `<Combobox>` and `<Autocomplete>`. It is no longer necessary to add a `Header` within the `<Section>`.
+  
+  Use the newly added `header` prop instead. Additionally, to unify the APIs all choices of  `<Select>`, `<Combobox>` and `<Autocomplete>` are now called `<Option>` instead of `<Item>`.

--- a/.changeset/bright-masks-love.md
+++ b/.changeset/bright-masks-love.md
@@ -1,0 +1,17 @@
+---
+"@marigold/docs": patch
+"@marigold/components": patch
+"@marigold/system": patch
+"@marigold/theme-b2b": patch
+---
+
+refa(listbox): Allow sections in `Combobox` and `Autocomplete`, adjust Section API in `Select`, `Combobox` and `Autocomplete`.
+
+- Added the possibility to use sections with `Combobox` and `Autocomplete`
+- Refactored the `Section` (from `Listbox`) to fit our API, no need for the extra `Header` anymore. Instead you can do `<Select.Section header="My header">`, same for the other components
+- Renamed `Item` to `Option` in `Combobox` and `Autocomplete` to align with `Select`
+- Updated the docs for `Select`, `Combobox` and `Autocomplete`
+- Updated Storybook for `Select`, `Combobox` and `Autocomplete` with section stories
+
+  **BREAKING CHANGE:** We changed the API of the `Section` component that is used in `Select`, `Combobox` and `Autocomplete`. It is no longer necessary to add a `Header` within the `Section`.
+  Use the newly added `header` prop instead. Additionally, to unify the APIs all choices of  `Select`, `Combobox` and `Autocomplete` are now called `Option` instead of `Item`.

--- a/.changeset/bright-masks-love.md
+++ b/.changeset/bright-masks-love.md
@@ -12,6 +12,7 @@ refa(listbox): Allow sections in `Combobox` and `Autocomplete`, adjust Section A
 - Renamed `Item` to `Option` in `Combobox` and `Autocomplete` to align with `Select`
 - Updated the docs for `Select`, `Combobox` and `Autocomplete`
 - Updated Storybook for `Select`, `Combobox` and `Autocomplete` with section stories
+- Renamed the part of the `ListBox` accordingly (from `sectionTitle` to `header`)
 
   **BREAKING CHANGE:** We changed the API of the `Section` component that is used in `Select`, `Combobox` and `Autocomplete`. It is no longer necessary to add a `Header` within the `Section`.
   Use the newly added `header` prop instead. Additionally, to unify the APIs all choices of  `Select`, `Combobox` and `Autocomplete` are now called `Option` instead of `Item`.

--- a/docs/content/components/form/autocomplete/autocomplete-appearance.demo.tsx
+++ b/docs/content/components/form/autocomplete/autocomplete-appearance.demo.tsx
@@ -12,16 +12,16 @@ export default () => {
         label="Favorite vegetable:"
         onSubmit={(id, val) => setSubmitted([id, val])}
       >
-        <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-        <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-        <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-        <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
-        <Autocomplete.Item id="brussels-sprouts">
+        <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+        <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+        <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+        <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
+        <Autocomplete.Option id="brussels-sprouts">
           Brussels Sprouts
-        </Autocomplete.Item>
-        <Autocomplete.Item id="kale">Kale</Autocomplete.Item>
-        <Autocomplete.Item id="peas">Peas</Autocomplete.Item>
-        <Autocomplete.Item id="beets">Beets</Autocomplete.Item>
+        </Autocomplete.Option>
+        <Autocomplete.Option id="kale">Kale</Autocomplete.Option>
+        <Autocomplete.Option id="peas">Peas</Autocomplete.Option>
+        <Autocomplete.Option id="beets">Beets</Autocomplete.Option>
       </Autocomplete>
       <Text weight="black">User subbmitted: "{submitted}"</Text>
     </Stack>

--- a/docs/content/components/form/autocomplete/autocomplete-async.demo.tsx
+++ b/docs/content/components/form/autocomplete/autocomplete-async.demo.tsx
@@ -53,7 +53,7 @@ export default () => {
         onSubmit={handleSubmit}
       >
         {(item: any) => (
-          <Autocomplete.Item id={item.name}>{item.name}</Autocomplete.Item>
+          <Autocomplete.Option id={item.name}>{item.name}</Autocomplete.Option>
         )}
       </Autocomplete>
       {result === null ? null : result.length > 0 ? (

--- a/docs/content/components/form/autocomplete/autocomplete-section.demo.tsx
+++ b/docs/content/components/form/autocomplete/autocomplete-section.demo.tsx
@@ -1,0 +1,78 @@
+import { Autocomplete } from '@marigold/components';
+
+export default () => (
+  <Autocomplete label="Genres" width="fit">
+    {options.map(item => (
+      <Autocomplete.Section key={item.category} header={item.category}>
+        {item.genres.map(genre => (
+          <Autocomplete.Option key={genre}>{genre}</Autocomplete.Option>
+        ))}
+      </Autocomplete.Section>
+    ))}
+  </Autocomplete>
+);
+
+const options = [
+  {
+    category: 'Pop and Dance',
+    genres: [
+      'Pop',
+      'Synth-pop',
+      'Electropop',
+      'Dance-pop',
+      'Teen pop',
+      'Disco',
+    ],
+  },
+  {
+    category: 'Rock and Alternative',
+    genres: [
+      'Rock',
+      'Hard rock',
+      'Punk rock',
+      'Alternative rock',
+      'Indie rock',
+      'Grunge',
+      'Psychedelic rock',
+    ],
+  },
+  {
+    category: 'Hip-Hop and R&B',
+    genres: ['Hip-Hop', 'Rap', 'Trap', 'R&B', 'Neo-soul'],
+  },
+  {
+    category: 'Electronic and Experimental',
+    genres: ['EDM', 'House', 'Techno', 'Dubstep', 'Ambient', 'Industrial'],
+  },
+  {
+    category: 'Jazz and Blues',
+    genres: [
+      'Jazz',
+      'Smooth jazz',
+      'Bebop',
+      'Blues',
+      'Delta blues',
+      'Chicago blues',
+    ],
+  },
+  {
+    category: 'Classical and Orchestral',
+    genres: ['Classical', 'Baroque', 'Opera', 'Symphony', 'Chamber music'],
+  },
+  {
+    category: 'Folk and Country',
+    genres: ['Folk', 'Country', 'Bluegrass', 'Americana'],
+  },
+  {
+    category: 'Latin and World',
+    genres: ['Reggaeton', 'Salsa', 'Bossa Nova', 'Flamenco', 'Afrobeats'],
+  },
+  {
+    category: 'Metal and Hard Music',
+    genres: ['Heavy metal', 'Thrash metal', 'Death metal', 'Doom metal'],
+  },
+  {
+    category: 'Reggae and Caribbean',
+    genres: ['Reggae', 'Ska', 'Dancehall', 'Soca'],
+  },
+];

--- a/docs/content/components/form/autocomplete/autocomplete.mdx
+++ b/docs/content/components/form/autocomplete/autocomplete.mdx
@@ -64,136 +64,149 @@ It is also suitable for fields where people know what they’re looking for, e.g
   <Do.Description>Use an `<Autocomplete>` instead of a long list.</Do.Description>
 </Do>
 
-### Text Label
+### Text label
 
 The label of the `<Autocomplete>` provides a clear and concise description of its purpose, making it easier for users to
 interact with the interface and understand it.
 Always display a label unless the `<Autocomplete>` is next to another component which already has a label.
 
-    <GuidelineTiles>
-      <Do>
-        <Do.Figure>
-          <Image
-            width={700}
-            height={700}
-            unoptimized
-            src="/autocomplete/autocomplete-do-label.jpg"
-            alt="Use a clear and concise text label to clarify the meaning."
-          />
-        </Do.Figure>
-        <Do.Description>
-          Use a clear and concise text label to clarify the meaning.
-        </Do.Description>
-      </Do>
-      <Dont>
-        <Dont.Figure>
-          <Image
-            width={700}
-            height={700}
-            unoptimized
-            src="/autocomplete/autocomplete-dont-label.jpg"
-            alt="Avoid using the Autocomplete without a label unless the Autocomplete is part of a complex scenario and its context is already set."
-          />
-        </Dont.Figure>
-        <Dont.Description>
-          Avoid using the Autocomplete without a label unless the Autocomplete is part of a complex scenario and its
-          context
-          is already set.
-        </Dont.Description>
-      </Dont>
-    </GuidelineTiles>
+<GuidelineTiles>
+  <Do>
+    <Do.Figure>
+      <Image
+        width={700}
+        height={700}
+        unoptimized
+        src="/autocomplete/autocomplete-do-label.jpg"
+        alt="Use a clear and concise text label to clarify the meaning."
+      />
+    </Do.Figure>
+    <Do.Description>
+      Use a clear and concise text label to clarify the meaning.
+    </Do.Description>
+  </Do>
+  <Dont>
+    <Dont.Figure>
+      <Image
+        width={700}
+        height={700}
+        unoptimized
+        src="/autocomplete/autocomplete-dont-label.jpg"
+        alt="Avoid using the Autocomplete without a label unless the Autocomplete is part of a complex scenario and its context is already set."
+      />
+    </Dont.Figure>
+    <Dont.Description>
+      Avoid using the Autocomplete without a label unless the Autocomplete is
+      part of a complex scenario and its context is already set.
+    </Dont.Description>
+  </Dont>
+</GuidelineTiles>
 
-    ### Item Content
+### Item content
 
-    Consider the width of the Autocomplete and keep the names of the options short and compact so that they fit. Long
-    item
-    names that occupy multiple lines are hard to perceive and should be avoided.
+Consider the width of the Autocomplete and keep the names of the options short and compact so that they fit. Long
+item
+names that occupy multiple lines are hard to perceive and should be avoided.
 
-    <GuidelineTiles>
-      <Do>
-        <Do.Figure>
-          <Image
-            width={700}
-            height={700}
-            unoptimized
-            src="/autocomplete/autocomplete-do-content.jpg"
-            alt="Keep the description of the options as short as possible to improve readability."
-          />
-        </Do.Figure>
-        <Do.Description>
-          Keep the description of the options as short as possible to improve readability.
-        </Do.Description>
-      </Do>
-      <Dont>
-        <Dont.Figure>
-          <Image
-            width={700}
-            height={700}
-            unoptimized
-            src="/autocomplete/autocomplete-dont-content.jpg"
-            alt="Avoid using lengthy option descriptions because the text can get truncated and users will find it difficult to read."
-          />
-        </Dont.Figure>
-        <Dont.Description>
-          Avoid using lengthy option descriptions because the text can get truncated and users will find it difficult to
-          read.
-        </Dont.Description>
-      </Dont>
-    </GuidelineTiles>
+<GuidelineTiles>
+  <Do>
+    <Do.Figure>
+      <Image
+        width={700}
+        height={700}
+        unoptimized
+        src="/autocomplete/autocomplete-do-content.jpg"
+        alt="Keep the description of the options as short as possible to improve readability."
+      />
+    </Do.Figure>
+    <Do.Description>
+      Keep the description of the options as short as possible to improve
+      readability.
+    </Do.Description>
+  </Do>
+  <Dont>
+    <Dont.Figure>
+      <Image
+        width={700}
+        height={700}
+        unoptimized
+        src="/autocomplete/autocomplete-dont-content.jpg"
+        alt="Avoid using lengthy option descriptions because the text can get truncated and users will find it difficult to read."
+      />
+    </Dont.Figure>
+    <Dont.Description>
+      Avoid using lengthy option descriptions because the text can get truncated
+      and users will find it difficult to read.
+    </Dont.Description>
+  </Dont>
+</GuidelineTiles>
 
-    ## Props
-    <StorybookHintMessage component={title} />
+### With sections
+
+When related options are present, organizing them into sections enhances clarity and usability. Grouping options provides additional context and helps users navigate choices more easily. This approach reduces complexity and allows for additional guidance when needed, ensuring a more intuitive experience.
+
+This can be achieved by wrapping the options in the `<Autocomplete.Section>` component. A header is required for each section, which is set using the `header` prop.
+
+<ComponentDemo file="./autocomplete-section.demo.tsx" />
+
+## Props
+
+<StorybookHintMessage component={title} />
 
 ### Autocomplete
 
 <PropsTable component={title} />
 
-### Autocomplete.Item
+### Autocomplete.Option
 
 <PropsTable component="ListBoxItem" />
 
-    ## Alternative components
+### Autocomplete.Section
 
-    <ul>
-      <li>
-        [Combobox](/components/form/combobox): A text field that allows the user to
-        select values from a provided items array. Useful when there are mote than
-        15 options.
-      </li>
-      <li>
-        [Radio](/components/form/radio): Component which allows to select only one
-        option from a list. Use it if you have less than 5 options.
-      </li>
-      <li>
-        [Select](/components/form/select): A component with which you can choose exactly one option from a list with
-        predefined options.
-      </li>
-    </ul>
+<PropsTable component="ListBoxSection" />
 
-    ## Related
+## Alternative components
 
-    <TeaserList
-      items={[
-        {
-          title: 'Building forms',
-          href: '../../patterns/building-forms',
-          caption: 'Learn how to build forms.',
-          icon: (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width={24}
-              height={24}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M12 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
-              <path d="M18.375 2.625a2.121 2.121 0 113 3L12 15l-4 1 1-4z" />
-            </svg>
-          ),
-        },
-      ]}
-    />
+<ul>
+  <li>
+    [Combobox](/components/form/combobox): A text field that allows the user to
+    select values from a provided items array. Useful when there are mote than
+    15 options.
+  </li>
+  <li>
+    [Radio](/components/form/radio): Component which allows to select only one
+    option from a list. Use it if you have less than 5 options.
+  </li>
+  <li>
+    [Select](/components/form/select): A component with which you can choose
+    exactly one option from a list with predefined options.
+  </li>
+</ul>
+
+## Related
+
+<TeaserList
+  items={[
+    {
+      title: 'Building forms',
+      href: '../../patterns/building-forms',
+      caption: 'Learn how to build forms.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={24}
+          height={24}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+          <path d="M18.375 2.625a2.121 2.121 0 113 3L12 15l-4 1 1-4z" />
+        </svg>
+      ),
+    },
+  ]}
+/>

--- a/docs/content/components/form/combobox/combobox-appearance.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-appearance.demo.tsx
@@ -1,7 +1,7 @@
 import { ComboBox } from '@marigold/components';
 
 export default () => (
-  <ComboBox defaultSelectedKey={'dog'} label="Animals">
+  <ComboBox defaultSelectedKey={'dog'} label="Animals" width="fit">
     <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
     <ComboBox.Option id="cat">Cat</ComboBox.Option>
     <ComboBox.Option id="dog">Dog</ComboBox.Option>

--- a/docs/content/components/form/combobox/combobox-async.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-async.demo.tsx
@@ -22,7 +22,7 @@ export default () => {
       items={list.items}
     >
       {(item: { name: string }) => (
-        <ComboBox.Item id={item.name}>{item.name}</ComboBox.Item>
+        <ComboBox.Option id={item.name}>{item.name}</ComboBox.Option>
       )}
     </ComboBox>
   );

--- a/docs/content/components/form/combobox/combobox-basic.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-basic.demo.tsx
@@ -2,13 +2,13 @@ import { ComboBox } from '@marigold/components';
 
 export default () => (
   <ComboBox defaultSelectedKey={'dog'} label="Animals">
-    <ComboBox.Item id="red panda">Red Panda</ComboBox.Item>
-    <ComboBox.Item id="cat">Cat</ComboBox.Item>
-    <ComboBox.Item id="dog">Dog</ComboBox.Item>
-    <ComboBox.Item id="aardvark">Aardvark</ComboBox.Item>
-    <ComboBox.Item id="kangaroo">Kangaroo</ComboBox.Item>
-    <ComboBox.Item id="snake">Snake</ComboBox.Item>
-    <ComboBox.Item id="vegan">Vegan</ComboBox.Item>
-    <ComboBox.Item id="mar">Margrita</ComboBox.Item>
+    <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+    <ComboBox.Option id="cat">Cat</ComboBox.Option>
+    <ComboBox.Option id="dog">Dog</ComboBox.Option>
+    <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+    <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+    <ComboBox.Option id="snake">Snake</ComboBox.Option>
+    <ComboBox.Option id="vegan">Vegan</ComboBox.Option>
+    <ComboBox.Option id="mar">Margrita</ComboBox.Option>
   </ComboBox>
 );

--- a/docs/content/components/form/combobox/combobox-controlled.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-controlled.demo.tsx
@@ -11,11 +11,11 @@ export default () => {
         defaultSelectedKey={3}
         label="Animals"
       >
-        <ComboBox.Item id="red panda">Red Panda</ComboBox.Item>
-        <ComboBox.Item id="cat">Cat</ComboBox.Item>
-        <ComboBox.Item id="dog">Dog</ComboBox.Item>
-        <ComboBox.Item id="aardvark">Aardvark</ComboBox.Item>
-        <ComboBox.Item id="kangaroo">Kangaroo</ComboBox.Item>
+        <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+        <ComboBox.Option id="cat">Cat</ComboBox.Option>
+        <ComboBox.Option id="dog">Dog</ComboBox.Option>
+        <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+        <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
       </ComboBox>
       <Text weight="black">currentValue: "{currentValue}"</Text>
     </Stack>

--- a/docs/content/components/form/combobox/combobox-menu-trigger.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-menu-trigger.demo.tsx
@@ -2,13 +2,13 @@ import { ComboBox } from '@marigold/components';
 
 export default () => (
   <ComboBox label="Animals" menuTrigger="focus">
-    <ComboBox.Item id="red panda">Red Panda</ComboBox.Item>
-    <ComboBox.Item id="cat">Cat</ComboBox.Item>
-    <ComboBox.Item id="dog">Dog</ComboBox.Item>
-    <ComboBox.Item id="aardvark">Aardvark</ComboBox.Item>
-    <ComboBox.Item id="kangaroo">Kangaroo</ComboBox.Item>
-    <ComboBox.Item id="snake">Snake</ComboBox.Item>
-    <ComboBox.Item id="vegan">Vegan</ComboBox.Item>
-    <ComboBox.Item id="mar">Margrita</ComboBox.Item>
+    <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+    <ComboBox.Option id="cat">Cat</ComboBox.Option>
+    <ComboBox.Option id="dog">Dog</ComboBox.Option>
+    <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+    <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+    <ComboBox.Option id="snake">Snake</ComboBox.Option>
+    <ComboBox.Option id="vegan">Vegan</ComboBox.Option>
+    <ComboBox.Option id="mar">Margrita</ComboBox.Option>
   </ComboBox>
 );

--- a/docs/content/components/form/combobox/combobox-section.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-section.demo.tsx
@@ -1,0 +1,78 @@
+import { ComboBox } from '@marigold/components';
+
+export default () => (
+  <ComboBox label="Genres" width="fit">
+    {options.map(item => (
+      <ComboBox.Section key={item.category} header={item.category}>
+        {item.genres.map(genre => (
+          <ComboBox.Option key={genre}>{genre}</ComboBox.Option>
+        ))}
+      </ComboBox.Section>
+    ))}
+  </ComboBox>
+);
+
+const options = [
+  {
+    category: 'Pop and Dance',
+    genres: [
+      'Pop',
+      'Synth-pop',
+      'Electropop',
+      'Dance-pop',
+      'Teen pop',
+      'Disco',
+    ],
+  },
+  {
+    category: 'Rock and Alternative',
+    genres: [
+      'Rock',
+      'Hard rock',
+      'Punk rock',
+      'Alternative rock',
+      'Indie rock',
+      'Grunge',
+      'Psychedelic rock',
+    ],
+  },
+  {
+    category: 'Hip-Hop and R&B',
+    genres: ['Hip-Hop', 'Rap', 'Trap', 'R&B', 'Neo-soul'],
+  },
+  {
+    category: 'Electronic and Experimental',
+    genres: ['EDM', 'House', 'Techno', 'Dubstep', 'Ambient', 'Industrial'],
+  },
+  {
+    category: 'Jazz and Blues',
+    genres: [
+      'Jazz',
+      'Smooth jazz',
+      'Bebop',
+      'Blues',
+      'Delta blues',
+      'Chicago blues',
+    ],
+  },
+  {
+    category: 'Classical and Orchestral',
+    genres: ['Classical', 'Baroque', 'Opera', 'Symphony', 'Chamber music'],
+  },
+  {
+    category: 'Folk and Country',
+    genres: ['Folk', 'Country', 'Bluegrass', 'Americana'],
+  },
+  {
+    category: 'Latin and World',
+    genres: ['Reggaeton', 'Salsa', 'Bossa Nova', 'Flamenco', 'Afrobeats'],
+  },
+  {
+    category: 'Metal and Hard Music',
+    genres: ['Heavy metal', 'Thrash metal', 'Death metal', 'Doom metal'],
+  },
+  {
+    category: 'Reggae and Caribbean',
+    genres: ['Reggae', 'Ska', 'Dancehall', 'Soca'],
+  },
+];

--- a/docs/content/components/form/combobox/combobox.mdx
+++ b/docs/content/components/form/combobox/combobox.mdx
@@ -1,33 +1,20 @@
 ---
 title: ComboBox
 caption: A text-field that allows the user to select values from a provided items array.
+badge: updated
 ---
 
 The `<ComboBox>` component combines a text input with a listbox, allowing users to filter a list of options to items matching a query or adding a new value.
 
 Its purpose is to make interaction with software more intuitive by presenting options in a concise, readable manner instead of requiring users to remember cryptic commands or navigate through complex hierarchies
 
-## Import
-
-```tsx
-import { ComboBox } from '@marigold/components';
-```
-
 ## Appearance
+
+<AppearanceDemo component={title} />
 
 <AppearanceTable component={title} />
 
-## Props
-
-### ComboBox
-
-<PropsTable component={title} />
-
-### ComboBox.Item
-
-<PropsTable component="ListBoxItem" />
-
-## Examples
+## Usage
 
 ### Controlled Usage with custom Filter
 
@@ -36,6 +23,14 @@ If you want to listen or act while the user is typing into the `ComboBox` field,
 This is especially helpful if you need to customize the filtering. For example, you may only want to show suggestions when the user has typed at least two characters. Furthermore, you can improve the matching, as shown in the example below. In the demo, the user would not receive a suggestion if they typed "ssp" without the custom filter.
 
 <ComponentDemo file="./combobox-controlled.demo.tsx" />
+
+### With sections
+
+When related options are present, organizing them into sections enhances clarity and usability. Grouping options provides additional context and helps users navigate choices more easily. This approach reduces complexity and allows for additional guidance when needed, ensuring a more intuitive experience.
+
+This can be achieved by wrapping the options in the `<ComboBox.Section>` component. A header is required for each section, which is set using the `header` prop.
+
+<ComponentDemo file="./combobox-section.demo.tsx" />
 
 ### Working with asynchronous Data
 
@@ -54,3 +49,17 @@ Opening the suggestion popover can be triggered through various interactions. Th
 The below examples will display the suggestions when the input field is focused.
 
 <ComponentDemo file="./combobox-menu-trigger.demo.tsx" />
+
+## Props
+
+### ComboBox
+
+<PropsTable component={title} />
+
+### ComboBox.Option
+
+<PropsTable component="ListBoxItem" />
+
+### ComboBox.Section
+
+<PropsTable component="ListBoxSection" />

--- a/docs/content/components/form/select/select-section.demo.tsx
+++ b/docs/content/components/form/select/select-section.demo.tsx
@@ -1,38 +1,34 @@
-import { Header, Select } from '@marigold/components';
+import { Select } from '@marigold/components';
 
-export default () => {
-  const items = [
-    { category: 'Comedy', genres: ['Kabarett', 'Satire', 'Stand Up Comedy'] },
-    {
-      category: 'Classic',
-      genres: ['Chor', 'Kammermusik', 'Kantate', 'Klavierkonzert'],
-    },
-    {
-      category: 'Hardcore',
-      genres: [
-        'Hardcore Punk',
-        'Jazzcore',
-        'Mathcore',
-        'Melodic Hardcore',
-        'Metalcore',
-      ],
-    },
-    {
-      category: 'Metal',
-      genres: ['Black Metal', 'Death Metal', 'Heavy Metal', 'Nu Metal'],
-    },
-  ];
+export default () => (
+  <Select label="Genres" width="fit">
+    {options.map(item => (
+      <Select.Section key={item.category} header={item.category}>
+        {item.genres.map(genre => (
+          <Select.Option key={genre}>{genre}</Select.Option>
+        ))}
+      </Select.Section>
+    ))}
+  </Select>
+);
 
-  return (
-    <Select label="Genres" items={items} width="fit">
-      {items.map(item => (
-        <Select.Section key={item.category}>
-          <Header>{item.category}</Header>
-          {item.genres.map(genre => (
-            <Select.Option key={genre}>{genre}</Select.Option>
-          ))}
-        </Select.Section>
-      ))}
-    </Select>
-  );
-};
+const options = [
+  {
+    category: 'Pop and Dance',
+    genres: ['Pop', 'Electropop', 'Dance-pop', 'Teen pop', 'Disco'],
+  },
+  {
+    category: 'Rock and Alternative',
+    genres: [
+      'Hard rock',
+      'Punk rock',
+      'Alternative rock',
+      'Indie rock',
+      'Grunge',
+    ],
+  },
+  {
+    category: 'Hip-Hop and R&B',
+    genres: ['Hip-Hop', 'Rap', 'Trap', 'R&B'],
+  },
+];

--- a/docs/content/components/form/select/select.mdx
+++ b/docs/content/components/form/select/select.mdx
@@ -71,9 +71,11 @@ When there are too many options (e.g., more than 15-20), usability can suffer. U
   </Dont>
 </GuidelineTiles>
 
-### Select with sections
+### With sections
 
-Use sections when it is helpful to group different options from each other, this can be for example to categorize related options together. For that you habe to use the `<Select.Section>` component. A clear line appears to separate different options, and you can set the title of `<Select.Section>` by using `<Header>` component inside `<Select.Section>`.
+When related options are present, organizing them into sections enhances clarity and usability. Grouping options provides additional context and helps users navigate choices more easily. This approach reduces complexity and allows for additional guidance when needed, ensuring a more intuitive experience.
+
+This can be achieved by wrapping the options in the `<Select.Section>` component. A header is required for each section, which is set using the `header` prop.
 
 <ComponentDemo file="./select-section.demo.tsx" />
 
@@ -99,13 +101,13 @@ Keep in mind that you always should write information why a certain option is di
 
 <PropsTable component={title} />
 
-### Select.Section
-
-<PropsTable component="ListBoxSection" />
-
 ### Select.Option
 
 <PropsTable component="ListBoxItem" />
+
+### Select.Section
+
+<PropsTable component="ListBoxSection" />
 
 ## Alternative components
 

--- a/docs/content/recipes/multiselect-recipes/multiselect-basic.demo.tsx
+++ b/docs/content/recipes/multiselect-recipes/multiselect-basic.demo.tsx
@@ -85,9 +85,9 @@ const Multiselect = ({ label, children, ...props }: MultiSelectProps) => {
         {...props}
       >
         {unselected.map((item: MultiSelectItemProps) => (
-          <ComboBox.Item key={item.id} id={item.id}>
+          <ComboBox.Option key={item.id} id={item.id}>
             {item.children}
-          </ComboBox.Item>
+          </ComboBox.Option>
         ))}
       </ComboBox>
     </div>

--- a/packages/components/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.tsx
@@ -75,16 +75,16 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
   render: args => (
     <Autocomplete placeholder="Movie" {...args}>
-      <Autocomplete.Item id="Harry Potter" textValue="Harry Potter">
+      <Autocomplete.Option id="Harry Potter" textValue="Harry Potter">
         <Text slot="label">Harry Potter</Text>
         <Text slot="description">best series ever</Text>
-      </Autocomplete.Item>
-      <Autocomplete.Item id="Lord of the Rings">
+      </Autocomplete.Option>
+      <Autocomplete.Option id="Lord of the Rings">
         Lord of the Rings
-      </Autocomplete.Item>
-      <Autocomplete.Item id="Star Wars">Star Wars</Autocomplete.Item>
-      <Autocomplete.Item id="Star Trek">Star Trek</Autocomplete.Item>
-      <Autocomplete.Item id="Firefly">Firefly</Autocomplete.Item>
+      </Autocomplete.Option>
+      <Autocomplete.Option id="Star Wars">Star Wars</Autocomplete.Option>
+      <Autocomplete.Option id="Star Trek">Star Trek</Autocomplete.Option>
+      <Autocomplete.Option id="Firefly">Firefly</Autocomplete.Option>
     </Autocomplete>
   ),
 };
@@ -107,22 +107,22 @@ export const Controlled: Story = {
             onSubmit={(key, val) => setSubmitted([key, val])}
             disabledKeys={['star-trek']}
           >
-            <Autocomplete.Item id="harry-potter" textValue="Harry Potter">
+            <Autocomplete.Option id="harry-potter" textValue="Harry Potter">
               Harry Potter
-            </Autocomplete.Item>
-            <Autocomplete.Item
+            </Autocomplete.Option>
+            <Autocomplete.Option
               id="lord-of-the-rings"
               textValue="Lord of the Rings"
             >
               Lord of the Rings
-            </Autocomplete.Item>
-            <Autocomplete.Item id="star-wars" textValue="Star Wars">
+            </Autocomplete.Option>
+            <Autocomplete.Option id="star-wars" textValue="Star Wars">
               Star Wars
-            </Autocomplete.Item>
-            <Autocomplete.Item id="star-trek" textValue="Star Trek">
+            </Autocomplete.Option>
+            <Autocomplete.Option id="star-trek" textValue="Star Trek">
               Star Trek
-            </Autocomplete.Item>
-            <Autocomplete.Item id="firefly">Firefly</Autocomplete.Item>
+            </Autocomplete.Option>
+            <Autocomplete.Option id="firefly">Firefly</Autocomplete.Option>
           </Autocomplete>
           <pre>current: {current}</pre>
           <pre>
@@ -159,7 +159,7 @@ export const Async: Story = {
         {...args}
       >
         {(item: any) => (
-          <Autocomplete.Item id={item.name}>{item.name}</Autocomplete.Item>
+          <Autocomplete.Option id={item.name}>{item.name}</Autocomplete.Option>
         )}
       </Autocomplete>
     );

--- a/packages/components/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.tsx
@@ -89,6 +89,28 @@ export const Basic: Story = {
   ),
 };
 
+export const WithSections: Story = {
+  render: args => (
+    <Autocomplete placeholder="Pick a food" {...args}>
+      <Autocomplete.Section header="Veggies">
+        <Autocomplete.Option id="lettuce">Lettuce</Autocomplete.Option>
+        <Autocomplete.Option id="tomato">Tomato</Autocomplete.Option>
+        <Autocomplete.Option id="onion">Onion</Autocomplete.Option>
+      </Autocomplete.Section>
+      <Autocomplete.Section header="Protein">
+        <Autocomplete.Option id="ham">Ham</Autocomplete.Option>
+        <Autocomplete.Option id="tuna">Tuna</Autocomplete.Option>
+        <Autocomplete.Option id="tofu">Tofu</Autocomplete.Option>
+      </Autocomplete.Section>
+      <Autocomplete.Section header="Condiments">
+        <Autocomplete.Option id="mayo">Mayonaise</Autocomplete.Option>
+        <Autocomplete.Option id="mustard">Mustard</Autocomplete.Option>
+        <Autocomplete.Option id="ranch">Ranch</Autocomplete.Option>
+      </Autocomplete.Section>
+    </Autocomplete>
+  ),
+};
+
 export const Controlled: Story = {
   render: args => {
     const [submitted, setSubmitted] = useState<

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -85,10 +85,10 @@ afterEach(cleanup);
 test('renders an input', () => {
   render(
     <Autocomplete label="vegetables">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -101,10 +101,10 @@ test('renders an input', () => {
 test('renders a label', () => {
   render(
     <Autocomplete label="Label">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -116,8 +116,8 @@ test('renders a label', () => {
 test('supports disabled', () => {
   render(
     <Autocomplete label="Label" disabled>
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -128,8 +128,8 @@ test('supports disabled', () => {
 test('supports required', () => {
   render(
     <Autocomplete label="Label" required>
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -140,8 +140,8 @@ test('supports required', () => {
 test('supports readonly', () => {
   render(
     <Autocomplete label="Label" readOnly>
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -156,8 +156,8 @@ test('uses field structure', () => {
       description="Some helpful text"
       errorMessage="Whoopsie"
     >
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -174,10 +174,10 @@ test('uses field structure', () => {
 test('opens the suggestions on user input', async () => {
   render(
     <Autocomplete label="Label">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -191,10 +191,10 @@ test('opens the suggestions on user input', async () => {
 test('opens the suggestions on focus', async () => {
   render(
     <Autocomplete label="Label" menuTrigger="focus">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -208,10 +208,10 @@ test('opens the suggestions on focus', async () => {
 test('opens the suggestions on arrow down (manual)', async () => {
   render(
     <Autocomplete label="Label" menuTrigger="manual">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -225,10 +225,10 @@ test('opens the suggestions on arrow down (manual)', async () => {
 test('shows suggestions based on user input', async () => {
   render(
     <Autocomplete label="Label">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -245,10 +245,10 @@ test('shows suggestions based on user input', async () => {
 test('supports disabling suggestions', async () => {
   render(
     <Autocomplete label="Label" disabledKeys={['spinach']}>
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -262,10 +262,10 @@ test('supports disabling suggestions', async () => {
 test('supporst showing a help text', () => {
   render(
     <Autocomplete label="Label" description="This is a description">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -275,10 +275,10 @@ test('supporst showing a help text', () => {
 test('supporst showing an error', () => {
   render(
     <Autocomplete label="Label" error errorMessage="Error!">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -288,10 +288,10 @@ test('supporst showing an error', () => {
 test('supports default value', () => {
   render(
     <Autocomplete label="Label" defaultValue="garlic">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -304,10 +304,10 @@ test('can be controlled', async () => {
     return (
       <>
         <Autocomplete label="Label" value={value} onChange={setValue}>
-          <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-          <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-          <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-          <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+          <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+          <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+          <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+          <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
         </Autocomplete>
         <span data-testid="output">{value}</span>
       </>
@@ -325,10 +325,10 @@ test('can be controlled', async () => {
 test('supports autocompletion', async () => {
   render(
     <Autocomplete label="Label">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -344,10 +344,10 @@ test('supports autocompletion', async () => {
 test('supports clear input value', async () => {
   render(
     <Autocomplete label="Label">
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 
@@ -365,10 +365,10 @@ test('supports submit handler', async () => {
 
   render(
     <Autocomplete label="Label" onSubmit={spy}>
-      <Autocomplete.Item id="spinach">Spinach</Autocomplete.Item>
-      <Autocomplete.Item id="carrots">Carrots</Autocomplete.Item>
-      <Autocomplete.Item id="broccoli">Broccoli</Autocomplete.Item>
-      <Autocomplete.Item id="garlic">Garlic</Autocomplete.Item>
+      <Autocomplete.Option id="spinach">Spinach</Autocomplete.Option>
+      <Autocomplete.Option id="carrots">Carrots</Autocomplete.Option>
+      <Autocomplete.Option id="broccoli">Broccoli</Autocomplete.Option>
+      <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   );
 

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -58,7 +58,7 @@ const theme: Theme = {
       list: cva(),
       option: cva(),
       section: cva(),
-      sectionTitle: cva(),
+      header: cva(),
     },
     Button: cva(),
   },

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -259,6 +259,30 @@ test('supports disabling suggestions', async () => {
   expect(spinach).toHaveAttribute('aria-disabled', 'true');
 });
 
+test('supports sections', async () => {
+  render(
+    <Autocomplete label="Label" data-testid="Autocomplete">
+      <Autocomplete.Section header="Section 1">
+        <Autocomplete.Option id="one">one</Autocomplete.Option>
+        <Autocomplete.Option id="two">two</Autocomplete.Option>
+      </Autocomplete.Section>
+      <Autocomplete.Section header="Section 2">
+        <Autocomplete.Option id="three">three</Autocomplete.Option>
+        <Autocomplete.Option id="four">four</Autocomplete.Option>
+      </Autocomplete.Section>
+    </Autocomplete>
+  );
+
+  const input = screen.getAllByLabelText('Label')[0];
+  await user.type(input, 'o');
+
+  const s1 = await screen.findByText('Section 1');
+  const s2 = await screen.findByText('Section 2');
+
+  expect(s1).toBeVisible();
+  expect(s2).toBeVisible();
+});
+
 test('supporst showing a help text', () => {
   render(
     <Autocomplete label="Label" description="This is a description">

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -163,7 +163,15 @@ interface AutocompleteComponent
   extends ForwardRefExoticComponent<
     AutocompleteProps & RefAttributes<HTMLInputElement>
   > {
+  /**
+   * Options for the Combobox.
+   */
   Option: typeof ListBox.Item;
+
+  /**
+   * Section for the Combobox, to put options in.
+   */
+  Section: typeof ListBox.Section;
 }
 
 // Component
@@ -210,5 +218,6 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
 ) as AutocompleteComponent;
 
 _Autocomplete.Option = ListBox.Item;
+_Autocomplete.Section = ListBox.Section;
 
 export { _Autocomplete as Autocomplete };

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -163,7 +163,7 @@ interface AutocompleteComponent
   extends ForwardRefExoticComponent<
     AutocompleteProps & RefAttributes<HTMLInputElement>
   > {
-  Item: typeof ListBox.Item;
+  Option: typeof ListBox.Item;
 }
 
 // Component
@@ -209,6 +209,6 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
   }
 ) as AutocompleteComponent;
 
-_Autocomplete.Item = ListBox.Item;
+_Autocomplete.Option = ListBox.Item;
 
 export { _Autocomplete as Autocomplete };

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -109,14 +109,14 @@ export const Basic: StoryObj<typeof ComboBox> = {
   render: args => {
     return (
       <ComboBox label="Animals" disabledKeys={['snake']} {...args}>
-        <ComboBox.Item id="red panda">Red Panda</ComboBox.Item>
-        <ComboBox.Item id="cat">Cat</ComboBox.Item>
-        <ComboBox.Item id="dog">Dog</ComboBox.Item>
-        <ComboBox.Item id="aardvark">Aardvark</ComboBox.Item>
-        <ComboBox.Item id="kangaroo">Kangaroo</ComboBox.Item>
-        <ComboBox.Item id="snake">Snake</ComboBox.Item>
-        <ComboBox.Item id="vegan">Vegan</ComboBox.Item>
-        <ComboBox.Item id="mar">Margrita</ComboBox.Item>
+        <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+        <ComboBox.Option id="cat">Cat</ComboBox.Option>
+        <ComboBox.Option id="dog">Dog</ComboBox.Option>
+        <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+        <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+        <ComboBox.Option id="snake">Snake</ComboBox.Option>
+        <ComboBox.Option id="vegan">Vegan</ComboBox.Option>
+        <ComboBox.Option id="mar">Margrita</ComboBox.Option>
       </ComboBox>
     );
   },
@@ -136,11 +136,11 @@ export const Controlled: StoryObj<typeof ComboBox> = {
           label="Animals"
           {...args}
         >
-          <ComboBox.Item id="red panda">Red Panda</ComboBox.Item>
-          <ComboBox.Item id="cat">Cat</ComboBox.Item>
-          <ComboBox.Item id="dog">Dog</ComboBox.Item>
-          <ComboBox.Item id="aardvark">Aardvark</ComboBox.Item>
-          <ComboBox.Item id="kangaroo">Kangaroo</ComboBox.Item>
+          <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+          <ComboBox.Option id="cat">Cat</ComboBox.Option>
+          <ComboBox.Option id="dog">Dog</ComboBox.Option>
+          <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+          <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
         </ComboBox>
         <pre>
           current: {current}, selected: {id?.toString()}
@@ -174,9 +174,9 @@ export const AsyncLoading: StoryObj<typeof ComboBox> = {
         {...args}
       >
         {(item: { name: string }) => (
-          <ComboBox.Item key={item.name} id={item.name}>
+          <ComboBox.Option key={item.name} id={item.name}>
             {item.name}
-          </ComboBox.Item>
+          </ComboBox.Option>
         )}
       </ComboBox>
     );

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { Key, useState } from 'react';
 import { useAsyncList } from '@react-stately/data';
 import { Stack } from '../Stack';
+import { Text } from '../Text';
 import { ComboBox } from './ComboBox';
 
 const meta = {
@@ -99,7 +100,7 @@ const meta = {
     width: 'full',
     menuTrigger: 'input',
     placeholder: undefined,
-    label: '',
+    label: 'Label',
   },
 } satisfies Meta;
 
@@ -181,4 +182,33 @@ export const AsyncLoading: StoryObj<typeof ComboBox> = {
       </ComboBox>
     );
   },
+};
+
+export const Sections: StoryObj<typeof ComboBox> = {
+  render: args => (
+    <ComboBox {...args}>
+      <ComboBox.Section header="Fantasy">
+        <ComboBox.Option id="harry-potter" textValue="Harry Potter">
+          <Text slot="label">Harry Potter</Text>
+          <Text slot="description">About the boy who lived</Text>
+        </ComboBox.Option>
+        <ComboBox.Option id="lord-of-the-rings" textValue="Lord of the Rings">
+          <Text slot="label">Lord of the Rings</Text>
+          <Text slot="description">In the lands of Middle earth</Text>
+        </ComboBox.Option>
+      </ComboBox.Section>
+      <ComboBox.Section header="Sci-Fi">
+        <ComboBox.Option id="star-wars" textValue="Start Wars">
+          <Text slot="label">Start Wars</Text>
+          <Text slot="description">
+            A long time ago, in a galaxy far, far away
+          </Text>
+        </ComboBox.Option>
+        <ComboBox.Option id="star-trek" textValue="Star Trek">
+          <Text slot="label">Star Trek</Text>
+          <Text slot="description">What is this</Text>
+        </ComboBox.Option>
+      </ComboBox.Section>
+    </ComboBox>
+  ),
 };

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Theme, cva } from '@marigold/system';
@@ -331,6 +331,30 @@ test('supports default value', () => {
 
   const textField = screen.getAllByLabelText('Label')[0];
   expect(textField).toHaveValue('garlic');
+});
+
+test('supports sections', async () => {
+  render(
+    <ComboBox label="Label" data-testid="ComboBox">
+      <ComboBox.Section header="Section 1">
+        <ComboBox.Option id="one">one</ComboBox.Option>
+        <ComboBox.Option id="two">two</ComboBox.Option>
+      </ComboBox.Section>
+      <ComboBox.Section header="Section 2">
+        <ComboBox.Option id="three">three</ComboBox.Option>
+        <ComboBox.Option id="four">four</ComboBox.Option>
+      </ComboBox.Section>
+    </ComboBox>
+  );
+
+  const input = screen.getAllByLabelText('Label')[0];
+  await user.type(input, 'o');
+
+  const s1 = await screen.findByText('Section 1');
+  const s2 = await screen.findByText('Section 2');
+
+  expect(s1).toBeVisible();
+  expect(s2).toBeVisible();
 });
 
 test('can be controlled', async () => {

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Theme, cva } from '@marigold/system';

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -86,10 +86,10 @@ const { render } = setup({ theme });
 test('renders an input', () => {
   render(
     <ComboBox label="Label">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -102,10 +102,10 @@ test('renders an input', () => {
 test('supports width classname', () => {
   render(
     <ComboBox label="Label" data-testid="input-field">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -122,10 +122,10 @@ test('supports classnames', () => {
       variant="one"
       size="small"
     >
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -145,8 +145,8 @@ test('supports classnames', () => {
 test('supports disabled', () => {
   render(
     <ComboBox label="Label" disabled>
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
     </ComboBox>
   );
 
@@ -157,8 +157,8 @@ test('supports disabled', () => {
 test('supports required', () => {
   render(
     <ComboBox label="Label" required>
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
     </ComboBox>
   );
 
@@ -169,8 +169,8 @@ test('supports required', () => {
 test('supports readonly', () => {
   render(
     <ComboBox label="Label" readOnly>
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
     </ComboBox>
   );
 
@@ -185,8 +185,8 @@ test('uses field structure', () => {
       description="Some helpful text"
       errorMessage="Whoopsie"
     >
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
     </ComboBox>
   );
 
@@ -203,10 +203,10 @@ test('uses field structure', () => {
 test('opens the suggestions on user input', async () => {
   render(
     <ComboBox label="Label">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -220,10 +220,10 @@ test('opens the suggestions on user input', async () => {
 test('opens the suggestions on focus', async () => {
   render(
     <ComboBox label="Label" menuTrigger="focus">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -237,10 +237,10 @@ test('opens the suggestions on focus', async () => {
 test('opens the suggestions on arrow down (manual)', async () => {
   render(
     <ComboBox label="Label" menuTrigger="manual">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -254,10 +254,10 @@ test('opens the suggestions on arrow down (manual)', async () => {
 test('shows suggestions based on user input', async () => {
   render(
     <ComboBox label="Label">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -274,10 +274,10 @@ test('shows suggestions based on user input', async () => {
 test('supports disabling suggestions', async () => {
   render(
     <ComboBox label="Label" disabledKeys={['spinach']}>
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -291,10 +291,10 @@ test('supports disabling suggestions', async () => {
 test('supporst showing a help text', () => {
   render(
     <ComboBox label="Label" description="This is a description">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -309,10 +309,10 @@ test('supporst showing an error', () => {
       error
       errorMessage="Error!"
     >
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -322,10 +322,10 @@ test('supporst showing an error', () => {
 test('supports default value', () => {
   render(
     <ComboBox label="Label" defaultValue="garlic">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 
@@ -339,10 +339,10 @@ test('can be controlled', async () => {
     return (
       <>
         <ComboBox label="Label" value={value} onChange={setValue}>
-          <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-          <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-          <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-          <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+          <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+          <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+          <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+          <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
         </ComboBox>
         <span data-testid="output">{value}</span>
       </>
@@ -360,10 +360,10 @@ test('can be controlled', async () => {
 test('supports autocompletion', async () => {
   render(
     <ComboBox label="Label">
-      <ComboBox.Item id="spinach">Spinach</ComboBox.Item>
-      <ComboBox.Item id="carrots">Carrots</ComboBox.Item>
-      <ComboBox.Item id="broccoli">Broccoli</ComboBox.Item>
-      <ComboBox.Item id="garlic">Garlic</ComboBox.Item>
+      <ComboBox.Option id="spinach">Spinach</ComboBox.Option>
+      <ComboBox.Option id="carrots">Carrots</ComboBox.Option>
+      <ComboBox.Option id="broccoli">Broccoli</ComboBox.Option>
+      <ComboBox.Option id="garlic">Garlic</ComboBox.Option>
     </ComboBox>
   );
 

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -46,7 +46,7 @@ const theme: Theme = {
       list: cva(),
       option: cva(),
       section: cva(),
-      sectionTitle: cva(),
+      header: cva(),
     },
     Popover: cva(['mt-0.5'], {
       variants: {

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -91,7 +91,15 @@ interface ComboBoxComponent
   extends ForwardRefExoticComponent<
     ComboBoxProps & RefAttributes<HTMLInputElement>
   > {
-  Item: typeof ListBox.Item;
+  /**
+   * Options for the Combobox.
+   */
+  Option: typeof ListBox.Item;
+
+  /**
+   * Section for the Combobox, to put options in.
+   */
+  Section: typeof ListBox.Section;
 }
 
 // Component
@@ -143,6 +151,7 @@ const _ComboBox = forwardRef<HTMLInputElement, ComboBoxProps>(
   }
 ) as ComboBoxComponent;
 
-_ComboBox.Item = ListBox.Item;
+_ComboBox.Option = ListBox.Item;
+_ComboBox.Section = ListBox.Section;
 
 export { _ComboBox as ComboBox };

--- a/packages/components/src/ListBox/ListBox.stories.tsx
+++ b/packages/components/src/ListBox/ListBox.stories.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { Header } from '../Header';
 import { ListBox } from './ListBox';
 
 const meta = {
@@ -31,20 +30,17 @@ export const Basic: Story = {
 export const WithSections: Story = {
   render: args => (
     <ListBox aria-labelledby="listbox" {...args}>
-      <ListBox.Section>
-        <Header>Veggies</Header>
+      <ListBox.Section header="Veggies">
         <ListBox.Item id="lettuce">Lettuce</ListBox.Item>
         <ListBox.Item id="tomato">Tomato</ListBox.Item>
         <ListBox.Item id="onion">Onion</ListBox.Item>
       </ListBox.Section>
-      <ListBox.Section>
-        <Header>Protein</Header>
+      <ListBox.Section header="Protein">
         <ListBox.Item id="ham">Ham</ListBox.Item>
         <ListBox.Item id="tuna">Tuna</ListBox.Item>
         <ListBox.Item id="tofu">Tofu</ListBox.Item>
       </ListBox.Section>
-      <ListBox.Section>
-        <Header>Condiments</Header>
+      <ListBox.Section header="Condiments">
         <ListBox.Item id="mayo">Mayonaise</ListBox.Item>
         <ListBox.Item id="mustard">Mustard</ListBox.Item>
         <ListBox.Item id="ranch">Ranch</ListBox.Item>

--- a/packages/components/src/ListBox/ListBoxSection.tsx
+++ b/packages/components/src/ListBox/ListBoxSection.tsx
@@ -6,7 +6,13 @@ import { useListBoxContext } from './Context';
 
 export interface SectionProps
   extends Omit<RAC.SectionProps<object>, 'className' | 'style' | 'children'> {
+  /**
+   * Section header to display.
+   */
   header: ReactNode;
+  /**
+   * Children of the section.
+   */
   children: ReactNode;
 }
 

--- a/packages/components/src/ListBox/ListBoxSection.tsx
+++ b/packages/components/src/ListBox/ListBoxSection.tsx
@@ -1,18 +1,25 @@
+import type { ReactNode } from 'react';
 import type RAC from 'react-aria-components';
-import { Section } from 'react-aria-components';
+import { Header, Section } from 'react-aria-components';
 import { cn } from '@marigold/system';
 import { useListBoxContext } from './Context';
 
 export interface SectionProps
-  extends Omit<RAC.SectionProps<object>, 'className' | 'style'> {}
+  extends Omit<RAC.SectionProps<object>, 'className' | 'style' | 'children'> {
+  header: ReactNode;
+  children: ReactNode;
+}
 
-const _Section = (props: SectionProps) => {
+const _Section = ({ header, children, ...props }: SectionProps) => {
   const { classNames } = useListBoxContext();
   return (
     <Section
       {...props}
       className={cn(classNames.section, classNames.sectionTitle)}
-    />
+    >
+      <Header>{header}</Header>
+      {children}
+    </Section>
   );
 };
 

--- a/packages/components/src/ListBox/ListBoxSection.tsx
+++ b/packages/components/src/ListBox/ListBoxSection.tsx
@@ -19,10 +19,7 @@ export interface SectionProps
 const _Section = ({ header, children, ...props }: SectionProps) => {
   const { classNames } = useListBoxContext();
   return (
-    <Section
-      {...props}
-      className={cn(classNames.section, classNames.sectionTitle)}
-    >
+    <Section {...props} className={cn(classNames.section, classNames.header)}>
       <Header>{header}</Header>
       {children}
     </Section>

--- a/packages/components/src/Multiselect/Multiselect.tsx
+++ b/packages/components/src/Multiselect/Multiselect.tsx
@@ -111,9 +111,9 @@ export const Multiselect = ({
         {...props}
       >
         {unselected.map((item: MultiSelectItemProps) => (
-          <ComboBox.Item key={item.id} id={item.id}>
+          <ComboBox.Option key={item.id} id={item.id}>
             {item.children}
-          </ComboBox.Item>
+          </ComboBox.Option>
         ))}
       </ComboBox>
     </div>

--- a/packages/components/src/Provider/OverlayContainerProvider.test.tsx
+++ b/packages/components/src/Provider/OverlayContainerProvider.test.tsx
@@ -37,7 +37,7 @@ const theme: Theme = {
       list: cva(),
       option: cva(),
       section: cva(),
-      sectionTitle: cva(),
+      header: cva(),
     },
     Field: cva(),
   },
@@ -62,7 +62,7 @@ test('renders portal container', async () => {
       <OverlayContainerProvider value="testid">
         <MarigoldProvider theme={theme}>
           <Select label="Label" data-testid="select" defaultOpen>
-            <Select.Section>
+            <Select.Section header="section">
               <Select.Option id="one">one</Select.Option>
               <Select.Option id="two">two</Select.Option>
             </Select.Section>

--- a/packages/components/src/SearchField/SearchField.test.tsx
+++ b/packages/components/src/SearchField/SearchField.test.tsx
@@ -44,7 +44,7 @@ const theme: Theme = {
       list: cva(),
       option: cva(),
       section: cva(),
-      sectionTitle: cva(),
+      header: cva(),
     },
   },
 };

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useState } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
-import { Header } from '../Header';
 import { Inset } from '../Inset';
 import { Text } from '../Text';
 import { Select } from './Select';
@@ -188,8 +187,7 @@ export const LotsOfOptions: StoryObj<typeof Select> = {
 export const Sections: StoryObj<typeof Select> = {
   render: args => (
     <Select {...args}>
-      <Select.Section>
-        <Header>Fantasy</Header>
+      <Select.Section header="Fantasy">
         <Select.Option id="harry-potter">
           <Text slot="label">Harry Potter</Text>
           <Text slot="description">About the boy who lived</Text>
@@ -199,8 +197,7 @@ export const Sections: StoryObj<typeof Select> = {
           <Text slot="description">In the lands of Middle earth</Text>
         </Select.Option>
       </Select.Section>
-      <Select.Section>
-        <Header>Sci-Fi</Header>
+      <Select.Section header="Sci-Fi">
         <Select.Option id="star-wars">
           <Text slot="label">Start Wars</Text>
           <Text slot="description">

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -362,7 +362,7 @@ test('supports default value via "defaultSelectedKey"', () => {
   expect(three).toHaveAttribute('aria-selected', 'true');
 });
 
-test('supports sections', () => {
+test('supports sections', async () => {
   render(
     <Select label="Label" data-testid="select">
       <Select.Section header="Section 1">
@@ -377,7 +377,7 @@ test('supports sections', () => {
   );
 
   const button = screen.getByRole('button');
-  fireEvent.click(button);
+  await user.click(button);
 
   const options = screen.getByRole('listbox');
   const sectionOne = within(options).getByText('Section 1');

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -9,7 +9,6 @@ import {
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Theme, cva, useSmallScreen } from '@marigold/system';
-import { Header } from '../Header';
 import { Text } from '../Text';
 import { setup } from '../test.utils';
 import { Select } from './Select';
@@ -68,7 +67,7 @@ const theme: Theme = {
       list: cva(),
       option: cva(),
       section: cva(),
-      sectionTitle: cva(),
+      header: cva(),
     },
   },
 };
@@ -366,13 +365,11 @@ test('supports default value via "defaultSelectedKey"', () => {
 test('supports sections', () => {
   render(
     <Select label="Label" data-testid="select">
-      <Select.Section>
-        <Header>Section 1</Header>
+      <Select.Section header="Section 1">
         <Select.Option id="one">one</Select.Option>
         <Select.Option id="two">two</Select.Option>
       </Select.Section>
-      <Select.Section>
-        <Header>Section 2</Header>
+      <Select.Section header="Section 2">
         <Select.Option id="three">three</Select.Option>
         <Select.Option id="four">four</Select.Option>
       </Select.Section>
@@ -393,8 +390,7 @@ test('supports sections', () => {
 test('supports styling classnames with variants and sizes from theme', () => {
   render(
     <Select label="Label" data-testid="select" variant="violet" size="small">
-      <Select.Section>
-        <Header>Section 1</Header>
+      <Select.Section header="Section 1">
         <Select.Option id="one">one</Select.Option>
         <Select.Option id="two">two</Select.Option>
       </Select.Section>
@@ -410,7 +406,7 @@ test('supports styling classnames with variants and sizes from theme', () => {
 test('supports applying styles to the caret icon', () => {
   render(
     <Select label="Label" data-testid="select">
-      <Select.Section>
+      <Select.Section header="Section 1">
         <Select.Option id="one">one</Select.Option>
         <Select.Option id="two">two</Select.Option>
       </Select.Section>
@@ -442,8 +438,7 @@ test('forwards ref', () => {
   const ref = React.createRef<HTMLButtonElement>();
   render(
     <Select label="Label" data-testid="select" ref={ref as any}>
-      <Select.Section>
-        <Header>Section 1</Header>
+      <Select.Section header="Section 1">
         <Select.Option id="one">one</Select.Option>
         <Select.Option id="two">two</Select.Option>
       </Select.Section>
@@ -469,8 +464,7 @@ test('renders as tray', () => {
 
   render(
     <Select label="Label" data-testid="select" ref={ref as any}>
-      <Select.Section>
-        <Header>Section 1</Header>
+      <Select.Section header="Section 1">
         <Select.Option id="one">one</Select.Option>
         <Select.Option id="two">two</Select.Option>
       </Select.Section>

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -15,7 +15,7 @@ const theme: Theme = {
       list: cva('outline-none'),
       option: cva('p-3 outline-none'),
       section: cva('border outline-none'),
-      sectionTitle: cva('[&_header]:text-text-accent'),
+      header: cva('[&_header]:text-text-accent'),
     },
     Button: cva('bg-green-300'),
     Checkbox: {

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -73,7 +73,7 @@ export type Theme = {
     List?: Record<'ol' | 'ul' | 'item', ComponentStyleFunction<string, string>>;
     Link?: ComponentStyleFunction<string, string>;
     ListBox?: Record<
-      'container' | 'list' | 'option' | 'section' | 'sectionTitle',
+      'container' | 'list' | 'option' | 'section' | 'header',
       ComponentStyleFunction<string, string>
     >;
     Menu?: Record<

--- a/themes/theme-b2b/src/components/ListBox.styles.ts
+++ b/themes/theme-b2b/src/components/ListBox.styles.ts
@@ -26,7 +26,7 @@ export const ListBox: ThemeComponent<'ListBox'> = {
   section: cva(
     '[&:nth-child(n+1)]:border-border-base border outline-none [&:nth-child(n+1)]:border-t [&:nth-child(n+1)]:border-solid'
   ),
-  sectionTitle: cva(
+  header: cva(
     '[&_header]:text-text-accent [&_header]:px-2 [&_header]:pt-2 [&_header]:text-sm'
   ),
 };

--- a/themes/theme-core/src/components/ListBox.styles.ts
+++ b/themes/theme-core/src/components/ListBox.styles.ts
@@ -16,5 +16,5 @@ export const ListBox: ThemeComponent<'ListBox'> = {
     'rac-disabled:text-text-base-disabled aria-disabled:cursor-not-allowed',
   ]),
   section: cva('[&:nth-child(n+2)]:pt-2 [&_div]:px-5'),
-  sectionTitle: cva([font, '[&_header]:px-1.5 [&_header]:font-bold']),
+  header: cva([font, '[&_header]:px-1.5 [&_header]:font-bold']),
 };

--- a/themes/theme-docs/src/components/ListBox.styles.ts
+++ b/themes/theme-docs/src/components/ListBox.styles.ts
@@ -29,5 +29,5 @@ export const ListBox: ThemeComponent<'ListBox'> = {
     }
   ),
   section: cva(),
-  sectionTitle: cva(),
+  header: cva(),
 };


### PR DESCRIPTION
> [!WARNING]  
> This PR contains a breaking change! See below. This should be merged with #4164 

# Description

- Added the possibility to use sections with `Combobox` and `Autocomplete`
- Refactored the `Section` (from `Listbox`) to fit our API, no need for the extra `Header` anymore. Instead you can do `<Select.Section header="My header">`, same for the other components
- Renamed `Item` to `Option` in `Combobox` and `Autocomplete` to align with `Select`
- Updated the docs for `Select`, `Combobox` and `Autocomplete`
- Updated Storybook for `Select`, `Combobox` and `Autocomplete` with section stories

- [x] Requires a change in the UI kit @tirado-rx 

# What should be tested?

Using sections with `Select`, `Combobox` and `Autocomplete`

## Are they some special informations required to test something?

nope.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer

Closes [DSTSUP-89]

[DSTSUP-89]: https://reservix.atlassian.net/browse/DSTSUP-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ