### PR TITLE
feat(components): Expose `Selection` type for easy usage with `Table` and other components

### DIFF
--- a/.changeset/polite-plants-deliver.md
+++ b/.changeset/polite-plants-deliver.md
@@ -1,0 +1,13 @@
+---
+"@marigold/components": patch
+---
+
+feat(components): Expose `Selection` type for easy usage with `Table` and other components
+
+When working with a `<Table>` you can now use 
+
+```ts
+import type { Selection } from '@marigold/components';
+```
+
+instead of creating the type.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export * from './types';
 export * from './hooks';
 
 export * from './Accordion';

--- a/packages/components/src/types.ts
+++ b/packages/components/src/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Re-export type from `react-aria` for DX.
+ */
+
+export type { Selection } from '@react-types/shared';


### PR DESCRIPTION
# Description

When working with a `<Table>` you can now use 

```ts
import type { Selection } from '@marigold/components';
```

instead of creating the type.

# What should be tested?

-

## Are they some special informations required to test something?

-

# Reviewers:

@marigold-ui/developer