### PR TITLE
docs: Apply root styles to overlay portal so they are displayed correctly.

### DIFF
--- a/.changeset/yellow-lies-bake.md
+++ b/.changeset/yellow-lies-bake.md
@@ -1,0 +1,7 @@
+---
+"@marigold/docs": patch
+---
+
+docs: Apply root styles to overlay portal so they are displayed correctly.
+
+Overlay components (e.g. `<Dialog>` did not display correctly in the docs.

--- a/docs/app/_components/PortalContainer.tsx
+++ b/docs/app/_components/PortalContainer.tsx
@@ -3,11 +3,12 @@
 import { useThemeSwitch } from '@/ui/ThemeSwitch';
 
 export const PortalContaier = () => {
-  const { current } = useThemeSwitch();
+  const { current, themes } = useThemeSwitch();
+  const theme = themes[current];
 
   return (
     <div data-theme={current}>
-      <div id="portalContainer" className="not-prose" />
+      <div id="portalContainer" className={`not-prose ${theme.root?.()}`} />
     </div>
   );
 };

--- a/docs/ui/ComponentDemo.tsx
+++ b/docs/ui/ComponentDemo.tsx
@@ -6,7 +6,7 @@ import {
   OverlayContainerProvider,
   Tabs,
 } from '@/ui';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { useThemeSwitch } from '@/ui/ThemeSwitch';
 
 // Props
@@ -40,7 +40,7 @@ export const ComponentDemo = ({
     throw Error(`No demo with name "${name}" found in the registry.`);
   }
 
-  const Demo = registry[name].demo;
+  const Demo: ComponentType<{}> = registry[name].demo;
   const { current, themes } = useThemeSwitch();
 
   const Wrapper = ({ children }: { children: ReactNode }) =>


### PR DESCRIPTION
# Description

Because overlays inherited the root styles of the docs page instead of their theme, some stuff didn't display correctly.

# What should be tested?

Go to e.g. dialog page and open one. Should look more accurate.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
