### PR TITLE
docs: fix the badge backgroundcolor

### DIFF
--- a/themes/theme-docs/src/components/Badge.styles.ts
+++ b/themes/theme-docs/src/components/Badge.styles.ts
@@ -5,7 +5,7 @@ export const Badge: ThemeComponent<'Badge'> = cva(
   {
     variants: {
       variant: {
-        dark: 'bg-bg-lowered text-white',
+        dark: 'bg-bg-inverted text-white',
       },
       size: {
         default: 'text-xs',


### PR DESCRIPTION
# Description

In latest vercel/docs the badge color is not set correctly. With this PR it will be fixed. Old token does not exist in code

## Reviewer:
@marigold-ui/developer
@marigold-ui/designer
