### PR TITLE
docs: remove `<Hotkey>` from a11y tree

### DIFF
--- a/docs/app/_components/SiteMenu.tsx
+++ b/docs/app/_components/SiteMenu.tsx
@@ -52,7 +52,7 @@ export const Hotkey = ({ letter, className }: HotKeyProps) => {
   }
   const isMacOS = window.navigator.userAgent.includes('Mac OS');
   return (
-    <span className={cn('opacity-50', className)}>
+    <span className={cn('opacity-50', className)} aria-hidden="true">
       ({isMacOS ? '⌘' : 'Ctrl+'}
       {letter})
     </span>


### PR DESCRIPTION
# Description

Noticed that they hotkey display is part of the a11y tree -> removed it.

@marigold-ui/developer
