### PR TITLE
style([DSTSUP-93]): Adjust disabled label color

### DIFF
--- a/.changeset/mean-countries-own.md
+++ b/.changeset/mean-countries-own.md
@@ -1,0 +1,7 @@
+---
+"@marigold/theme-b2b": patch
+---
+
+style(b2b): Adjust disabled label color
+
+Labels where unreadyble when the field was disabled. They had a really bad constrast on the white background. Use regular text color instead.

--- a/themes/theme-b2b/src/components/Label.styles.ts
+++ b/themes/theme-b2b/src/components/Label.styles.ts
@@ -1,7 +1,7 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const Label: ThemeComponent<'Label'> = {
-  container: cva('group-disabled/field:text-text-base-disabled text-sm '),
+  container: cva('text-sm'),
   indicator: cva(
     'group-required/field:text-text-error group-required/field:block'
   ),


### PR DESCRIPTION
# Description

Disabled color in labels was unreadable and had a really bad constrast (white background). Use regular text color instead.

- [x] This change requires a UI-Kit update - inform Alex Tirado (@tirado-rx)


# Reviewers:

@marigold-ui/developer
@marigold-ui/designer

Ref [DSTSUP-93]

[DSTSUP-93]: https://reservix.atlassian.net/browse/DSTSUP-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ