### PR TITLE
style(dialog): make dialog sizes responsive

### DIFF
--- a/.changeset/eight-countries-sort.md
+++ b/.changeset/eight-countries-sort.md
@@ -1,0 +1,9 @@
+---
+"@marigold/components": minor
+"@marigold/theme-b2b": minor
+"@marigold/theme-core": minor
+---
+
+style(dialog): make `<Dialog>` sizes responsive
+
+Using `size` with a `<Dialog>` will allow the dialog to be at most sm/md/lg wide. Will use full width on smaller screens.

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -61,11 +61,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  render: args => {
+  render: ({ size, ...args }) => {
     return (
       <Dialog.Trigger {...args}>
         <Button variant="primary">Open</Button>
-        <Dialog closeButton>
+        <Dialog size={size} closeButton>
           <Dialog.Title>This is a headline!</Dialog.Title>
           <Text>This is some not so very long text.</Text>
         </Dialog>
@@ -75,11 +75,11 @@ export const Basic: Story = {
 };
 
 export const Form: Story = {
-  render: args => {
+  render: ({ size, ...args }) => {
     return (
       <Dialog.Trigger {...args}>
         <Button variant="primary">Open</Button>
-        <Dialog closeButton>
+        <Dialog size={size} closeButton>
           {({ close }) => (
             <>
               <Dialog.Title>Please log into account </Dialog.Title>
@@ -102,10 +102,10 @@ export const Form: Story = {
 };
 
 export const CustomTitleProps: Story = {
-  render: args => (
+  render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
       <Button variant="primary">Open</Button>
-      <Dialog closeButton aria-labelledby="my-cool-headline">
+      <Dialog size={size} closeButton aria-labelledby="my-cool-headline">
         <Dialog.Title>This is a headline!</Dialog.Title>
         <Dialog.Content>
           <Text>This is some not so very long text.</Text>
@@ -116,10 +116,10 @@ export const CustomTitleProps: Story = {
 };
 
 export const ScrollableContent: Story = {
-  render: args => (
+  render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
       <Button variant="primary">Open</Button>
-      <Dialog closeButton aria-labelledby="my-cool-headline">
+      <Dialog size={size} closeButton aria-labelledby="my-cool-headline">
         <Dialog.Title>This is a headline!</Dialog.Title>
         <Dialog.Content>
           <Stack space={2}>
@@ -149,10 +149,10 @@ export const ScrollableContent: Story = {
 };
 
 export const StickyFooter: Story = {
-  render: args => (
+  render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
       <Button variant="primary">Open</Button>
-      <Dialog closeButton aria-labelledby="my-cool-headline">
+      <Dialog size={size} closeButton aria-labelledby="my-cool-headline">
         <Dialog.Title>This is a headline!</Dialog.Title>
         <div className="flex max-h-[400px] flex-col">
           <Text>This is some additional text that is always visible!</Text>

--- a/packages/components/src/Overlay/Modal.tsx
+++ b/packages/components/src/Overlay/Modal.tsx
@@ -37,7 +37,7 @@ const _Modal = forwardRef<
     >
       <Modal
         ref={ref}
-        className="relative flex w-full justify-center sm:w-auto"
+        className="relative flex w-full justify-center"
         {...props}
       >
         {props.children}

--- a/themes/theme-b2b/src/components/Dialog.styles.ts
+++ b/themes/theme-b2b/src/components/Dialog.styles.ts
@@ -11,10 +11,14 @@ export const Dialog: ThemeComponent<'Dialog'> = {
     {
       variants: {
         size: {
-          small: 'sm:w-[640px]',
-          medium: 'md:w-[768px]',
-          large: 'lg:w-[1024px]',
+          default: '',
+          small: 'w-[min(100%,640px)]',
+          medium: 'w-[min(100%,768px)]',
+          large: 'w-[min(100%,1024px)]',
         },
+      },
+      defaultVariants: {
+        size: 'default',
       },
     }
   ),

--- a/themes/theme-core/src/components/Dialog.styles.ts
+++ b/themes/theme-core/src/components/Dialog.styles.ts
@@ -6,10 +6,14 @@ export const Dialog: ThemeComponent<'Dialog'> = {
     {
       variants: {
         size: {
-          small: 'sm:w-[640px]',
-          medium: 'md:w-[768px]',
-          large: 'lg:w-[1024px]',
+          default: '',
+          small: 'w-[min(100%,640px)]',
+          medium: 'w-[min(100%,768px)]',
+          large: 'w-[min(100%,1024px)]',
         },
+      },
+      defaultVariants: {
+        size: 'default',
       },
     }
   ),


### PR DESCRIPTION
# Description

Using `size` with a dialog will allow the dialog to be at most sm/md/lg widths. Will be full size on smaller screens.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
