### PR TITLE
style(core): adjust the underlay color to be darker

### DIFF
--- a/.changeset/heavy-impalas-tie.md
+++ b/.changeset/heavy-impalas-tie.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-core": patch
+---
+
+style(core): adjust the underlay color to be darker

--- a/themes/theme-core/src/components/Underlay.styles.ts
+++ b/themes/theme-core/src/components/Underlay.styles.ts
@@ -3,7 +3,7 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const Underlay: ThemeComponent<'Underlay'> = cva('', {
   variants: {
     variant: {
-      modal: ['bg-bg-surface-sunken/30 backdrop-blur-sm'],
+      modal: ['bg-black/25 backdrop-blur-sm'],
     },
   },
 });


### PR DESCRIPTION
# Description

Underlay was very bright and used a surface token for some reason.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
