### PR TITLE
chore: refa `<Text>` component

### DIFF
--- a/.changeset/rare-squids-shake.md
+++ b/.changeset/rare-squids-shake.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+chore: refa `<Text>` component. Based on the slot property it now takes the RAC text or not. Needed to prevent other components breaking.

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -71,3 +71,14 @@ export const Basic: Story = {
     </Text>
   ),
 };
+
+export const Slot: Story = {
+  render: args => (
+    <Text slot="description" {...args}>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+      dignissim dapibus elit, vel egestas felis pharetra non. Cras malesuada,
+      massa nec ultricies efficitur, lectus ante consequat magna, a porttitor
+      massa ex ut quam.
+    </Text>
+  ),
+};

--- a/packages/components/src/Text/Text.test.tsx
+++ b/packages/components/src/Text/Text.test.tsx
@@ -94,6 +94,7 @@ test('get theme color', () => {
 <div
   class="text-[--color] outline-[--outline] font-["Oswald_Regular"]"
   data-testid="text"
+  elementtype="div"
   style="--color: rgb(5 150 105);"
 />
 `);

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -69,34 +69,12 @@ const _Text = ({
     size,
   });
 
-  const Component = as;
-
-  if (props.slot) {
-    return (
-      <Text
-        {...props}
-        elementType={as}
-        className={cn(
-          'text-[--color] outline-[--outline]',
-          classNames,
-          fontStyle && textStyle[fontStyle],
-          align && textAlign[align],
-          cursor && cursorStyle[cursor],
-          weight && fontWeight[weight],
-          fontSize && textSize[fontSize]
-        )}
-        style={createVar({
-          color: color && getColor(theme, color, color /* fallback */),
-        })}
-      >
-        {children}
-      </Text>
-    );
-  }
+  const Component = props.slot ? Text : as;
 
   return (
     <Component
       {...props}
+      elementType={as}
       className={cn(
         'text-[--color] outline-[--outline]',
         classNames,

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -69,10 +69,34 @@ const _Text = ({
     size,
   });
 
+  const Component = as;
+
+  if (props.slot) {
+    return (
+      <Text
+        {...props}
+        elementType={as}
+        className={cn(
+          'text-[--color] outline-[--outline]',
+          classNames,
+          fontStyle && textStyle[fontStyle],
+          align && textAlign[align],
+          cursor && cursorStyle[cursor],
+          weight && fontWeight[weight],
+          fontSize && textSize[fontSize]
+        )}
+        style={createVar({
+          color: color && getColor(theme, color, color /* fallback */),
+        })}
+      >
+        {children}
+      </Text>
+    );
+  }
+
   return (
-    <Text
+    <Component
       {...props}
-      elementType={as}
       className={cn(
         'text-[--color] outline-[--outline]',
         classNames,
@@ -87,7 +111,7 @@ const _Text = ({
       })}
     >
       {children}
-    </Text>
+    </Component>
   );
 };
 


### PR DESCRIPTION
# Description

Added possibility to not use the RAC text, needed for components like: Menu, Radio, Checkbox

# What should be tested?

Text with slots and without are working?

# Reviewers:

@marigold-ui/developer
