### PR TITLE
docs: Added/activated a11y addon to storybook

### DIFF
--- a/.changeset/popular-files-destroy.md
+++ b/.changeset/popular-files-destroy.md
@@ -1,0 +1,5 @@
+---
+"@marigold/storybook-config": patch
+---
+
+docs: Added/activated a11y addon to storybook. In all components is now a panel called Accessibility which shows how accessible our components are and if there are some violations or incomplete issues.

--- a/config/storybook/.storybook/main.ts
+++ b/config/storybook/.storybook/main.ts
@@ -16,6 +16,7 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-interactions'),
     getAbsolutePath('@storybook/addon-themes'),
     getAbsolutePath('@storybook/addon-storysource'),
+    getAbsolutePath('@storybook/addon-a11y'),
   ],
   framework: {
     name: getAbsolutePath('@storybook/react-vite'),

--- a/config/storybook/.storybook/preview.tsx
+++ b/config/storybook/.storybook/preview.tsx
@@ -12,6 +12,8 @@ import core from '@marigold/theme-core';
 import '@marigold/theme-core/styles.css';
 
 // Helpers
+
+// Helpers
 // ---------------
 const THEME = {
   core: core,
@@ -26,7 +28,7 @@ type ThemeNames = keyof typeof THEME;
 export const parameters: Preview['parameters'] = {
   layout: 'fullscreen',
   a11y: {
-    element: '#root',
+    element: '#storybook-root',
   },
   options: {
     storySort: {

--- a/config/storybook/package.json
+++ b/config/storybook/package.json
@@ -22,7 +22,7 @@
     "@marigold/theme-b2b": "workspace:*",
     "@marigold/theme-core": "workspace:*",
     "@mdx-js/react": "3.0.1",
-    "@storybook/addon-a11y": "^8.1.11",
+    "@storybook/addon-a11y": "^8.2.9",
     "@storybook/addon-essentials": "^8.1.11",
     "@storybook/addon-interactions": "^8.1.11",
     "@storybook/source-loader": "^8.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,7 +244,7 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(@types/react@18.3.12)(react@18.3.1)
       '@storybook/addon-a11y':
-        specifier: ^8.1.11
+        specifier: ^8.2.9
         version: 8.3.6(storybook@8.3.6)
       '@storybook/addon-essentials':
         specifier: ^8.1.11


### PR DESCRIPTION
# Description

I added a11y addon to storybook s. https://storybook.js.org/addons/@storybook/addon-a11y

The dependency was already there but the panel wasn't active.

# How to test?
Open a component in storybook and check out the accesibility tab.

# Reviewers:

@marigold-ui/developer
