### PR TITLE
docs: make `code` in `<SectionMessage>` look nicer

### DIFF
--- a/.changeset/sweet-squids-design.md
+++ b/.changeset/sweet-squids-design.md
@@ -1,0 +1,6 @@
+---
+"@marigold/docs": patch
+"@marigold/theme-docs": patch
+---
+
+docs: make `code` in `<SectionMessage>` look nicer

--- a/.changeset/sweet-squids-design.md
+++ b/.changeset/sweet-squids-design.md
@@ -3,4 +3,4 @@
 "@marigold/theme-docs": patch
 ---
 
-docs: make `code` in `<SectionMessage>` look nicer
+docs: adjust font size of `code` in `<SectionMessage>` and make them less distracting

--- a/docs/ui/mdx.tsx
+++ b/docs/ui/mdx.tsx
@@ -129,7 +129,7 @@ const typography = {
   ),
   code: (props: HTMLAttributes<HTMLElement>) => (
     <code
-      className="my-0 inline-grid rounded bg-black/10 px-1 py-0.5 font-mono text-sm before:content-none after:content-none"
+      className="my-0 inline-grid rounded bg-black/5 px-1 py-0.5 font-mono text-sm before:content-none after:content-none"
       {...props}
     />
   ),

--- a/themes/theme-docs/src/components/SectionMessage.styles.ts
+++ b/themes/theme-docs/src/components/SectionMessage.styles.ts
@@ -17,5 +17,5 @@ export const SectionMessage: ThemeComponent<'SectionMessage'> = {
   ),
   icon: cva('size-6'),
   title: cva('mb-1 font-bold leading-none tracking-tight'),
-  content: cva('text-sm [&_p]:leading-relaxed'),
+  content: cva('text-sm [&_p]:leading-relaxed [&_code]:text-xs'),
 };


### PR DESCRIPTION
# Description

Adjusted the text size of `code` blocks inside a `SectionMessage` so they are not bigger than the regular text in side the messages.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
