### PR TITLE
fix(Text): Only apply `elementType` when RAC Text component is used.

### DIFF
--- a/.changeset/dirty-flies-tan.md
+++ b/.changeset/dirty-flies-tan.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix(Text): Only apply `elementType` when RAC Text component is used.

--- a/packages/components/src/Text/Text.test.tsx
+++ b/packages/components/src/Text/Text.test.tsx
@@ -94,7 +94,6 @@ test('get theme color', () => {
 <div
   class="text-[--color] outline-[--outline] font-["Oswald_Regular"]"
   data-testid="text"
-  elementtype="div"
   style="--color: rgb(5 150 105);"
 />
 `);

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -74,7 +74,7 @@ const _Text = ({
   return (
     <Component
       {...props}
-      elementType={as}
+      elementType={props.slot ? as : undefined}
       className={cn(
         'text-[--color] outline-[--outline]',
         classNames,


### PR DESCRIPTION
# Description

Removes this warning:

```
Warning: React does not recognize the `elementType` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `elementtype` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

# Reviewers:

@marigold-ui/developer

