### PR TITLE
docs: Adjust the storybook hin to look like the props table

### DIFF
--- a/themes/theme-docs/src/components/Card.styles.ts
+++ b/themes/theme-docs/src/components/Card.styles.ts
@@ -9,7 +9,7 @@ export const Card: ThemeComponent<'Card'> = cva(
         hovering:
           'bg-bg-surface p-6 shadow transition-shadow hover:cursor-pointer hover:shadow-md border border-secondary-300',
         content: 'bg-bg-surface my-6 shadow border border-secondary-300',
-        outline: 'bg-bg-surface/40 my-6 border border-secondary-300',
+        outline: 'bg-white/40 my-6 border border-secondary-200',
         lowered: 'bg-bg-surface-lowered p-6',
         image: '',
       },


### PR DESCRIPTION
# Description

The storybook hint looked slightly off because it used different colors than the props table. Not anymore!

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
