### PR TITLE
fix: Remove `isOpen` from `<Select>`

### DIFF
--- a/.changeset/blue-scissors-admire.md
+++ b/.changeset/blue-scissors-admire.md
@@ -1,0 +1,7 @@
+---
+"@marigold/components": patch
+---
+
+fix: Remove `isOpen` from `<Select>`
+
+The `isOpen` prop was set by default. Remove it. Only required when controlled.

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -130,14 +130,7 @@ const _Select = forwardRef<any, SelectProps<object>>(
     const classNames = useClassNames({ component: 'Select', variant, size });
 
     return (
-      <FieldBase
-        isOpen
-        as={Select}
-        ref={ref}
-        variant={variant}
-        size={size}
-        {...props}
-      >
+      <FieldBase as={Select} ref={ref} variant={variant} size={size} {...props}>
         <Button
           className={cn(
             'flex w-full items-center justify-between gap-1 overflow-hidden',


### PR DESCRIPTION
# Description

`isOpen` was set by default on the `<Select>` component. Seems to be somebody forgot to remove it when debugging something?

# What should be tested?

Is the select still working!?

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
