### PR TITLE
docs: improve displaying the variant/size in the appearance demo

### DIFF
--- a/docs/ui/AppearanceDemo.tsx
+++ b/docs/ui/AppearanceDemo.tsx
@@ -61,8 +61,16 @@ export const AppearanceDemo = ({
   const appearance = getAppearance(component, theme);
 
   const [selected, setSelected] = useState({
-    variant: appearance.variant.length ? appearance.variant[0] : 'none',
-    size: appearance.size.length ? appearance.size[0] : 'none',
+    variant: appearance.variant.length
+      ? appearance.variant.includes('default')
+        ? 'default'
+        : appearance.variant[0]
+      : 'none',
+    size: appearance.size.length
+      ? appearance.size.includes('default')
+        ? 'default'
+        : appearance.size[0]
+      : 'none',
   });
 
   const Wrapper = ({ children }: { children: ReactNode }) =>

--- a/docs/ui/AppearanceDemo.tsx
+++ b/docs/ui/AppearanceDemo.tsx
@@ -61,8 +61,8 @@ export const AppearanceDemo = ({
   const appearance = getAppearance(component, theme);
 
   const [selected, setSelected] = useState({
-    variant: 'default',
-    size: 'default',
+    variant: appearance.variant.length ? appearance.variant[0] : 'none',
+    size: appearance.size.length ? appearance.size[0] : 'none',
   });
 
   const Wrapper = ({ children }: { children: ReactNode }) =>
@@ -106,7 +106,9 @@ export const AppearanceDemo = ({
             }
             disabled={appearance.variant.length === 0 ? true : false}
           >
-            <Select.Option id="default">default</Select.Option>
+            {appearance.variant.length === 0 ? (
+              <Select.Option id="none">-</Select.Option>
+            ) : null}
             {appearance.variant.map(v => (
               <Select.Option key={v} id={v}>
                 {v}
@@ -124,7 +126,9 @@ export const AppearanceDemo = ({
             }
             disabled={appearance.size.length === 0 ? true : false}
           >
-            <Select.Option id="default">default</Select.Option>
+            {appearance.size.length === 0 ? (
+              <Select.Option id="none">-</Select.Option>
+            ) : null}
             {appearance.size.map(v => (
               <Select.Option key={v} id={v}>
                 {v}

--- a/docs/ui/AppearanceDemo.tsx
+++ b/docs/ui/AppearanceDemo.tsx
@@ -115,7 +115,7 @@ export const AppearanceDemo = ({
             disabled={appearance.variant.length === 0 ? true : false}
           >
             {appearance.variant.length === 0 ? (
-              <Select.Option id="none">-</Select.Option>
+              <Select.Option id="none">default</Select.Option>
             ) : null}
             {appearance.variant.map(v => (
               <Select.Option key={v} id={v}>
@@ -135,7 +135,7 @@ export const AppearanceDemo = ({
             disabled={appearance.size.length === 0 ? true : false}
           >
             {appearance.size.length === 0 ? (
-              <Select.Option id="none">-</Select.Option>
+              <Select.Option id="none">default</Select.Option>
             ) : null}
             {appearance.size.map(v => (
               <Select.Option key={v} id={v}>

--- a/themes/theme-b2b/src/components/Button.styles.ts
+++ b/themes/theme-b2b/src/components/Button.styles.ts
@@ -9,6 +9,7 @@ export const Button: ThemeComponent<'Button'> = cva(
   {
     variants: {
       variant: {
+        default: '',
         primary: [
           'text-text-inverted bg-bg-accent',
           'hover:bg-bg-accent-hover',
@@ -36,8 +37,13 @@ export const Button: ThemeComponent<'Button'> = cva(
         ],
       },
       size: {
+        default: '',
         small: 'px-4 leading-8',
       },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
     },
   }
 );

--- a/themes/theme-core/src/components/Button.styles.ts
+++ b/themes/theme-core/src/components/Button.styles.ts
@@ -10,6 +10,7 @@ export const Button: ThemeComponent<'Button'> = cva(
   {
     variants: {
       variant: {
+        default: '',
         primary: [
           'border-border-brand bg-bg-brand text-text-inverted',
           'hover:bg-bg-brand-hover hover:border-border-brand-hover',
@@ -32,8 +33,13 @@ export const Button: ThemeComponent<'Button'> = cva(
         ],
       },
       size: {
+        default: '',
         small: 'py-1',
       },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
     },
   }
 );


### PR DESCRIPTION
# Description

- automatically select first variant
- better display that there is no variant/size selected (indication by a "-")

This might fail with components that have a "default" (no variant/size) and additional variants, I would rather add a empty "default" to them to "fix" this then. If you find some, let me know!

**Before**
![image](https://github.com/user-attachments/assets/051c77ca-ed33-4f21-a1bb-ec2f20bd24db)

**After**
![image](https://github.com/user-attachments/assets/7505cf51-150a-40b0-af5d-f04973f14bc5)


# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
