### PR TITLE
fix([DST-638]): update package.jsons to resolve warning

### DIFF
--- a/.changeset/purple-seas-thank.md
+++ b/.changeset/purple-seas-thank.md
@@ -1,0 +1,7 @@
+---
+"@marigold/theme-b2b": patch
+"@marigold/theme-core": patch
+"@marigold/theme-docs": patch
+---
+
+fix([DST-638]): update theme package.jsons to resolve the warning: The condition "types" here will never be used as it comes after both "import" and "require".

--- a/themes/theme-b2b/package.json
+++ b/themes/theme-b2b/package.json
@@ -14,14 +14,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": {
-      "require": "./dist/*.js",
       "import": "./dist/*.mjs",
-      "types": "./dist/*.d.ts"
+      "require": "./dist/*.js"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/themes/theme-core/package.json
+++ b/themes/theme-core/package.json
@@ -15,13 +15,11 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./*": {
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs",
-      "types": "./dist/*.d.ts"
+      "import": "./dist/*.mjs"
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/themes/theme-docs/package.json
+++ b/themes/theme-docs/package.json
@@ -15,13 +15,11 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./*": {
       "require": "./dist/*.js",
-      "import": "./dist/*.mjs",
-      "types": "./dist/*.d.ts"
+      "import": "./dist/*.mjs"
     },
     "./styles.css": "./dist/styles.css"
   },


### PR DESCRIPTION
# Description

while building the themes, there appears always: `The condition "types" here will never be used as it comes after both "import" and "require" [package.js]`

Fixed through removing the types entry in `exports` should be covered through: 
`"types": "./dist/index.d.ts",`

# Reviewers:
@marigold-ui/developer
