### PR TITLE
fix(DSTSUP-102): Set dimensions of checkmark

### DIFF
--- a/.changeset/fuzzy-panthers-vanish.md
+++ b/.changeset/fuzzy-panthers-vanish.md
@@ -2,6 +2,6 @@
 "@marigold/components": patch
 ---
 
-fix(checkbox): Set dimensions of checkmark
+fix(DSTSUP-102): Set dimensions of checkmark
 
 Fixes a bug in Safari where the checkmark was not displayed.

--- a/.changeset/fuzzy-panthers-vanish.md
+++ b/.changeset/fuzzy-panthers-vanish.md
@@ -1,0 +1,7 @@
+---
+"@marigold/components": patch
+---
+
+fix(checkbox): Set dimensions of checkmark
+
+Fixes a bug in Safari where the checkmark was not displayed.

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -14,7 +14,7 @@ import { useCheckboxGroupContext } from './Context';
 
 // SVG Icon
 const CheckMark = () => (
-  <svg viewBox="0 0 12 10">
+  <svg width="12px" height="10px" viewBox="0 0 12 10">
     <path
       fill="currentColor"
       stroke="none"
@@ -24,7 +24,7 @@ const CheckMark = () => (
 );
 
 const IndeterminateMark = () => (
-  <svg width="12" height="3" viewBox="0 0 12 3">
+  <svg width="12px" height="3px" viewBox="0 0 12 3">
     <path
       fill="currentColor"
       stroke="none"


### PR DESCRIPTION
# Description

Safari needs dimensions for SVGs!

# What should be tested?

- Open Safari, check if you see the checkmark when a `Checkbox` is checked.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
