### PR TITLE
HOTFIX: add theme-plugins as dependency

### DIFF
--- a/.changeset/rude-flies-live.md
+++ b/.changeset/rude-flies-live.md
@@ -1,0 +1,8 @@
+---
+"@marigold/theme-plugins": patch
+"@marigold/theme-b2b": patch
+"@marigold/theme-core": patch
+"@marigold/theme-docs": patch
+---
+
+HOTFIX: add missing dependency for marigold 11

--- a/packages/theme-plugins/package.json
+++ b/packages/theme-plugins/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@marigold/theme-plugins",
+  "version": "1.0.0",
+  "description": "Marigold plugins",
+  "license": "MIT",
+  "keywords": [
+    "marigold",
+    "library",
+    "styling",
+    "css",
+    "tailwind"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marigold-ui/marigold",
+    "directory": "packages/theme-plugins"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,8 @@ importers:
         specifier: 8.3.5
         version: 8.3.5(@swc/core@1.10.7(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.6.1)
 
+  packages/theme-plugins: {}
+
   packages/types:
     dependencies:
       type-fest:
@@ -638,6 +640,9 @@ importers:
       '@marigold/system':
         specifier: workspace:*
         version: link:../../packages/system
+      '@marigold/theme-plugins':
+        specifier: workspace:*
+        version: link:../../packages/theme-plugins
     devDependencies:
       '@marigold/tsconfig':
         specifier: workspace:*
@@ -669,6 +674,9 @@ importers:
       '@marigold/system':
         specifier: workspace:*
         version: link:../../packages/system
+      '@marigold/theme-plugins':
+        specifier: workspace:*
+        version: link:../../packages/theme-plugins
     devDependencies:
       '@marigold/tsconfig':
         specifier: workspace:*
@@ -697,6 +705,9 @@ importers:
       '@marigold/system':
         specifier: workspace:*
         version: link:../../packages/system
+      '@marigold/theme-plugins':
+        specifier: workspace:*
+        version: link:../../packages/theme-plugins
     devDependencies:
       '@marigold/tsconfig':
         specifier: workspace:*

--- a/themes/theme-b2b/package.json
+++ b/themes/theme-b2b/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@marigold/components": "workspace:*",
-    "@marigold/system": "workspace:*"
+    "@marigold/system": "workspace:*",
+    "@marigold/theme-plugins": "workspace:*"
   },
   "scripts": {
     "build": "NODE_ENV=production tsup && postcss -o dist/styles.css src/styles.css && cp src/theme.css dist/theme.css"

--- a/themes/theme-b2b/src/theme.css
+++ b/themes/theme-b2b/src/theme.css
@@ -1,6 +1,6 @@
-@plugin "./../../../packages/theme-plugins/src/tw-rac-plugins";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-placement-plugin";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-aria-variants-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-rac-plugins";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-placement-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-aria-variants-plugin";
 
 @theme {
   /* rebuild preset.ts */

--- a/themes/theme-core/package.json
+++ b/themes/theme-core/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@marigold/components": "workspace:*",
-    "@marigold/system": "workspace:*"
+    "@marigold/system": "workspace:*",
+    "@marigold/theme-plugins": "workspace:*"
   },
   "scripts": {
     "build": "NODE_ENV=production tsup && postcss -o dist/styles.css src/styles.css && cp src/theme.css dist/theme.css"

--- a/themes/theme-core/src/theme.css
+++ b/themes/theme-core/src/theme.css
@@ -265,6 +265,6 @@
   }
 }
 
-@plugin "./../../../packages/theme-plugins/src/tw-rac-plugins";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-placement-plugin";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-aria-variants-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-rac-plugins";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-placement-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-aria-variants-plugin";

--- a/themes/theme-docs/package.json
+++ b/themes/theme-docs/package.json
@@ -50,7 +50,8 @@
   },
   "dependencies": {
     "@marigold/components": "workspace:*",
-    "@marigold/system": "workspace:*"
+    "@marigold/system": "workspace:*",
+    "@marigold/theme-plugins": "workspace:*"
   },
   "scripts": {
     "build": "NODE_ENV=production tsup && postcss -o dist/styles.css src/styles.css && cp src/theme.css dist/theme.css"

--- a/themes/theme-docs/src/theme.css
+++ b/themes/theme-docs/src/theme.css
@@ -168,6 +168,6 @@
   --color-border-error: var(--color-red-400);
 }
 
-@plugin "./../../../packages/theme-plugins/src/tw-rac-plugins";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-placement-plugin";
-@plugin "./../../../packages/theme-plugins/src/tw-custom-aria-variants-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-rac-plugins";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-placement-plugin";
+@plugin "./../node_modules/@marigold/theme-plugins/src/tw-custom-aria-variants-plugin";


### PR DESCRIPTION
# Description

Marigold 11 doesn'T work cause of missing dep. Create a package.json in theme-plugins, added as dependency in the other themes, adjust paths to plugins.


# What should be tested?

## Are they some special informations required to test something?

# Reviewers:

Which persons should review this PR? Add person with @mentions

@marigold-ui/developer
