### PR TITLE
fix([DSTSUP-104]): mobile behaviour for popover

### DIFF
--- a/.changeset/twenty-baboons-clap.md
+++ b/.changeset/twenty-baboons-clap.md
@@ -1,0 +1,7 @@
+---
+"@marigold/components": patch
+---
+
+fix([DSTSUP-104]): mobile behaviour for `<Popover>`
+
+`<Underlay>` stayed remaining open on small screens while `<Popover>` was correctly closing, fixed this and added styles for `<Popover>` back.

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -62,6 +62,7 @@ const _Menu = ({
 }: MenuProps) => {
   const classNames = useClassNames({ component: 'Menu', variant, size });
 
+  console.log(props);
   return (
     <MenuTrigger {...props}>
       <Button variant="menu" disabled={disabled} aria-label={ariaLabel}>

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -62,7 +62,6 @@ const _Menu = ({
 }: MenuProps) => {
   const classNames = useClassNames({ component: 'Menu', variant, size });
 
-  console.log(props);
   return (
     <MenuTrigger {...props}>
       <Button variant="menu" disabled={disabled} aria-label={ariaLabel}>

--- a/packages/components/src/Overlay/Popover.test.tsx
+++ b/packages/components/src/Overlay/Popover.test.tsx
@@ -117,7 +117,7 @@ test('popover is small screen', () => {
   const popover = screen.getByTestId('popover');
 
   expect(popover.className).toMatchInlineSnapshot(
-    `"fixed! top-auto! bottom-0! left-0! max-h-fit! w-full"`
+    `"fixed! top-auto! bottom-0! left-0! max-h-fit! w-full mt-0.5 min-w-(--trigger-width)"`
   );
   expect(popover).toBeInTheDocument();
 });

--- a/packages/components/src/Overlay/Popover.tsx
+++ b/packages/components/src/Overlay/Popover.tsx
@@ -55,7 +55,7 @@ const _Popover = forwardRef<HTMLDivElement, PopoverProps>(
               UNSTABLE_portalContainer={portal as Element}
             >
               {children}
-              <Underlay open={open} variant="modal"></Underlay>
+              <Underlay open={open} variant="modal" />
             </Popover>
           </>
         ) : (

--- a/packages/components/src/Overlay/Popover.tsx
+++ b/packages/components/src/Overlay/Popover.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { ReactNode, forwardRef } from 'react';
 import type RAC from 'react-aria-components';
 import { Popover } from 'react-aria-components';
 import { cn, useClassNames, useSmallScreen } from '@marigold/system';
@@ -10,11 +10,12 @@ import { Underlay } from './Underlay';
 export interface PopoverProps
   extends Omit<
     RAC.PopoverProps,
-    'isOpen' | 'isKeyboardDismissDisabled' | 'style' | 'className'
+    'isOpen' | 'isKeyboardDismissDisabled' | 'style' | 'className' | 'children'
   > {
   keyboardDismissDisabled?: boolean;
   open?: boolean;
   container?: Element;
+  children: ReactNode;
 }
 
 // Component
@@ -40,20 +41,22 @@ const _Popover = forwardRef<HTMLDivElement, PopoverProps>(
     const isSmallScreen = useSmallScreen();
     const portal = usePortalContainer();
 
+    console.log(props);
     return (
       <>
         {isSmallScreen ? (
           <>
-            <Underlay open={open} variant="modal" />
             <Popover
               ref={ref}
               {...props}
               className={cn(
-                'fixed! top-auto! bottom-0! left-0! max-h-fit! w-full'
+                'fixed! top-auto! bottom-0! left-0! max-h-fit! w-full',
+                classNames
               )}
               UNSTABLE_portalContainer={portal as Element}
             >
               {children}
+              <Underlay open={open} variant="modal"></Underlay>
             </Popover>
           </>
         ) : (

--- a/packages/components/src/Overlay/Popover.tsx
+++ b/packages/components/src/Overlay/Popover.tsx
@@ -41,7 +41,6 @@ const _Popover = forwardRef<HTMLDivElement, PopoverProps>(
     const isSmallScreen = useSmallScreen();
     const portal = usePortalContainer();
 
-    console.log(props);
     return (
       <>
         {isSmallScreen ? (

--- a/packages/components/src/Overlay/Underlay.tsx
+++ b/packages/components/src/Overlay/Underlay.tsx
@@ -34,6 +34,8 @@ export const Underlay = ({
     ...rest,
   };
   const portal = usePortalContainer();
+
+  console.log(props);
   return (
     <ModalOverlay
       className={({ isEntering, isExiting }) =>

--- a/packages/components/src/Overlay/Underlay.tsx
+++ b/packages/components/src/Overlay/Underlay.tsx
@@ -35,7 +35,6 @@ export const Underlay = ({
   };
   const portal = usePortalContainer();
 
-  console.log(props);
   return (
     <ModalOverlay
       className={({ isEntering, isExiting }) =>


### PR DESCRIPTION
# Description

Underlay stayed remaining open on mobile, while Popover was closed, 
also Popover styles for mobile were missing, added them back.

# What should be tested?

Components that open on small screen with a tray like `<Select>`, `<DatePicker>` and `<Menu>` components

# Reviewers:
@marigold-ui/developer
