### PR TITLE
feat[DST-676]: add button styles to rui theme

### DIFF
--- a/docs/scripts/build-component-props.mjs
+++ b/docs/scripts/build-component-props.mjs
@@ -158,6 +158,7 @@ const transformTypeValue = async val => {
     '"Accordion" | "Badge" | "Body" | "Button" | "Card" | "DateField" | "Dialog" | "Divider" | "Field" | "Footer" | "Header" | "Headline" | "Popover" | "HelpText" | "Image" | "Checkbox" | ... 21 more ... | "ComboBox"',
     '"Accordion" | "Badge" | "Body" | "Button" | "Card" | "DateField" | "Dialog" | "Divider" | "Field" | "Footer" | "Header" | "Headline" | "Popover" | "HelpText" | "Image" | "Checkbox" | ... 22 more ... | "XLoader"',
     '"Accordion" | "Badge" | "Body" | "Button" | "Card" | "DateField" | "Dialog" | "Divider" | "Field" | "Footer" | "Header" | "Headline" | "Popover" | "HelpText" | "Image" | "Checkbox" | ... 23 more ... | "XLoader"',
+    '"Accordion" | "Badge" | "Body" | "Button" | "Card" | "DateField" | "Dialog" | "Divider" | "Field" | "Footer" | "Header" | "Headline" | "Popover" | "HelpText" | "Image" | "Checkbox" | ... 24 more ... | "XLoader"',
     'string | { [slot in keyof ThemeComponent<C>]?: string; }',
     'keyof NumberFormatOptionsCurrencyDisplayRegistry',
     'boolean | keyof NumberFormatOptionsUseGroupingRegistry | "true" | "false"',

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
+import { Container, Stack } from '@marigold/components';
 import { Facebook } from '@marigold/icons';
 import { Button } from './Button';
 
@@ -56,6 +57,7 @@ const meta = {
       options: [
         'primary',
         'secondary',
+        'destructive',
         'ghost',
         'link',
         'text',
@@ -89,7 +91,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  render: args => <Button {...args} />,
+  parameters: {
+    controls: { exclude: ['variant', 'children', 'loading'] },
+  },
+  render: args => (
+    <Container>
+      <Stack space={4}>
+        <Button {...args} variant="primary">
+          Primary
+        </Button>
+        <Button {...args} variant="secondary">
+          Secondary
+        </Button>
+        <Button {...args} variant="destructive">
+          Destructive
+        </Button>
+        <Button {...args} variant="ghost">
+          Ghost
+        </Button>
+      </Stack>
+    </Container>
+  ),
 };
 
 export const WithIcon: Story = {

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -20,6 +20,7 @@ const theme: Theme = {
         },
       },
     }),
+    ProgressCycle: cva(),
   },
 };
 

--- a/packages/components/src/ProgressCycle/ProgressCycle.test.tsx
+++ b/packages/components/src/ProgressCycle/ProgressCycle.test.tsx
@@ -1,11 +1,13 @@
 import { screen } from '@testing-library/react';
-import { Theme } from '@marigold/system';
+import { Theme, cva } from '@marigold/system';
 import { setup } from '../test.utils';
 import { ProgressCycle } from './ProgressCycle';
 
 const theme: Theme = {
   name: 'Progress Cycle testing',
-  components: {},
+  components: {
+    ProgressCycle: cva('stroke-gray-800'),
+  },
 };
 
 const { render } = setup({ theme });

--- a/packages/components/src/ProgressCycle/ProgressCycle.tsx
+++ b/packages/components/src/ProgressCycle/ProgressCycle.tsx
@@ -1,6 +1,6 @@
 import type RAC from 'react-aria-components';
 import { ProgressBar } from 'react-aria-components';
-import { SVG } from '@marigold/system';
+import { SVG, cn, useClassNames } from '@marigold/system';
 
 export interface ProgressCycleProps extends RAC.ProgressBarProps {
   /**
@@ -22,6 +22,8 @@ export const ProgressCycle = ({
   }
 
   const radius = `calc(50% - ${strokeWidth / 2}px)`;
+
+  const classNames = useClassNames({ component: 'ProgressCycle' });
 
   return (
     <ProgressBar {...props} aria-label="loading" isIndeterminate>
@@ -47,7 +49,10 @@ export const ProgressCycle = ({
           strokeDasharray="100 200"
           strokeDashoffset="0"
           strokeLinecap="round"
-          className="animate-progress-cycle origin-center -rotate-90 stroke-gray-800"
+          className={cn(
+            'animate-progress-cycle origin-center -rotate-90',
+            classNames
+          )}
         />
       </SVG>
     </ProgressBar>

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -12,6 +12,7 @@ const theme: Theme = {
       container: cva(),
       indicator: cva(),
     },
+    ProgressCycle: cva(),
     Switch: {
       container: cva(),
       track: cva(
@@ -68,7 +69,7 @@ test('supports base styling', () => {
   );
   expect(track.className).toMatchInlineSnapshot(`"relative"`);
   expect(thumb.className).toMatchInlineSnapshot(
-    `"h-6 w-12 basis-12 rounded-3xl group-disabled/switch:cursor-not-allowed bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
+    `"bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
   );
 });
 
@@ -78,7 +79,7 @@ test('supports a custom variant', () => {
 
   expect(track.className).toMatchInlineSnapshot(`"relative"`);
   expect(thumb.className).toMatchInlineSnapshot(
-    `"h-6 w-12 basis-12 rounded-3xl group-disabled/switch:cursor-not-allowed bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
+    `"bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
   );
 });
 
@@ -110,7 +111,7 @@ test('supports disabled prop', () => {
   expect(input).toBeDisabled();
   expect(track.className).toMatchInlineSnapshot(`"relative"`);
   expect(thumb.className).toMatchInlineSnapshot(
-    `"h-6 w-12 basis-12 rounded-3xl group-disabled/switch:cursor-not-allowed bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
+    `"bg-switch-track-background shadow-switch-track-shadow shadow-[0_0_0_1px] group-selected/switch:bg-switch-track-primary group-selected/switch:shadow-switch-track-checked disabled:bg-dis disabled:opacity-50 focus:outline-switch-track-outline-focus"`
   );
 });
 

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -81,6 +81,7 @@ export type Theme = {
       ComponentStyleFunction<string, string>
     >;
     Pagination?: ComponentStyleFunction<string, string>;
+    ProgressCycle?: ComponentStyleFunction<string, string>;
     Radio?: Record<
       'container' | 'label' | 'radio' | 'group',
       ComponentStyleFunction<string, string>

--- a/themes/theme-b2b/src/components/ProgressCycle.styles.ts
+++ b/themes/theme-b2b/src/components/ProgressCycle.styles.ts
@@ -1,0 +1,5 @@
+import { ThemeComponent, cva } from '@marigold/system';
+
+export const ProgressCycle: ThemeComponent<'ProgressCycle'> = cva([
+  'stroke-gray-800',
+]);

--- a/themes/theme-b2b/src/components/index.ts
+++ b/themes/theme-b2b/src/components/index.ts
@@ -24,6 +24,7 @@ export * from './ListBox.styles';
 export * from './Menu.styles';
 export * from './NumberField.styles';
 export * from './Popover.styles';
+export * from './ProgressCycle.styles';
 export * from './Radio.styles';
 export * from './SectionMessage.styles';
 export * from './Select.styles';

--- a/themes/theme-core/src/components/ProgressCycle.styles.ts
+++ b/themes/theme-core/src/components/ProgressCycle.styles.ts
@@ -1,0 +1,5 @@
+import { ThemeComponent, cva } from '@marigold/system';
+
+export const ProgressCycle: ThemeComponent<'ProgressCycle'> = cva([
+  'stroke-gray-800',
+]);

--- a/themes/theme-core/src/components/index.ts
+++ b/themes/theme-core/src/components/index.ts
@@ -38,3 +38,4 @@ export * from './Underlay.styles';
 export * from './Popover.styles';
 export * from './XLoader.styles';
 export * from './Pagination.styles';
+export * from './ProgressCycle.styles';

--- a/themes/theme-rui/src/components/Button.styles.ts
+++ b/themes/theme-rui/src/components/Button.styles.ts
@@ -1,18 +1,29 @@
-import { cva } from '@marigold/system';
 import type { ThemeComponent } from '@marigold/system';
+import { cva } from '@marigold/system';
 
 export const Button: ThemeComponent<'Button'> = cva(
   [
-    'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors outline-offset-2 focus-visible:outline-2 focus-visible:outline-ring/70 disabled:pointer-events-none disabled:opacity-50',
+    'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors outline-hidden',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+    'focus-visible:outline-offset-2 focus-visible:outline focus-visible:outline-ring/70',
+    'h-button px-4 py-2',
+    'disabled:pointer-events-none disabled:bg-disabled disabled:text-disabled-foreground disabled:border-none disabled:cursor-not-allowed',
+    'pending:text-disabled-foreground pending:bg-disabled pending:cursor-not-allowed pending:border-none',
   ],
   {
     variants: {
       variant: {
         primary:
-          'bg-brand text-brand-foreground shadow-sm shadow-black/5 hover:bg-primary/90',
-
-        destructive: 'bg-destructive text-destructive-foreground',
+          'bg-brand text-brand-foreground shadow-sm shadow-black/5 hover:bg-brand/90',
+        secondary:
+          'border border-border bg-background shadow-sm shadow-black/5 hover:bg-accent hover:text-foreground',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        ghost: 'hover:bg-accent hover:text-foreground',
       },
+    },
+    defaultVariants: {
+      variant: 'secondary',
     },
   }
 );

--- a/themes/theme-rui/src/components/ProgressCycle.styles.ts
+++ b/themes/theme-rui/src/components/ProgressCycle.styles.ts
@@ -1,0 +1,5 @@
+import { ThemeComponent, cva } from '@marigold/system';
+
+export const ProgressCycle: ThemeComponent<'ProgressCycle'> = cva([
+  'stroke-background',
+]);

--- a/themes/theme-rui/src/components/index.ts
+++ b/themes/theme-rui/src/components/index.ts
@@ -11,6 +11,7 @@ export { ListBox } from './ListBox.styles';
 export { NumberField } from './NumberField.styles';
 export { Popover } from './Popover.styles';
 export { Radio } from './Radio.styles';
+export { ProgressCycle } from './ProgressCycle.styles';
 export { Select } from './Select.styles';
 export { Switch } from './Switch.styles';
 export { Table } from './Table.styles';

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -43,6 +43,10 @@
   --color-brand: var(--color-stone-950);
   --color-brand-foreground: var(--color-stone-50);
 
+  /* stone (use for secondary) */
+  --color-secondary: var(--color-stone-50);
+  --color-secondary-foreground: var(--color-stone-950);
+
   /* accent colors used for highlighting certain parts of components */
 
   /*
@@ -52,12 +56,15 @@
   --color-destructive-foreground: var(--color-white);
 
   /* 
-    muted colors are desaturated colors of the brand color, 
+    muted colors are desaturated colors of the brand color,
     they help create hierarchy for secondary text. 
     Currently used for: helptext, icons inside inputs, readonly background inside inputs
   */
   --color-muted: var(--color-stone-100);
   --color-muted-foreground: var(--color-stone-500);
+
+  --color-disabled: var(--color-stone-400);
+  --color-disabled-foreground: var(--color-stone-50);
 
   /* used for placeholder color */
   --color-placeholder: --alpha(var(--color-stone-500) / 70%);
@@ -70,6 +77,9 @@
   /* component height for input elements */
   --spacing-input: 2.25rem;
 
+  /* component height for button elements */
+  --spacing-button: 2.25rem;
+
   /* surface colors used for elevation levels */
   --color-surface-overlay: var(--color-white);
 
@@ -80,4 +90,31 @@
 
   /* Selected color is used when there is an active selection in the component */
   --color-selected: var(--color-stone-100);
+
+  /* animation and keyframes */
+  --animate-rotate-spinner: rotate-spinner 2s linear infinite;
+  --animate-progress-cycle: progress-cycle 1.5s linear infinite;
+
+  @keyframes rotate-spinner {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes progress-cycle {
+    0% {
+      transform: rotate(0deg);
+      stroke-dashoffset: 75;
+    }
+    30% {
+      stroke-dashoffset: 20;
+    }
+    100% {
+      transform: rotate(360deg);
+      stroke-dashoffset: 75;
+    }
+  }
 }


### PR DESCRIPTION
# Description

Button styles added in 4 variants according to OriginUI:

- primary
- secondary (default when no variant specified)
- destructive
- ghost

Also added states:

- disabled
- hover
- pending (for loading)
- focus-visible (with outline when tabbed into)

- [] This change requires a UI-Kit update - inform Alex Tirado (@tirado-rx , @benjirsvx )

# What should be tested?

Look into Storybook "Button".

The basic show all variants add once. Toggle disable to true.

Also look add loading story.

In general color should be checked.

For hover I used our accent color in secondary and ghost variant like OriginUI - I think this should be changed but idk which color to use.

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
