### PR TITLE
fix([DST-702]): add space for multiple selection mode in `<SelectList>`

### DIFF
--- a/.changeset/chatty-clouds-jump.md
+++ b/.changeset/chatty-clouds-jump.md
@@ -1,0 +1,7 @@
+---
+"@marigold/components": patch
+---
+
+fix([DST-702]): add space for multiple selection mode in `<SelectList>`
+
+There were no space between `<Checkbox>` and `children` when using `<SelectList>` in multiple selection mode.

--- a/packages/components/src/SelectList/SelectListItem.tsx
+++ b/packages/components/src/SelectList/SelectListItem.tsx
@@ -26,10 +26,10 @@ const _SelectListItem = forwardRef<HTMLDivElement, SelectListItemProps>(
         ref={ref}
       >
         {({ selectionMode }) => (
-          <>
+          <div className="flex gap-2">
             {selectionMode === 'multiple' && <Checkbox slot="selection" />}
             {children}
-          </>
+          </div>
         )}
       </SelectListItem>
     );


### PR DESCRIPTION
# Description

There were no space between the Checkbox and the children of SelectList when using multiple selection mode. 

- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
