### PR TITLE
feat(overlay): allow passing HTMLElement

### DIFF
--- a/packages/components/src/Provider/OverlayContainerProvider.tsx
+++ b/packages/components/src/Provider/OverlayContainerProvider.tsx
@@ -1,21 +1,24 @@
 import { createContext, useContext } from 'react';
 import { useIsSSR } from '@react-aria/ssr';
 
-// needs an id for the portal container, it will be overgiven as string,
-// if there is no the body is used
-const OverlayContainerContext = createContext<string | undefined>(undefined);
+/**
+ * Context to provide the container element for overlay components.
+ * This is used by overlay components to append themselves to the correct container.
+ * If no container is provided, it falls back to `document.body`.
+ */
+const OverlayContainerContext = createContext<string | HTMLElement | undefined>(
+  undefined
+);
 
 export const OverlayContainerProvider = OverlayContainerContext.Provider;
 
 export const usePortalContainer = () => {
   const portalContainer = useContext(OverlayContainerContext);
-  const isSSR = useIsSSR();
 
-  const portal = isSSR
-    ? null
-    : portalContainer
-      ? document.getElementById(portalContainer)
-      : document.body;
+  if (useIsSSR()) return null;
 
-  return portal;
+  if (typeof portalContainer === 'string')
+    return document.getElementById(portalContainer);
+
+  return portalContainer || document.body;
 };


### PR DESCRIPTION
# Description  

## Context:
We use a custom HTML element with a shadow root to render our application. This encapsulates our element from the document's DOM, preventing it from accessing main document elements. 

Currently, the `OverlayContainerProvider` expects an element ID and retrieves it using `document.getElementById(portalContainer)`. However, this approach fails in our use case, as the query always returns `null` due to shadow DOM encapsulation.  Additionally, there is no `body` in our case, which further limits our ability to append overlays to the standard document structure.  

<img width="304" alt="Screenshot 2025-03-03 at 11 06 22 PM" src="https://github.com/user-attachments/assets/a51fea50-27f5-482a-95c1-dc51d5c66b9b" />


## This PR:
- Adds support for passing an `HTMLElement` directly to the `OverlayContainerProvider`.  
- Preserves the existing behavior of accepting an element ID.  
- Enhances and fixes unit tests for `OverlayContainerProvider`.

- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# What should be tested?

- Render portal container by element ID.
- Fallback the portal container to the `body`.
- Render portal container by HTMLElement.

## Are they some special informations required to test something?

# Reviewers:

Which persons should review this PR? Add person with @mentions

Examples:
@marigold-ui/developer
@marigold-ui/designer
