### PR TITLE
chore([DSTSUP-109]): change visibility of icon to hidden when sorting…

### DIFF
--- a/.changeset/calm-spoons-worry.md
+++ b/.changeset/calm-spoons-worry.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+chore([DSTSUP-109]): change visibility of icon to hidden when sorting…

--- a/packages/components/src/Table/TableColumnHeader.tsx
+++ b/packages/components/src/Table/TableColumnHeader.tsx
@@ -56,7 +56,7 @@ export const TableColumnHeader = ({
             <SortDown className="inline-block" />
           )
         ) : (
-          <span className="invisible">
+          <span className="hidden">
             <SortDown className="inline-block" />
           </span>
         ))}


### PR DESCRIPTION
… a table

# Description

When aligning the column of a sortable table, there is a gap between the text and the end of the column. To avoid this i changed to `display: none` instead of `visibility: hidden`

# Reviewers:
@marigold-ui/developer
@marigold-ui/designer
