### PR TITLE
fix([DST-752]): use `rgba` instead of `alpha` value in our theme.css

### DIFF
--- a/.changeset/late-crews-appear.md
+++ b/.changeset/late-crews-appear.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+fix([DST-752]): use `rgba` instead of `alpha` value in our theme.css

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -102,7 +102,7 @@
   --color-disabled-foreground: var(--color-stone-400);
 
   /* used for placeholder color */
-  --color-placeholder: --alpha(var(--color-stone-500) / 70%);
+  --color-placeholder: rgba(var(--color-stone-500), 0.7);
   /* used for outline/border as ring*/
   --color-ring: var(--color-stone-400);
 


### PR DESCRIPTION
# Description

The alpha value causes syntax problems when using them in custom tokens. Instead we should use rgba for this use case.

# Reviewers:
@marigold-ui/developer
