### PR TITLE
[DST-768]: add exports to marigold packages

### DIFF
--- a/docs/content/components/form/search-field/search-field-basic.demo.tsx
+++ b/docs/content/components/form/search-field/search-field-basic.demo.tsx
@@ -1,3 +1,3 @@
-import { SearchField } from '@marigold/components/src/SearchField';
+import { SearchField } from '@marigold/components';
 
 export default () => <SearchField label="search" />;

--- a/docs/content/components/form/search-field/searchfield-appearance.demo.tsx
+++ b/docs/content/components/form/search-field/searchfield-appearance.demo.tsx
@@ -1,3 +1,3 @@
-import { SearchField } from '@marigold/components/src/SearchField';
+import { SearchField } from '@marigold/components';
 
 export default () => <SearchField label="search" />;

--- a/docs/content/components/form/slider/slider-form.demo.tsx
+++ b/docs/content/components/form/slider/slider-form.demo.tsx
@@ -4,10 +4,10 @@ import {
   Center,
   FieldBase,
   FieldGroup,
+  Form,
   Slider,
   Stack,
 } from '@marigold/components';
-import { Form } from '@marigold/components/src/Form/Form';
 
 export default () => {
   const handleSubmit = (e: FormEvent) => {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -13,6 +13,16 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,6 +12,16 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist"

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -14,6 +14,16 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
# Description

The goal ist to use imports from marigold starting with _@marigold_ like we have it for the theme.

Instead of 

`
@source "../../../../../../../node_modules/@marigold/components";
@source "../../../../../../../node_modules/@marigold/system";
`
it should now be possible to use

`
@source "@marigold/components";
@source "@marigold/system";
`

# What should be tested?

Please check configuration.


# Reviewers:

@marigold-ui/developer
