### PR TITLE
fix([DST-232]): Align icon in `<HelpText>` to the start

### DIFF
--- a/.changeset/fast-bees-count.md
+++ b/.changeset/fast-bees-count.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix([DST-232]): Align icon in `<HelpText>` to the start of text begin.

--- a/packages/components/src/HelpText/HelpText.tsx
+++ b/packages/components/src/HelpText/HelpText.tsx
@@ -77,7 +77,7 @@ export const HelpText = ({
               </div>
             ))
           ) : (
-            <div className="flex items-center justify-start gap-1">
+            <div className="flex items-start justify-start gap-1">
               <Icon className={classNames.icon} />
               {messages}
             </div>


### PR DESCRIPTION
# Description


- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# What should be tested?

Icon working as expected

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
