### PR TITLE
refa([DST-762]): Unify Label API Across Form Fields

### DIFF
--- a/.changeset/tiny-feet-enjoy.md
+++ b/.changeset/tiny-feet-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@marigold/docs": patch
+"@marigold/components": patch
+---
+
+refa([DST-762]): support `label` prop for `<CheckBox>` and `<Switch>`. Deprecate `children` property, use `label` instead. With the next major version `children` will be removed.

--- a/.changeset/tiny-feet-enjoy.md
+++ b/.changeset/tiny-feet-enjoy.md
@@ -3,4 +3,6 @@
 "@marigold/components": patch
 ---
 
-refa([DST-762]): support `label` prop for `<CheckBox>` and `<Switch>`. Deprecate `children` property, use `label` instead. With the next major version `children` will be removed.
+refa([DST-762]): support `label` prop for `<CheckBox>` and `<Switch>`. 
+
+**Breaking Change**: Deprecate `children` property, use `label` instead. With the next major version `children` will be removed.

--- a/docs/content/components/form/checkbox/checkbox-appearance.demo.tsx
+++ b/docs/content/components/form/checkbox/checkbox-appearance.demo.tsx
@@ -3,8 +3,9 @@ import { Checkbox, FieldGroup } from '@marigold/components';
 
 export default (props: CheckboxProps) => (
   <FieldGroup labelWidth="0px">
-    <Checkbox {...props}>
-      I agree to the Terms of Service and Privacy Policy
-    </Checkbox>
+    <Checkbox
+      {...props}
+      label="I agree to the Terms of Service and Privacy Policy"
+    />
   </FieldGroup>
 );

--- a/docs/content/components/form/checkbox/checkbox-indeterminate.demo.tsx
+++ b/docs/content/components/form/checkbox/checkbox-indeterminate.demo.tsx
@@ -37,9 +37,7 @@ export default () => {
           onChange={(keys: Genres[]) => setSelected(keys)}
         >
           {Object.entries(genres).map(([value, label]) => (
-            <Checkbox key={value} value={value}>
-              {label}
-            </Checkbox>
+            <Checkbox key={value} value={value} label={label} />
           ))}
         </Checkbox.Group>
       </Inset>

--- a/docs/content/components/form/switch/switch-appearance.demo.tsx
+++ b/docs/content/components/form/switch/switch-appearance.demo.tsx
@@ -1,5 +1,5 @@
 import { Switch, SwitchProps } from '@marigold/components';
 
 export default (props: SwitchProps) => (
-  <Switch {...props}>Default Switch</Switch>
+  <Switch {...props} label="Default Switch" />
 );

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   title: 'Components/Checkbox',
   component: Checkbox,
   argTypes: {
-    children: {
+    label: {
       control: {
         type: 'text',
       },
@@ -15,6 +15,15 @@ const meta = {
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: 'This is a Checkbox' },
+      },
+    },
+    children: {
+      control: {
+        type: 'text',
+      },
+      description: 'deprecated use `label` instead',
+      table: {
+        type: { summary: 'string' },
       },
     },
     disabled: {
@@ -64,7 +73,7 @@ const meta = {
     readOnly: false,
     indeterminate: false,
     disabled: false,
-    children: 'This is a Checkbox',
+    label: 'This is a Checkbox',
     size: 'default',
   },
 } satisfies Meta<typeof Checkbox>;

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from '@storybook/test';
 import React from 'react';
 import { FieldGroup } from '../FieldBase/FieldGroup';
 import { Checkbox } from './Checkbox';
@@ -75,6 +76,9 @@ const meta = {
     disabled: false,
     label: 'This is a Checkbox',
     size: 'default',
+    defaultChecked: false,
+    error: false,
+    required: false,
   },
 } satisfies Meta<typeof Checkbox>;
 
@@ -82,7 +86,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  render: args => <Checkbox size="small" {...args} defaultChecked />,
+  args: {
+    defaultChecked: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = await canvas.findByRole('checkbox');
+
+    await userEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+  },
 };
 
 export const WithFieldGroup: Story = {

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -86,9 +86,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  args: {
-    defaultChecked: false,
-  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const checkbox = await canvas.findByRole('checkbox');

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -86,6 +86,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
+  tags: ['component-test'],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const checkbox = await canvas.findByRole('checkbox');

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -106,8 +106,14 @@ export interface CheckboxProps extends Omit<RAC.CheckboxProps, RemovedProps> {
   size?: string;
   /**
    * Children of the component.
+   * @deprecated Will be removed in the next major version. Use `label` prop instead.
    */
   children?: ReactNode;
+  /**
+   * The label of the component.
+   *
+   */
+  label?: ReactNode;
 }
 
 export interface CheckboxComponent
@@ -132,9 +138,9 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       checked,
       defaultChecked,
       indeterminate,
-      children,
       variant,
       size,
+      label,
       ...rest
     },
     ref
@@ -176,9 +182,11 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
               indeterminate={isIndeterminate}
               className={classNames.checkbox}
             />
-            {children ? (
-              <div className={classNames.label}>{children}</div>
-            ) : null}
+            {(props.children || label) && (
+              <div className={classNames.label}>
+                {(props.children as React.ReactNode) || label}
+              </div>
+            )}
           </>
         )}
       </Checkbox>

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -105,12 +105,12 @@ export interface CheckboxProps extends Omit<RAC.CheckboxProps, RemovedProps> {
   variant?: string;
   size?: string;
   /**
-   * Children of the component.
+   * Children of the checkbox.
    * @deprecated Will be removed in the next major version. Use `label` prop instead.
    */
   children?: ReactNode;
   /**
-   * The label of the component.
+   * Set the label of the checkbox.
    *
    */
   label?: ReactNode;

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -44,7 +44,7 @@ export interface SliderProps<T>
   children?: ReactNode;
 
   /**
-   * The label of the component.
+   * Set the label of the slider.
    */
   label?: string;
 }

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -43,6 +43,9 @@ export interface SliderProps<T>
    */
   children?: ReactNode;
 
+  /**
+   * The label of the component.
+   */
   label?: string;
 }
 

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -68,7 +68,6 @@ const meta = {
   args: {
     children: 'Default Switch',
     disabled: false,
-    selected: false,
     defaultSelected: false,
   },
 } satisfies Meta<typeof Switch>;
@@ -78,12 +77,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
   tags: ['component-test'],
-  play: async ({ canvasElement, args }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('switch');
 
     await userEvent.click(button);
 
-    expect(args.selected).toBe(true);
+    expect(button).toBeChecked();
   },
 };

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from '@storybook/test';
 import { Switch } from './Switch';
 
 const meta = {
@@ -15,7 +16,16 @@ const meta = {
       control: {
         type: 'text',
       },
-      description: 'Switch label',
+      description: 'deprecated use `label` instead',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    label: {
+      control: {
+        type: 'text',
+      },
+      description: 'Label of the component',
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: 'Default Switch' },
@@ -58,6 +68,8 @@ const meta = {
   args: {
     children: 'Default Switch',
     disabled: false,
+    selected: false,
+    defaultSelected: false,
   },
 } satisfies Meta<typeof Switch>;
 
@@ -65,5 +77,13 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
-  render: args => <Switch {...args} />,
+  tags: ['component-test'],
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('switch');
+
+    await userEvent.click(button);
+
+    expect(args.selected).toBe(true);
+  },
 };

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -126,20 +126,6 @@ test('renders hidden <input> element', () => {
   expect(input instanceof HTMLInputElement).toBeTruthy();
 });
 
-test('toggle switch per click', () => {
-  render(<Switch>Label</Switch>);
-
-  const { input, track } = getSwitchParts();
-
-  fireEvent.click(input);
-  expect(track.className).toMatchInlineSnapshot(`"relative"`);
-  expect(input.checked).toBeTruthy();
-
-  fireEvent.click(input);
-  expect(track.className).toMatchInlineSnapshot(`"relative"`);
-  expect(input.checked).toBeFalsy();
-});
-
 test('focus element and toggle switch per keyboard space', async () => {
   render(<Switch>Label</Switch>);
 

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -21,12 +21,12 @@ export interface SwitchProps extends Omit<RAC.SwitchProps, RemovedProps> {
   variant?: string;
   size?: string;
   /**
-   * The children of the component.
+   * The children of the switch.
    * @deprecated Will be removed in the next major version. Use `label` prop instead.
    */
   children?: ReactNode;
   /**
-   * The label of the component.
+   * Set the label of the switch.
    */
   label?: ReactNode;
 

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -20,7 +20,15 @@ type RemovedProps =
 export interface SwitchProps extends Omit<RAC.SwitchProps, RemovedProps> {
   variant?: string;
   size?: string;
+  /**
+   * The children of the component.
+   * @deprecated Will be removed in the next major version. Use `label` prop instead.
+   */
   children?: ReactNode;
+  /**
+   * The label of the component.
+   */
+  label?: ReactNode;
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
@@ -53,7 +61,7 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
       variant,
       size,
       width = 'full',
-      children,
+      label,
       selected,
       disabled,
       readOnly,
@@ -79,7 +87,11 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
           classNames.container
         )}
       >
-        <Label elementType="span">{children}</Label>
+        {(props.children || label) && (
+          <Label elementType="span">
+            {(props.children as ReactNode) || label}
+          </Label>
+        )}
         <div className="relative">
           <div className={classNames.track}>
             <div className={classNames.thumb} />


### PR DESCRIPTION
# Description

Added label prop to Switch and Checkbox,
deprecated the children prop as in `Slider` already exists

# What should be tested?

everything working as expected

# Reviewers:
@marigold-ui/developer
@marigold-ui/designer
