### PR TITLE
fix([DSTSUP-123]): Adjust z-index of table styles for sticky header

### DIFF
--- a/themes/theme-rui/src/components/Table.styles.ts
+++ b/themes/theme-rui/src/components/Table.styles.ts
@@ -14,7 +14,7 @@ export const Table: ThemeComponent<'Table'> = {
   ),
   thead: cva(
     // for sticky header
-    'bg-background/90 top-0 z-10 backdrop-blur-xs ',
+    'bg-background/90 top-0 z-1 backdrop-blur-xs ',
     {
       variants: {
         variant: {


### PR DESCRIPTION
# Description

When using a dropdown with a sticky header table, the header is set to the front, normally the listbox should cover it. 

# What should be tested?

everything working as expected

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
