### PR TITLE
fix([DST-802]): remove unneeded classnames from `<Modal>`

### DIFF
--- a/.changeset/kind-starfishes-remember.md
+++ b/.changeset/kind-starfishes-remember.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+fix([DST-802]): remove unneeded classnames from `<Modal>`

--- a/packages/components/src/Overlay/Modal.tsx
+++ b/packages/components/src/Overlay/Modal.tsx
@@ -35,11 +35,7 @@ const _Modal = forwardRef<
       open={open}
       variant="modal"
     >
-      <Modal
-        ref={ref}
-        className="relative flex w-full justify-center"
-        {...props}
-      >
+      <Modal ref={ref} {...props}>
         {props.children}
       </Modal>
     </Underlay>


### PR DESCRIPTION
# Description

Dialog was not dismissable when clicking on the left/right side, this was because of Modal classnames

# Reviewers:
@marigold-ui/developer
@marigold-ui/designer
