### PR TITLE
styles([DSTSUP-128]): Fix `disabled` styles for `Radio` and `Checkbox`

### DIFF
--- a/.changeset/forty-cheetahs-chew.md
+++ b/.changeset/forty-cheetahs-chew.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+styles([DSTSUP-128]): Fix `disabled` styles for `Radio` and `Checkbox`

--- a/themes/theme-rui/src/components/Checkbox.styles.ts
+++ b/themes/theme-rui/src/components/Checkbox.styles.ts
@@ -5,7 +5,7 @@ export const Checkbox: ThemeComponent<'Checkbox'> = {
     'grid size-4 shrink-0 place-content-center rounded',
     'border border-input shadow-sm shadow-black/5',
     'group-focus-visible/checkbox:util-focus-ring outline-none',
-    'group-disabled/checkbox:bg-disabled! group-disabled/checkbox:border-disabled! group-disabled/checkbox:text-disabled-foreground group-disabled/checkbox:cursor-not-allowed',
+    'group-disabled/checkbox:group-selected/checkbox:bg-disabled group-disabled/checkbox:border-disabled! group-disabled/checkbox:text-disabled-foreground group-disabled/checkbox:cursor-not-allowed',
     'group-selected/checkbox:border-brand group-selected/checkbox:bg-brand group-selected/checkbox:text-brand-foreground',
     'group-[indeterminate]/checkbox:border-brand group-[indeterminate]/checkbox:bg-brand group-[indeterminate]/checkbox:text-brand-foreground',
   ]),

--- a/themes/theme-rui/src/components/Radio.styles.ts
+++ b/themes/theme-rui/src/components/Radio.styles.ts
@@ -10,7 +10,7 @@ export const Radio: ThemeComponent<'Radio'> = {
     'aspect-square size-4 rounded-full',
     'border border-input shadow-sm shadow-black/5',
     'group-focus-visible/radio:util-focus-ring outline-none',
-    'group-disabled/radio:border-disabled',
+    'group-disabled/radio:group-selected/radio:bg-disabled group-disabled/radio:border-disabled! group-disabled/radio:cursor-not-allowed',
     'group-selected/radio:border-brand group-selected/radio:bg-brand group-selected/radio:text-brand-foreground',
   ]),
   group: cva(),


### PR DESCRIPTION
# Description

Changed disabled styles of Checkbox and Radio. Now they match each other

- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# What should be tested?

Check if they look the same

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
