### PR TITLE
styles([DST-823]): adjust RUI `<NumberField>` styles

### DIFF
--- a/.changeset/yellow-jobs-destroy.md
+++ b/.changeset/yellow-jobs-destroy.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+styles([DST-823]): adjust RUI `<NumberField>` background styles

--- a/themes/theme-rui/src/components/NumberField.styles.ts
+++ b/themes/theme-rui/src/components/NumberField.styles.ts
@@ -3,7 +3,7 @@ import { inputInvalid, inputReadOnly } from './Input.styles';
 
 export const NumberField: ThemeComponent<'NumberField'> = {
   group: cva([
-    'rounded-lg h-input',
+    'rounded-lg h-input bg-background',
     'has-focus-visible:util-focus-ring outline-none',
     inputInvalid,
     inputReadOnly,
@@ -17,7 +17,7 @@ export const NumberField: ThemeComponent<'NumberField'> = {
   ]),
   input: cva([
     'tabular-nums text-foreground px-3 py-2',
-    'min-w-0 flex-1',
+    'min-w-0 flex-1 bg-transparent',
     'group-[[data-stepper]]/field:text-center',
     'disabled:text-disabled-foreground disabled:bg-disabled',
   ]),


### PR DESCRIPTION
# Description

In Core system `<NumberField>` styles for background was not correctly applied. Adding `bg-background` on the group and `bg-transparent` on the input part works fixing it

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
