### PR TITLE
chore([DST-853]): Refa styles for `<Menu>` button

### DIFF
--- a/.changeset/breezy-roses-lick.md
+++ b/.changeset/breezy-roses-lick.md
@@ -1,0 +1,10 @@
+---
+"@marigold/components": patch
+"@marigold/system": patch
+"@marigold/theme-b2b": patch
+"@marigold/theme-core": patch
+"@marigold/theme-docs": patch
+"@marigold/theme-rui": patch
+---
+
+chore([DST-853]): Refa styles for <Menu> button

--- a/.changeset/breezy-roses-lick.md
+++ b/.changeset/breezy-roses-lick.md
@@ -7,4 +7,4 @@
 "@marigold/theme-rui": patch
 ---
 
-chore([DST-853]): Refa styles for <Menu> button
+chore([DST-853]): Refa styles for `<Menu>` button

--- a/packages/components/src/Menu/ActionMenu.tsx
+++ b/packages/components/src/Menu/ActionMenu.tsx
@@ -1,7 +1,6 @@
 import type RAC from 'react-aria-components';
-import { Menu, MenuTrigger } from 'react-aria-components';
+import { Button, Menu, MenuTrigger } from 'react-aria-components';
 import { SVG, useClassNames } from '@marigold/system';
-import { Button } from '../Button';
 import { Popover } from '../Overlay/Popover';
 
 interface ActionMenuProps extends RAC.MenuProps<object> {
@@ -19,7 +18,7 @@ export const ActionMenu = ({
   const classNames = useClassNames({ component: 'Menu', variant, size });
   return (
     <MenuTrigger>
-      <Button variant="menu" size="small" disabled={disabled}>
+      <Button className={classNames.button} isDisabled={disabled}>
         <SVG viewBox="0 0 24 24">
           <path d="M12.0117 7.47656C13.2557 7.47656 14.2734 6.45879 14.2734 5.21484C14.2734 3.9709 13.2557 2.95312 12.0117 2.95312C10.7678 2.95312 9.75 3.9709 9.75 5.21484C9.75 6.45879 10.7678 7.47656 12.0117 7.47656ZM12.0117 9.73828C10.7678 9.73828 9.75 10.7561 9.75 12C9.75 13.2439 10.7678 14.2617 12.0117 14.2617C13.2557 14.2617 14.2734 13.2439 14.2734 12C14.2734 10.7561 13.2557 9.73828 12.0117 9.73828ZM12.0117 16.5234C10.7678 16.5234 9.75 17.5412 9.75 18.7852C9.75 20.0291 10.7678 21.0469 12.0117 21.0469C13.2557 21.0469 14.2734 20.0291 14.2734 18.7852C14.2734 17.5412 13.2557 16.5234 12.0117 16.5234Z" />
         </SVG>

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -1,7 +1,6 @@
 import { useState } from '@storybook/preview-api';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, within } from '@storybook/test';
-import { vi } from 'vitest';
+import { expect, spyOn, userEvent, within } from '@storybook/test';
 import { Key } from '@react-types/shared';
 import { Button } from '../Button';
 import { ActionMenu } from './ActionMenu';
@@ -86,7 +85,10 @@ const meta = {
   args: {
     selectionMode: 'none',
     placement: 'bottom',
-    label: 'none',
+    variant: undefined,
+    size: undefined,
+    onOpenChange: undefined,
+    open: undefined,
   },
 } satisfies Meta<typeof Menu>;
 
@@ -97,7 +99,7 @@ export const Basic: Story = {
   tags: ['component-test'],
   render: args => {
     return (
-      <Menu {...args} label="Hogwarts Houses">
+      <Menu label="Hogwarts Houses" {...args}>
         <Menu.Item id="gryffindor">Gryffindor</Menu.Item>
         <Menu.Item id="hufflepuff">Hufflepuff</Menu.Item>
         <Menu.Item id="ravenclaw">Ravenclaw</Menu.Item>
@@ -171,20 +173,19 @@ export const OnActionMenu: Story = {
       </Menu>
     );
   },
-  args: {
-    onAction: fn(),
-  },
-  play: async ({ args }) => {
+  play: async () => {
     const canvas = within(document.body);
+    const alertMock = spyOn(window, 'alert').mockImplementation(() => {});
 
     const button = canvas.getByText('Choose');
+
     await userEvent.click(button);
+    await userEvent.click(canvas.getByText('🍔 Burger'));
 
-    const burger = canvas.getByText('🍔 Burger');
-    await userEvent.click(burger);
+    expect(alertMock).toHaveBeenCalledWith('burger');
+    expect(alertMock).not.toHaveBeenCalledWith('pizza');
 
-    expect(args.onAction).toHaveBeenCalledWith('burger');
-    expect(args.onAction).not.toHaveBeenCalledWith('pizza');
+    alertMock.mockRestore();
   },
 };
 

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -8,6 +8,7 @@ import { Menu } from './Menu';
 
 const meta = {
   title: 'Components/Menu',
+  component: Menu,
   argTypes: {
     open: {
       control: {
@@ -83,12 +84,7 @@ const meta = {
     },
   },
   args: {
-    selectionMode: 'none',
     placement: 'bottom',
-    variant: undefined,
-    size: undefined,
-    onOpenChange: undefined,
-    open: undefined,
   },
 } satisfies Meta<typeof Menu>;
 
@@ -97,16 +93,14 @@ type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {
   tags: ['component-test'],
-  render: args => {
-    return (
-      <Menu label="Hogwarts Houses" {...args}>
-        <Menu.Item id="gryffindor">Gryffindor</Menu.Item>
-        <Menu.Item id="hufflepuff">Hufflepuff</Menu.Item>
-        <Menu.Item id="ravenclaw">Ravenclaw</Menu.Item>
-        <Menu.Item id="slytherin">Slytherin</Menu.Item>
-      </Menu>
-    );
-  },
+  render: args => (
+    <Menu {...args} label="Hogwarts Houses">
+      <Menu.Item id="gryffindor">Gryffindor</Menu.Item>
+      <Menu.Item id="hufflepuff">Hufflepuff</Menu.Item>
+      <Menu.Item id="ravenclaw">Ravenclaw</Menu.Item>
+      <Menu.Item id="slytherin">Slytherin</Menu.Item>
+    </Menu>
+  ),
   play: async ({ step }) => {
     const canvas = within(document.body);
 

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,13 +1,11 @@
 import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { SVGProps } from 'react';
 import { vi } from 'vitest';
 import * as stories from './Menu.stories';
 
 // Setup
 // ---------------
-const user = userEvent.setup();
 
 const { Basic, BasicActionMenu, MenuSection } = composeStories(stories);
 

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -1,65 +1,15 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { composeStories } from '@storybook/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { SVGProps } from 'react';
+import { SVGProps } from 'react';
 import { vi } from 'vitest';
-import { Theme, cva } from '@marigold/system';
-import { Button } from '../Button';
-import { setup } from '../test.utils';
-import { ActionMenu } from './ActionMenu';
-import { Menu } from './Menu';
+import * as stories from './Menu.stories';
 
 // Setup
 // ---------------
 const user = userEvent.setup();
 
-const theme: Theme = {
-  name: 'test',
-  components: {
-    Button: cva('disabled:bg-disabled-bg p-3'),
-    Divider: cva(),
-
-    Menu: {
-      container: cva('bg-white focus:text-pink-600', {
-        variants: {
-          variant: {
-            one: 'bg-pink-900',
-          },
-          size: {
-            large: 'p-5',
-          },
-        },
-      }),
-      item: cva('text-black focus:text-pink-600', {
-        variants: {
-          variant: {
-            one: 'text-white',
-          },
-          size: {
-            large: 'p-2',
-          },
-        },
-      }),
-      section: cva('text-pink-300', {
-        variants: {
-          variant: {
-            one: 'text-black',
-          },
-        },
-      }),
-    },
-    Underlay: cva(),
-    Header: cva(),
-    Popover: cva(['mt-0.5'], {
-      variants: {
-        variant: {
-          top: ['mb-0.5'],
-        },
-      },
-    }),
-  },
-};
-
-const { render } = setup({ theme });
+const { Basic, OnActionMenu } = composeStories(stories);
 
 /**
  * We need to mock `matchMedia` because JSOM does not
@@ -74,128 +24,23 @@ const mockMatchMedia = (matches: string[]) =>
 window.matchMedia = mockMatchMedia(['(max-width: 600px)']);
 
 test('renders the button but no menu by default', () => {
-  render(
-    <Menu label="Choose">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-
-  const button = screen.queryByText('Choose');
-  const burger = screen.queryByText('Burger');
-  const pizza = screen.queryByText('Pizza');
+  render(<Basic />);
+  const button = screen.queryByText('Hogwarts Houses');
+  const gryffindor = screen.queryByText('Gryffindor');
+  const hufflepuff = screen.queryByText('Hufflepuff');
+  const ravenclaw = screen.queryByText('Ravenclaw');
+  const slytherin = screen.queryByText('Slytherin');
 
   expect(button).toBeInTheDocument();
-  expect(burger).not.toBeInTheDocument();
-  expect(pizza).not.toBeInTheDocument();
-});
-
-test('opens menu when trigger is clicked', () => {
-  window.matchMedia = mockMatchMedia([
-    'screen and (min-width: 40em)',
-    'screen and (min-width: 52em)',
-    'screen and (min-width: 64em)',
-  ]);
-  render(
-    <Menu label="Choose">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-
-  const button = screen.getByText('Choose');
-  fireEvent.click(button);
-
-  const burger = screen.getByText('Burger');
-  const pizza = screen.getByText('Pizza');
-
-  expect(burger.className).toMatchInlineSnapshot(
-    `"text-black focus:text-pink-600"`
-  );
-
-  expect(pizza.className).toMatchInlineSnapshot(
-    `"text-black focus:text-pink-600"`
-  );
-});
-
-test('closes menu when item is selected', () => {
-  window.matchMedia = mockMatchMedia([
-    'screen and (min-width: 40em)',
-    'screen and (min-width: 52em)',
-    'screen and (min-width: 64em)',
-  ]);
-  render(
-    <Menu label="Choose">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-
-  const button = screen.getByText('Choose');
-  fireEvent.click(button);
-
-  // Select burger from menu
-  const burger = screen.getByText('Burger');
-  expect(burger).toBeInTheDocument();
-  fireEvent.click(burger);
-
-  const pizza = screen.queryByText('Pizza');
-  expect(burger).not.toBeInTheDocument();
-  expect(pizza).not.toBeInTheDocument();
-});
-
-test('closes menu when trigger is clicked', () => {
-  render(
-    <Menu label="Choose">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-
-  const button = screen.getByText('Choose');
-  user.click(button);
-  user.click(button);
-
-  const burger = screen.queryByText('Burger');
-  const pizza = screen.queryByText('Pizza');
-
-  expect(burger).not.toBeInTheDocument();
-  expect(pizza).not.toBeInTheDocument();
-});
-
-test('closes menu when clicked outside', async () => {
-  render(
-    <>
-      <Button>outside</Button>
-
-      <Menu label="Choose">
-        <Menu.Item key="burger">Burger</Menu.Item>
-        <Menu.Item key="pizza">Pizza</Menu.Item>
-      </Menu>
-    </>
-  );
-
-  const button = screen.getByText('Choose');
-  await user.click(button);
-
-  const burger = screen.getByText('Burger');
-  const pizza = screen.queryByText('Pizza');
-
-  const outside = screen.getByText('outside');
-  await user.click(outside);
-
-  expect(burger).not.toBeInTheDocument();
-  expect(pizza).not.toBeInTheDocument();
+  expect(gryffindor).not.toBeInTheDocument();
+  expect(hufflepuff).not.toBeInTheDocument();
+  expect(ravenclaw).not.toBeInTheDocument();
+  expect(slytherin).not.toBeInTheDocument();
 });
 
 test('return action item', async () => {
   const spy = vi.fn();
-  render(
-    <Menu label="Choose" onAction={spy}>
-      <Menu.Item id="burger">Burger</Menu.Item>
-      <Menu.Item id="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
+  render(<OnActionMenu />);
 
   const button = screen.getByText('Choose');
   await user.click(button);

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -4,9 +4,6 @@ import { SVGProps } from 'react';
 import { vi } from 'vitest';
 import * as stories from './Menu.stories';
 
-// Setup
-// ---------------
-
 const { Basic, BasicActionMenu, MenuSection } = composeStories(stories);
 
 /**
@@ -36,33 +33,6 @@ test('renders the button but no menu by default', () => {
   expect(slytherin).not.toBeInTheDocument();
 });
 
-test('supports "Menu" variant classnames from theme', () => {
-  render(<Basic data-testid="menu" variant="one" />);
-  const button = screen.getByText('Hogwarts Houses');
-  fireEvent.click(button);
-
-  const menu = screen.getByRole('menu');
-  const item = screen.getByText('Gryffindor');
-
-  expect(menu.className).toMatchInlineSnapshot(
-    `"list-none break-words rounded-[2px] border p-0 sm:max-h-[75ch] md:max-h-[75vh] lg:max-h-[45vh] flex flex-col overflow-y-auto overflow-x-hidden border-border-inverted bg-surface-overlay border-solid"`
-  );
-  expect(item.className).toMatchInlineSnapshot(
-    `"cursor-pointer p-1 focus:outline-0 disabled:text-text-base-disabled disabled:cursor-not-allowed data-hovered:text-text-inverted data-hovered:bg-linear-to-t from-highlight-start/80 to-highlight-end/90 text-xs data-selected:bg-bg-selected"`
-  );
-});
-
-test('supports "Menu" sizes from theme', () => {
-  render(<Basic data-testid="menu" size="large" />);
-  const button = screen.getByRole('button');
-  fireEvent.click(button);
-
-  const item = screen.getByText('Gryffindor');
-  expect(item.className).toMatchInlineSnapshot(
-    `"cursor-pointer p-1 focus:outline-0 disabled:text-text-base-disabled disabled:cursor-not-allowed data-hovered:text-text-inverted data-hovered:bg-linear-to-t from-highlight-start/80 to-highlight-end/90 text-xs data-selected:bg-bg-selected"`
-  );
-});
-
 test('renders action menu', () => {
   render(<BasicActionMenu />);
   const button = screen.getByRole('button');
@@ -75,7 +45,7 @@ test('renders action menu', () => {
 });
 
 test('supports open property', () => {
-  render(<Basic data-testid="menu" open={true} />);
+  render(<Basic open={true} />);
 
   const item = screen.getByText('Gryffindor');
   expect(item).toBeInTheDocument();

--- a/packages/components/src/Menu/Menu.test.tsx
+++ b/packages/components/src/Menu/Menu.test.tsx
@@ -9,7 +9,7 @@ import * as stories from './Menu.stories';
 // ---------------
 const user = userEvent.setup();
 
-const { Basic, OnActionMenu } = composeStories(stories);
+const { Basic, BasicActionMenu, MenuSection } = composeStories(stories);
 
 /**
  * We need to mock `matchMedia` because JSOM does not
@@ -38,125 +38,62 @@ test('renders the button but no menu by default', () => {
   expect(slytherin).not.toBeInTheDocument();
 });
 
-test('return action item', async () => {
-  const spy = vi.fn();
-  render(<OnActionMenu />);
-
-  const button = screen.getByText('Choose');
-  await user.click(button);
-
-  const burger = screen.getByText('Burger');
-  await user.click(burger);
-
-  expect(spy).toHaveBeenCalledWith('burger');
-  expect(spy).not.toHaveBeenCalledWith('pizza');
-});
-
-test('uses base classes from "Menu" in theme', () => {
-  render(
-    <Menu data-testid="menu" label="Choose">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-  const button = screen.getByText('Choose');
-  fireEvent.click(button);
-
-  const menu = screen.getByRole('menu');
-  expect(menu).toHaveClass(`bg-white`);
-});
-
 test('supports "Menu" variant classnames from theme', () => {
-  render(
-    <Menu data-testid="menu" label="Choose" variant="one">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
-  const button = screen.getByText('Choose');
+  render(<Basic data-testid="menu" variant="one" />);
+  const button = screen.getByText('Hogwarts Houses');
   fireEvent.click(button);
 
   const menu = screen.getByRole('menu');
-  const item = screen.getByText('Burger');
+  const item = screen.getByText('Gryffindor');
 
   expect(menu.className).toMatchInlineSnapshot(
-    `"focus:text-pink-600 bg-pink-900"`
+    `"list-none break-words rounded-[2px] border p-0 sm:max-h-[75ch] md:max-h-[75vh] lg:max-h-[45vh] flex flex-col overflow-y-auto overflow-x-hidden border-border-inverted bg-surface-overlay border-solid"`
   );
   expect(item.className).toMatchInlineSnapshot(
-    `"text-black focus:text-pink-600"`
+    `"cursor-pointer p-1 focus:outline-0 disabled:text-text-base-disabled disabled:cursor-not-allowed data-hovered:text-text-inverted data-hovered:bg-linear-to-t from-highlight-start/80 to-highlight-end/90 text-xs data-selected:bg-bg-selected"`
   );
 });
 
 test('supports "Menu" sizes from theme', () => {
-  render(
-    <Menu data-testid="menu" label="Choose" size="large">
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
+  render(<Basic data-testid="menu" size="large" />);
   const button = screen.getByRole('button');
   fireEvent.click(button);
 
-  const item = screen.getByText('Burger');
+  const item = screen.getByText('Gryffindor');
   expect(item.className).toMatchInlineSnapshot(
-    `"text-black focus:text-pink-600"`
+    `"cursor-pointer p-1 focus:outline-0 disabled:text-text-base-disabled disabled:cursor-not-allowed data-hovered:text-text-inverted data-hovered:bg-linear-to-t from-highlight-start/80 to-highlight-end/90 text-xs data-selected:bg-bg-selected"`
   );
 });
 
 test('renders action menu', () => {
-  render(
-    <>
-      <ActionMenu>
-        <Menu.Item key="one">Settings</Menu.Item>
-        <Menu.Item key="two">Delete</Menu.Item>
-      </ActionMenu>
-    </>
-  );
+  render(<BasicActionMenu />);
   const button = screen.getByRole('button');
+
   expect(button).toBeInTheDocument();
   fireEvent.click(button);
+
   const item = screen.getByText('Settings');
   expect(item).toBeInTheDocument();
 });
 
 test('supports open property', () => {
-  render(
-    <Menu data-testid="menu" label="Choose" open={true}>
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
+  render(<Basic data-testid="menu" open={true} />);
 
-  const item = screen.getByText('Burger');
+  const item = screen.getByText('Gryffindor');
   expect(item).toBeInTheDocument();
 });
 
 test('supports onOpenChange property', () => {
   const onOpenChange = vi.fn();
-  render(
-    <Menu data-testid="menu" label="Choose" onOpenChange={() => onOpenChange()}>
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
-  );
+  render(<Basic data-testid="menu" onOpenChange={() => onOpenChange()} />);
   expect(onOpenChange).toBeCalledTimes(0);
   fireEvent.click(screen.getByRole('button'));
   expect(onOpenChange).toBeCalledTimes(1);
 });
 
 test('supports Menu with sections', () => {
-  render(
-    <Menu aria-label="Menu with sections" open>
-      <Menu.Section title="Food">
-        <Menu.Item key="burger">🍔 Burger</Menu.Item>
-        <Menu.Item key="pizza">🍕 Pizza</Menu.Item>
-      </Menu.Section>
-      <Menu.Section title="Fruits">
-        <Menu.Item key="apple">🍎 Apple</Menu.Item>
-        <Menu.Item key="banana">🍌 Banana</Menu.Item>
-      </Menu.Section>
-    </Menu>
-  );
+  render(<MenuSection aria-label="Menu with sections" open />);
+
   expect(screen.getByText('Food')).toBeInTheDocument();
   expect(screen.getByText('Fruits')).toBeInTheDocument();
 });
@@ -169,14 +106,11 @@ test('pass "aria-label" to button (when you use a menu with only an icon)', () =
   );
 
   render(
-    <Menu
+    <Basic
       data-testid="menu"
       aria-label="Descriptive label for the button"
       label={<Icon />}
-    >
-      <Menu.Item key="burger">Burger</Menu.Item>
-      <Menu.Item key="pizza">Pizza</Menu.Item>
-    </Menu>
+    />
   );
 
   const btn = screen.getByLabelText('Descriptive label for the button');

--- a/packages/components/src/Menu/Menu.tsx
+++ b/packages/components/src/Menu/Menu.tsx
@@ -1,8 +1,7 @@
 import { Key, ReactNode } from 'react';
 import type RAC from 'react-aria-components';
-import { Menu, MenuTrigger } from 'react-aria-components';
+import { Button, Menu, MenuTrigger } from 'react-aria-components';
 import { useClassNames } from '@marigold/system';
-import { Button } from '../Button';
 import type { PopoverProps } from '../Overlay/Popover';
 import { Popover } from '../Overlay/Popover';
 import { MenuItem } from './MenuItem';
@@ -64,7 +63,11 @@ const _Menu = ({
 
   return (
     <MenuTrigger {...props}>
-      <Button variant="menu" disabled={disabled} aria-label={ariaLabel}>
+      <Button
+        className={classNames.button}
+        aria-label={ariaLabel}
+        isDisabled={disabled}
+      >
         {label}
       </Button>
       <Popover open={open} placement={placement}>

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -90,7 +90,7 @@ export type Theme = {
       ComponentStyleFunction<string, string>
     >;
     Menu?: Record<
-      'container' | 'section' | 'item',
+      'container' | 'section' | 'item' | 'button',
       ComponentStyleFunction<string, string>
     >;
     Modal?: ComponentStyleFunction<string, string>;

--- a/themes/theme-b2b/src/components/Button.styles.ts
+++ b/themes/theme-b2b/src/components/Button.styles.ts
@@ -29,9 +29,6 @@ export const Button: ThemeComponent<'Button'> = cva(
         text: [
           'text-text-base hover:bg-bg-brand-hover hover:text-text-inverted active:bg-bg-brand-active active:text-text-inverted',
         ],
-        menu: [
-          'text-text-base bg-bg-surface hover:text-text-inverted hover:bg-bg-brand-hover',
-        ],
         icon: [
           'h-auto border-none bg-transparent px-0 leading-none',
           'disabled:bg-transparent',

--- a/themes/theme-b2b/src/components/Menu.styles.ts
+++ b/themes/theme-b2b/src/components/Menu.styles.ts
@@ -11,4 +11,7 @@ export const Menu: ThemeComponent<'Menu'> = {
     'disabled:text-text-base-disabled',
   ]),
   section: cva('text-text-accent border-t px-4 py-1  text-sm'),
+  button: cva(
+    'text-text-base bg-bg-surface hover:text-text-inverted hover:bg-bg-brand-hover'
+  ),
 };

--- a/themes/theme-core/src/components/Menu.styles.ts
+++ b/themes/theme-core/src/components/Menu.styles.ts
@@ -15,4 +15,11 @@ export const Menu: ThemeComponent<'Menu'> = {
     'data-selected:bg-bg-selected',
   ]),
   section: cva('text-text-base border-t p-1 text-xs font-normal'),
+  button: cva([
+    'border-border-base bg-bg-inverted text-text-base ease-ease-out h-component cursor-pointer rounded-xs border px-4 py-0 text-sm leading-[22px] transition-all duration-200 disabled:cursor-none',
+    'disabled:border-border-base-disabled disabled:bg-bg-inverted-disabled disabled:text-text-base-disabled disabled:cursor-not-allowed',
+    'pending:border-border-base-disabled pending:bg-bg-inverted-disabled pending:text-text-base-disabled pending:cursor-not-allowed',
+    'focus-visible:outline-outline-focus focus-visible:outline focus-visible:outline-offset-1 outline-hidden',
+    'hover:bg-bg-inverted-hover',
+  ]),
 };

--- a/themes/theme-docs/src/components/Button.styles.ts
+++ b/themes/theme-docs/src/components/Button.styles.ts
@@ -4,7 +4,6 @@ export const Button: ThemeComponent<'Button'> = cva('flex gap-2 rounded-xs', {
   variants: {
     variant: {
       ghost: 'text-secondary-700 hover:text-secondary-900 p-0',
-      menu: 'text-secondary-700 hover:bg-secondary-400/20 h-8 rounded-lg px-1',
       sunken:
         'text-secondary-600 hover:bg-secondary-400/20 bg-secondary-400/10 h-8 justify-start rounded-lg',
       inverted: 'bg-secondary-100',

--- a/themes/theme-docs/src/components/Menu.styles.ts
+++ b/themes/theme-docs/src/components/Menu.styles.ts
@@ -30,4 +30,7 @@ export const Menu: ThemeComponent<'Menu'> = {
       },
     },
   }),
+  button: cva(
+    'text-secondary-700 hover:bg-secondary-400/20 h-8 rounded-lg px-1'
+  ),
 };

--- a/themes/theme-rui/src/components/Menu.styles.ts
+++ b/themes/theme-rui/src/components/Menu.styles.ts
@@ -3,7 +3,7 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const Menu: ThemeComponent<'Menu'> = {
   container: cva(['text-foreground z-50 overflow-hidden rounded-md p-1']),
   item: cva([
-    'focus:bg-focus focus:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none disabled:text-disabled-foreground',
+    'focus:bg-focus focus:text-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none disabled:text-disabled-foreground',
   ]),
   section: cva(
     'text-muted-foreground px-2 py-1.5 text-xs font-medium border-t border-t-border in-first:border-t-0'

--- a/themes/theme-rui/src/components/Menu.styles.ts
+++ b/themes/theme-rui/src/components/Menu.styles.ts
@@ -10,7 +10,7 @@ export const Menu: ThemeComponent<'Menu'> = {
   ),
   button: cva([
     'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md h-button px-4 py-2',
-    'text-sm font-medium outline-none',
+    'text-sm font-medium outline-none cursor-pointer',
     'border border-input bg-background shadow-xs',
     'hover:bg-hover hover:text-foreground',
     'transition-[color,box-shadow]',

--- a/themes/theme-rui/src/components/Menu.styles.ts
+++ b/themes/theme-rui/src/components/Menu.styles.ts
@@ -1,13 +1,20 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const Menu: ThemeComponent<'Menu'> = {
-  container: cva([
-    'text-foreground z-50 min-w-40 overflow-hidden rounded-md p-1',
-  ]),
+  container: cva(['text-foreground z-50 overflow-hidden rounded-md p-1']),
   item: cva([
     'focus:bg-focus focus:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none disabled:text-disabled-foreground',
   ]),
   section: cva(
     'text-muted-foreground px-2 py-1.5 text-xs font-medium border-t border-t-border in-first:border-t-0'
   ),
+  button: cva([
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md h-button px-4 py-2',
+    'text-sm font-medium outline-none',
+    'border border-input bg-background shadow-xs',
+    'hover:bg-hover hover:text-foreground',
+    'transition-[color,box-shadow]',
+    'disabled:pointer-not-allowed disabled:bg-disabled disabled:text-disabled-foreground',
+    'focus-visible:util-focus-ring',
+  ]),
 };


### PR DESCRIPTION
# Description

Menu does not match Origin UI standards, that because inside our Menu component we use a variant menu which does not exists on RUI Button. 
My proposal is to take the menu button styles out of the button and add it to the menu

- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# What should be tested?

everything working as expected and styles are the same as origin ui 

# Reviewers:

@marigold-ui/developer
@marigold-ui/designer
