### PR TITLE
fix([DST-867]): Prevent focus ring from being cut of in `Accordion`

### DIFF
--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -46,7 +46,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
       },
     }
   ),
-  content: cva('overflow-hidden in-data-[expanded]:pb-2'),
+  content: cva('in-data-[expanded]:pb-2'),
   icon: cva(
     'pointer-events-none shrink-0 opacity-60 transition-transform duration-200'
   ),


### PR DESCRIPTION
## For Testing: Storybook -> Accordion/Basic -> Open "Informations" drawer, focus on `input`