### PR TITLE
chore([DST-882]): Remove default right alignment in RUI table

### DIFF
--- a/.changeset/quiet-buses-kick.md
+++ b/.changeset/quiet-buses-kick.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+chore([DST-882]): Remove default right alignment in RUI table

--- a/themes/theme-rui/src/components/Table.styles.ts
+++ b/themes/theme-rui/src/components/Table.styles.ts
@@ -37,7 +37,7 @@ export const Table: ThemeComponent<'Table'> = {
   }),
   header: cva(
     [
-      'h-12 px-3 align-middle font-medium text-muted-foreground last:text-right',
+      'h-12 px-3 align-middle font-medium text-muted-foreground',
       'focus-visible:outline-2 outline-offset-2 outline-ring/70',
     ],
     {
@@ -73,7 +73,7 @@ export const Table: ThemeComponent<'Table'> = {
   ),
   cell: cva(
     [
-      'p-3 align-middle last:text-right',
+      'p-3 align-middle',
       'focus-visible:outline-2 outline-offset-2 outline-ring/70',
     ],
     {


### PR DESCRIPTION
# Description

removed default right aligment
- [ ] This change requires a UI-Kit update - inform @tirado-rx @benjirsvx

# What should be tested?

## Are they some special informations required to test something?

# Reviewers:

Which persons should review this PR? Add person with @mentions

Examples:
@marigold-ui/developer
@marigold-ui/designer
