### PR TITLE
bugfix([DST-934]): fix mobile navigation

### DIFF
--- a/themes/theme-docs/src/components/CloseButton.styles.ts
+++ b/themes/theme-docs/src/components/CloseButton.styles.ts
@@ -1,0 +1,11 @@
+import type { ThemeComponent } from '@marigold/system';
+import { cva } from '@marigold/system';
+
+export const CloseButton: ThemeComponent<'CloseButton'> = cva([
+  'flex items-center justify-center whitespace-nowrap',
+  'cursor-pointer',
+  'transition-[color,box-shadow]',
+  'mixin-ring-focus-visible',
+  'rounded',
+  '[&_svg]:size-4 [&_svg]:opacity-60 [&_svg]:transition-opacity hover:[&_svg]:opacity-100',
+]);

--- a/themes/theme-docs/src/components/index.ts
+++ b/themes/theme-docs/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Button.styles';
 export * from './Card.styles';
+export * from './CloseButton.styles';
 export * from './Dialog.styles';
 export * from './Header.styles';
 export * from './Headline.styles';


### PR DESCRIPTION
# Description

Close Button styles for docs were missing, so it crashed when mobile navigation was opened


