### PR TITLE
[DST-986]: adjusted the vrt workflow

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -1,13 +1,13 @@
 name: Visual-Regression-Tests
 on:
-  push:
-    branches:
-      - changeset-release/main
-      - '!renovate/**' # shouldn't trigger when changes coming from renovate branches
-#  pull_request - could be used with turbosnap to keep snapshots low
+  pull_request:
+    branches-ignore:
+      - 'renovate/**'
+    types: [opened, synchronize, ready_for_review, labeled]
 
 jobs:
   chromatic:
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'run-vrt')
     name: Visual Regression Tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

The VRT workflow should be triggered again for every PR with the following restrictions:

- not for branches created by renovate
- PR isn't a draft
- PR hasn't the label run-vrt

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
