### PR TITLE
docs: fix PropsTable component reference in Toast documentation

### DIFF
--- a/docs/content/components/overlay/toast/toast.mdx
+++ b/docs/content/components/overlay/toast/toast.mdx
@@ -55,4 +55,4 @@ All Toasts can be dismissed with `clearToasts`.
 
 ### Toast
 
-<PropsTable component={title} />
+<PropsTable component="ToastProvider" />


### PR DESCRIPTION
# Description

Props table for Toast was not working

# Reviewers:

@marigold-ui/developer
