### PR TITLE
[DST-1027]: remove linedTable variant from Table component

### DIFF
--- a/docs/content/components/collection/table/table-async.demo.tsx
+++ b/docs/content/components/collection/table/table-async.demo.tsx
@@ -40,7 +40,6 @@ export default () => {
       sortDescriptor={list.sortDescriptor}
       onSortChange={list.sort}
       stretch
-      variant="linedTable"
     >
       <Table.Header>
         <Table.Column key="name" allowsSorting width="2/5">

--- a/docs/content/components/collection/table/table-numeric.demo.tsx
+++ b/docs/content/components/collection/table/table-numeric.demo.tsx
@@ -41,12 +41,7 @@ const rows = [
 ] as const;
 
 export default () => (
-  <Table
-    aria-label="Data Table"
-    selectionMode="multiple"
-    size="compact"
-    variant="linedTable"
-  >
+  <Table aria-label="Data Table" selectionMode="multiple" size="compact">
     <Table.Header>
       <Table.Column>Event</Table.Column>
       <Table.Column>Date</Table.Column>

--- a/docs/content/components/overlay/menu/menu-action-table.demo.tsx
+++ b/docs/content/components/overlay/menu/menu-action-table.demo.tsx
@@ -35,7 +35,7 @@ export default () => {
   };
 
   return (
-    <Table aria-label="Data Table" size="compact" variant="linedTable" stretch>
+    <Table aria-label="Data Table" size="compact" stretch>
       <Table.Header>
         <Table.Column>ID</Table.Column>
         <Table.Column>Event Name</Table.Column>

--- a/docs/content/foundations/accessibility/accessibility-keyboard.demo.tsx
+++ b/docs/content/foundations/accessibility/accessibility-keyboard.demo.tsx
@@ -93,7 +93,6 @@ export default () => {
         </header>
         <Table
           aria-labelledby="table-header table-description"
-          variant="linedTable"
           selectionMode="multiple"
           stretch
           selectedKeys={selected}

--- a/packages/components/src/Table/Table.stories.tsx
+++ b/packages/components/src/Table/Table.stories.tsx
@@ -59,7 +59,7 @@ const meta = {
       control: {
         type: 'select',
       },
-      options: ['default', 'grid', 'linedTable', 'muted'],
+      options: ['default', 'master', 'muted', 'muted', 'admin', 'grid'],
       description: 'variant for the table',
     },
     size: {


### PR DESCRIPTION
# Description
 removed linedTable variant from Table components

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
