### PR TITLE
Fix([DSTSUP-181]): Adjust Accordion.Header styles to support full width

### DIFF
--- a/.changeset/loud-badgers-wave.md
+++ b/.changeset/loud-badgers-wave.md
@@ -1,0 +1,6 @@
+---
+"@marigold/components": patch
+"@marigold/theme-rui": patch
+---
+
+Fix([DSTSUP-181]): Adjust Accordion.Header styles to support full width

--- a/packages/components/src/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/Accordion/Accordion.stories.tsx
@@ -58,24 +58,20 @@ type Story = StoryObj<typeof Accordion>;
 export const Basic: Story = {
   render: args => (
     <Accordion {...args}>
-      <Accordion.Item>
+      <Accordion.Item id="1">
         <Accordion.Header>Informations</Accordion.Header>
-        <Accordion.Content>
-          <Headline level={3}>Some Informations</Headline>
-          <TextField label="Name" />
-        </Accordion.Content>
+        <Accordion.Content>Here are some infos</Accordion.Content>
       </Accordion.Item>
-      <Accordion.Item>
+      <Accordion.Item id="2">
         <Accordion.Header>Personal Settings</Accordion.Header>
         <Accordion.Content>
           Some longer Text to see if it looks good
         </Accordion.Content>
       </Accordion.Item>
-      <Accordion.Item>
+      <Accordion.Item id="3">
         <Accordion.Header>Billing Adress</Accordion.Header>
         <Accordion.Content>
-          <Headline level={3}>Some Informations</Headline>
-          <Button>Don&apos;t click me</Button>
+          Please provide your billing adress
         </Accordion.Content>
       </Accordion.Item>
     </Accordion>

--- a/packages/components/src/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/Accordion/Accordion.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 import { Accessible, Parking, SettingDots } from '@marigold/icons';
 import { Badge } from '../Badge';
 import { Button } from '../Button/Button';
@@ -76,6 +77,24 @@ export const Basic: Story = {
       </Accordion.Item>
     </Accordion>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+
+    const item = canvas.getByText('Informations');
+    const itemtwo = canvas.getByText('Personal Settings');
+
+    await user.click(item);
+    await user.click(itemtwo);
+
+    expect(canvas.getByText('Here are some infos')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    expect(
+      canvas.getByText('Some longer Text to see if it looks good')
+    ).toHaveAttribute('aria-hidden', 'false');
+  },
 };
 
 let items = [

--- a/packages/components/src/Accordion/AccordionHeader.tsx
+++ b/packages/components/src/Accordion/AccordionHeader.tsx
@@ -17,9 +17,9 @@ export const AccordionHeader = ({ children }: AccordionHeaderProps) => {
   const { isExpanded } = useContext(DisclosureStateContext)!;
 
   return (
-    <Heading className="flex-1">
+    <Heading>
       <Button slot="trigger" className={classNames.header}>
-        {children}
+        <div className="flex-1">{children}</div>
         <ChevronDown
           className={cn(classNames.icon, isExpanded && 'rotate-180')}
         />

--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -29,7 +29,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
   }),
   header: cva(
     [
-      'flex flex-1 w-full items-center justify-between gap-4 rounded-md py-2 cursor-pointer',
+      'flex w-full items-center justify-between gap-4 rounded-md py-2 cursor-pointer',
       'text-left text-sm font-semibold leading-6 transition-all',
       'hover:no-underline',
       'disabled:cursor-not-allowed disabled:text-disabled-foreground',


### PR DESCRIPTION
# Description

Accordion.Header had messed up styles with `flex-1`. Moved it to the right place. So it works also again with Inline inside of it. See Story Core Example

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
