### PR TITLE
feat([DST-1037]): Add `description` (help text) to `<Checkbox>` component

### DIFF
--- a/.changeset/shiny-kangaroos-fry.md
+++ b/.changeset/shiny-kangaroos-fry.md
@@ -1,0 +1,8 @@
+---
+"@marigold/docs": minor
+"@marigold/components": minor
+"@marigold/system": minor
+"@marigold/theme-rui": minor
+---
+
+feat([DST-1037]): Add `description` (hept text) to `<Checkbox>` component

--- a/.changeset/shiny-kangaroos-fry.md
+++ b/.changeset/shiny-kangaroos-fry.md
@@ -5,4 +5,4 @@
 "@marigold/theme-rui": minor
 ---
 
-feat([DST-1037]): Add `description` (hept text) to `<Checkbox>` component
+feat([DST-1037]): Add `description` (help text) to `<Checkbox>` component

--- a/docs/content/components/form/checkbox/checkbox-description.demo.tsx
+++ b/docs/content/components/form/checkbox/checkbox-description.demo.tsx
@@ -1,0 +1,8 @@
+import { Checkbox } from '@marigold/components';
+
+export default () => (
+  <Checkbox
+    label="Enable SSL/TLS"
+    description="This encrypts the data transferred between your browser and our server."
+  />
+);

--- a/docs/content/components/form/checkbox/checkbox.mdx
+++ b/docs/content/components/form/checkbox/checkbox.mdx
@@ -171,6 +171,12 @@ It’s commonly used in "Select All" scenarios, where selecting only some of the
 
 <ComponentDemo file="./checkbox-indeterminate.demo.tsx" />
 
+### Description
+
+Adding a description to a checkbox is helpful when the label alone isn't enough to explain its function. Use a description to clarify complex or ambiguous actions, such as when the checkbox triggers a permanent change or has significant consequences. It's also useful for explaining technical terms or jargon that might be unfamiliar to the user. Finally, include a description to provide important context or warnings, like legal disclaimers or potential costs, ensuring the user fully understands what they're agreeing to.
+
+<ComponentDemo file="./checkbox-description.demo.tsx" />
+
 ## Props
 
 <StorybookHintMessage component={title} />

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -57,6 +57,12 @@ const meta = {
       },
       description: 'Padding y (top and bottom)',
     },
+    description: {
+      control: {
+        type: 'text',
+      },
+      description: 'Description text',
+    },
   },
   args: {
     readOnly: false,

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -90,8 +90,7 @@ export const Controlled: Story = {
   args: {
     onChange: fn(),
   },
-  play: async ({ args, canvasElement }) => {
-    const canvas = within(canvasElement);
+  play: async ({ args, canvas }) => {
     const input = canvas.getByLabelText<HTMLInputElement>('This is a Checkbox');
 
     await userEvent.click(input);
@@ -108,8 +107,7 @@ export const ReadOnly: Story = {
     defaultChecked: true,
     readOnly: true,
   },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+  play: async ({ canvas }) => {
     const checkbox =
       canvas.getByLabelText<HTMLInputElement>('This is a Checkbox');
     const component = canvas.getByText('This is a Checkbox');
@@ -117,5 +115,23 @@ export const ReadOnly: Story = {
     await userEvent.click(component);
 
     await expect(checkbox.checked).toBeTruthy();
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    description: 'This is a description',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const checkbox = await canvas.findByRole('checkbox');
+    const description = await canvas.queryByText('This is a description');
+
+    const helpTextId = description?.getAttribute('id');
+    const checkboxDescribedBy = checkbox.getAttribute('aria-describedby');
+
+    expect(description).toBeInTheDocument();
+    expect(checkboxDescribedBy).toBe(helpTextId);
   },
 };

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -44,7 +44,7 @@ test('check if all slot class names are applied correctly', () => {
   const label = screen.getByText('With Label');
 
   expect(label.parentElement?.className).toMatchInlineSnapshot(
-    `"group/checkbox flex items-center gap-[0.5rem] data-disabled:cursor-not-allowed cursor-pointer read-only:cursor-default"`
+    `"group/checkbox flex items-center data-disabled:cursor-not-allowed cursor-pointer read-only:cursor-default gap-2"`
   );
   expect(getVisibleCheckbox()?.className).toMatchInlineSnapshot(
     `"grow-0 basis-4 items-center justify-center p-px bg-white border-solid grid size-4 shrink-0 place-content-center rounded border border-input shadow-xs group-focus-visible/checkbox:util-focus-ring outline-none group-disabled/checkbox:group-selected/checkbox:bg-disabled group-disabled/checkbox:border-disabled! group-disabled/checkbox:text-disabled-foreground group-disabled/checkbox:cursor-not-allowed group-selected/checkbox:border-brand group-selected/checkbox:bg-brand group-selected/checkbox:text-brand-foreground group-[indeterminate]/checkbox:border-brand group-[indeterminate]/checkbox:bg-brand group-[indeterminate]/checkbox:text-brand-foreground"`
@@ -60,7 +60,7 @@ test('correct class name is set on size small', () => {
   const label = screen.getByText('With Label');
 
   expect(label.parentElement?.className).toMatchInlineSnapshot(
-    `"group/checkbox flex items-center gap-[0.5rem] data-disabled:cursor-not-allowed cursor-pointer read-only:cursor-default"`
+    `"group/checkbox flex items-center data-disabled:cursor-not-allowed cursor-pointer read-only:cursor-default gap-2"`
   );
 });
 

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -1,16 +1,54 @@
 import type {
   ForwardRefExoticComponent,
+  PropsWithChildren,
   ReactNode,
   RefAttributes,
 } from 'react';
 import { forwardRef } from 'react';
 import type RAC from 'react-aria-components';
-import { Checkbox } from 'react-aria-components';
+import {
+  Checkbox,
+  CheckboxContext,
+  Provider,
+  TextContext,
+} from 'react-aria-components';
+import { useId } from '@react-aria/utils';
 import { StateAttrProps, cn, useClassNames } from '@marigold/system';
+import { HelpText } from '../HelpText';
 import { CheckboxGroup } from './CheckboxGroup';
 import { useCheckboxGroupContext } from './Context';
 
-// SVG Icon
+// Field Wrapper
+// ---------------
+const Field = ({
+  description,
+  children,
+  className,
+}: PropsWithChildren<{ description: ReactNode; className: string }>) => {
+  const fieldClassName = useClassNames({
+    component: 'Field',
+  });
+  const descriptionId = useId();
+
+  if (!description) return children;
+
+  return (
+    <div className={fieldClassName}>
+      <Provider
+        values={[
+          [CheckboxContext, { 'aria-describedby': descriptionId }],
+          [TextContext, { id: descriptionId, className }],
+        ]}
+      >
+        {children}
+        <HelpText description={description} />
+      </Provider>
+    </div>
+  );
+};
+
+// Icons
+// ---------------
 const CheckMark = () => (
   <svg width="12px" height="10px" viewBox="0 0 12 10">
     <path
@@ -55,6 +93,8 @@ const Icon = ({ className, checked, indeterminate, ...props }: IconProps) => {
   );
 };
 
+// Component
+// ---------------
 export type RemovedProps =
   | 'children'
   | 'className'
@@ -110,6 +150,10 @@ export interface CheckboxProps extends Omit<RAC.CheckboxProps, RemovedProps> {
    *
    */
   label?: ReactNode;
+  /**
+   * A helpful text.
+   */
+  description?: ReactNode;
 }
 
 export interface CheckboxComponent
@@ -137,6 +181,7 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       variant,
       size,
       label,
+      description,
       ...rest
     },
     ref
@@ -161,26 +206,28 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
     });
 
     return (
-      <Checkbox
-        ref={ref}
-        className={cn(
-          'group/checkbox flex items-center gap-[0.5rem]',
-          'cursor-pointer data-disabled:cursor-not-allowed',
-          classNames.container
-        )}
-        {...props}
-      >
-        {({ isSelected, isIndeterminate }) => (
-          <>
-            <Icon
-              checked={isSelected}
-              indeterminate={isIndeterminate}
-              className={classNames.checkbox}
-            />
-            {label && <div className={classNames.label}>{label}</div>}
-          </>
-        )}
-      </Checkbox>
+      <Field description={description} className={classNames.helptext}>
+        <Checkbox
+          ref={ref}
+          className={cn(
+            'group/checkbox flex items-center',
+            'cursor-pointer data-disabled:cursor-not-allowed',
+            classNames.container
+          )}
+          {...props}
+        >
+          {({ isSelected, isIndeterminate }) => (
+            <>
+              <Icon
+                checked={isSelected}
+                indeterminate={isIndeterminate}
+                className={classNames.checkbox}
+              />
+              {label && <div className={classNames.label}>{label}</div>}
+            </>
+          )}
+        </Checkbox>
+      </Field>
     );
   }
 ) as CheckboxComponent;

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -23,9 +23,8 @@ import { useCheckboxGroupContext } from './Context';
 const Field = ({
   description,
   children,
-  className,
-}: PropsWithChildren<{ description: ReactNode; className: string }>) => {
-  const fieldClassName = useClassNames({
+}: PropsWithChildren<{ description: ReactNode }>) => {
+  const className = useClassNames({
     component: 'Field',
   });
   const descriptionId = useId();
@@ -33,11 +32,11 @@ const Field = ({
   if (!description) return children;
 
   return (
-    <div className={fieldClassName}>
+    <div className={className}>
       <Provider
         values={[
           [CheckboxContext, { 'aria-describedby': descriptionId }],
-          [TextContext, { id: descriptionId, className }],
+          [TextContext, { id: descriptionId }],
         ]}
       >
         {children}
@@ -206,7 +205,7 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
     });
 
     return (
-      <Field description={description} className={classNames.helptext}>
+      <Field description={description}>
         <Checkbox
           ref={ref}
           className={cn(

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -24,7 +24,6 @@ const theme: Theme = {
       container: cva('flex'),
       label: cva('text-black-300'),
       group: cva('flex'),
-      helptext: cva(''),
     },
     Field: cva(''),
   },

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -24,7 +24,9 @@ const theme: Theme = {
       container: cva('flex'),
       label: cva('text-black-300'),
       group: cva('flex'),
+      helptext: cva(''),
     },
+    Field: cva(''),
   },
 };
 

--- a/packages/components/src/Table/Table.test.tsx
+++ b/packages/components/src/Table/Table.test.tsx
@@ -15,6 +15,7 @@ const theme: Theme = {
       container: cva(),
       label: cva(),
       group: cva(),
+      helptext: cva(''),
     },
     Table: {
       table: cva('border-collapse'),
@@ -25,6 +26,7 @@ const theme: Theme = {
       row: cva('bg-blue-700'),
       cell: cva('p-10'),
     },
+    Field: cva(''),
   },
 };
 

--- a/packages/components/src/Table/Table.test.tsx
+++ b/packages/components/src/Table/Table.test.tsx
@@ -15,7 +15,6 @@ const theme: Theme = {
       container: cva(),
       label: cva(),
       group: cva(),
-      helptext: cva(''),
     },
     Table: {
       table: cva('border-collapse'),

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -78,7 +78,7 @@ export type Theme = {
     >;
     IconButton?: ComponentStyleFunction<string, string>;
     Checkbox?: Record<
-      'container' | 'label' | 'checkbox' | 'group' | 'helptext',
+      'container' | 'label' | 'checkbox' | 'group',
       ComponentStyleFunction<string, string>
     >;
     Switch?: Record<

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -78,7 +78,7 @@ export type Theme = {
     >;
     IconButton?: ComponentStyleFunction<string, string>;
     Checkbox?: Record<
-      'container' | 'label' | 'checkbox' | 'group',
+      'container' | 'label' | 'checkbox' | 'group' | 'helptext',
       ComponentStyleFunction<string, string>
     >;
     Switch?: Record<

--- a/themes/theme-rui/src/components/Checkbox.styles.ts
+++ b/themes/theme-rui/src/components/Checkbox.styles.ts
@@ -9,11 +9,13 @@ export const Checkbox: ThemeComponent<'Checkbox'> = {
     'group-selected/checkbox:border-brand group-selected/checkbox:bg-brand group-selected/checkbox:text-brand-foreground',
     'group-[indeterminate]/checkbox:border-brand group-[indeterminate]/checkbox:bg-brand group-[indeterminate]/checkbox:text-brand-foreground',
   ]),
-  container: cva('cursor-pointer read-only:cursor-default'),
+  container: cva('cursor-pointer read-only:cursor-default gap-2'),
   label: cva([
     'flex items-center gap-1',
     'text-sm leading-4 group-[group="checkbox"]/checkboxgroup:font-normal font-medium text-foregroun',
     'group-disabled/checkbox:text-disabled-foreground',
   ]),
   group: cva(),
+  // Align the helptext with the label text (checkbox size + container gap)
+  helptext: cva('pl-6'),
 };

--- a/themes/theme-rui/src/components/Checkbox.styles.ts
+++ b/themes/theme-rui/src/components/Checkbox.styles.ts
@@ -16,6 +16,4 @@ export const Checkbox: ThemeComponent<'Checkbox'> = {
     'group-disabled/checkbox:text-disabled-foreground',
   ]),
   group: cva(),
-  // Align the helptext with the label text (checkbox size + container gap)
-  helptext: cva('pl-6'),
 };


### PR DESCRIPTION
# Description

- `<Checkbox>` now supports the `description` prop like other form fields.

# Test Instructions:

Go to storybook (Checkbox -> With description) or to the checkbox documentation.

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
