### PR TITLE
fix(Tag): Adjust tag styles (no extra padding if empty state is small, e.g. only text)

### DIFF
--- a/.changeset/strong-seas-tease.md
+++ b/.changeset/strong-seas-tease.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+fix(Tag): Adjust tag styles (no extra padding if empty state is small, e.g. only text)

--- a/themes/theme-rui/src/components/Tag.styles.ts
+++ b/themes/theme-rui/src/components/Tag.styles.ts
@@ -3,12 +3,12 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const Tag: ThemeComponent<'Tag'> = {
   container: cva([
     'flex gap-3',
-    // prevent collapsing when the empty state is shown
-    'min-h-button-small',
+    // prevent layout jumps when a smaller empty state is shown (min height is set to height of tags)
+    'min-h-7',
   ]),
   tag: cva([
     'relative inline-flex items-center gap-[7px]',
-    'border border-solid border-input rounded-md',
+    'border border-solid border-input rounded-lg',
     'font-medium text-xs',
     'h-7 px-2 cursor-default',
     'bg-background',
@@ -21,7 +21,7 @@ export const Tag: ThemeComponent<'Tag'> = {
     'disabled:bg-disabled disabled:text-disabled-foreground disabled:cursor-not-allowed',
   ]),
   listItems: cva([
-    'flex flex-wrap items-center gap-1',
+    'flex flex-wrap gap-1',
     // mb-0 prevents whitespace when the hidden field is rendered
     'mb-0',
   ]),
@@ -30,6 +30,6 @@ export const Tag: ThemeComponent<'Tag'> = {
     'duration-150 active:scale-[0.98] pressed:scale-[0.98]',
     'focus-visible:util-focus-ring outline-none',
     'cursor-pointer',
-    'text-link text-xs h-button-small',
+    'text-link text-xs util-touch-hitbox',
   ]),
 };


### PR DESCRIPTION
# Description

- Adjusted border radius a bit to adhere origin ui
- reduce min height when empty state is small, e.g. only text

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
