### PR TITLE
fix([DST-1046]): Remove extra padding at the bottom of `<Select>`.

### DIFF
--- a/.changeset/wise-beans-exercise.md
+++ b/.changeset/wise-beans-exercise.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+fix([DST-1046]): Remove extra padding at the bottom of `<Select>`.

--- a/themes/theme-rui/src/components/HelpText.styles.ts
+++ b/themes/theme-rui/src/components/HelpText.styles.ts
@@ -4,6 +4,11 @@ export const HelpText: ThemeComponent<'HelpText'> = {
   container: cva([
     'text-xs text-muted-foreground group-disabled/field:text-disabled-foreground',
     'group-invalid/field:text-destructive',
+    /**
+     * Removes the spacing from the field when when there are hidden
+     * elements (e.g. the hidden select rendered by react-aria).
+     */
+    'has-[+_[aria-hidden="true"]]:mb-0',
   ]),
   icon: cva(''),
 };

--- a/themes/theme-rui/src/components/Select.styles.ts
+++ b/themes/theme-rui/src/components/Select.styles.ts
@@ -11,5 +11,11 @@ export const Select: ThemeComponent<'Select'> = {
     'h-input',
     'cursor-pointer',
     '*:data-placeholder:text-placeholder',
+    /**
+     * Removes the spacing from the field when there is no
+     * helptext. Spacing is applied because the select is followed
+     * by a hidden select that is rendered by react-aria.
+     */
+    'has-[+_[aria-hidden="true"]]:mb-0',
   ]),
 };


### PR DESCRIPTION
# Description

-

# Test Instructions:

Inspect the Select (Button) there should not be a margin anymore :D

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
