### PR TITLE
fix([DST-1049]): Add 'text-sm' class to Link component styles

### DIFF
--- a/.changeset/four-vans-kick.md
+++ b/.changeset/four-vans-kick.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+fix(Link): Add 'text-sm' class to Link component styles

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -11,14 +11,14 @@ const meta = {
         type: 'radio',
       },
       options: ['default', 'secondary'],
-      description: 'Variants of the link, content only for core.',
+      description: 'Variants of the link.',
     },
     size: {
       control: {
         type: 'radio',
       },
       options: ['default', 'small'],
-      description: 'Variants of the link, content only for core.',
+      description: 'Sizes of the link.',
     },
     href: {
       control: {

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -8,9 +8,16 @@ const meta = {
   argTypes: {
     variant: {
       control: {
-        type: 'select',
+        type: 'radio',
       },
-      options: ['none', 'menuItemLink', 'content', 'secondary'],
+      options: ['default', 'secondary'],
+      description: 'Variants of the link, content only for core.',
+    },
+    size: {
+      control: {
+        type: 'radio',
+      },
+      options: ['default', 'small'],
       description: 'Variants of the link, content only for core.',
     },
     href: {

--- a/themes/theme-rui/src/components/Link.styles.ts
+++ b/themes/theme-rui/src/components/Link.styles.ts
@@ -1,7 +1,7 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const Link: ThemeComponent<'Link'> = cva(
-  'aria-[disabled]:cursor-not-allowed',
+  'text-sm aria-[disabled]:cursor-not-allowed',
   {
     variants: {
       variant: {

--- a/themes/theme-rui/src/components/Link.styles.ts
+++ b/themes/theme-rui/src/components/Link.styles.ts
@@ -1,16 +1,21 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
 export const Link: ThemeComponent<'Link'> = cva(
-  'text-sm aria-[disabled]:cursor-not-allowed',
+  'aria-[disabled]:cursor-not-allowed',
   {
     variants: {
       variant: {
         default: 'text-link font-normal',
         secondary: 'font-medium text-foreground underline hover:no-underline',
       },
+      size: {
+        default: '',
+        small: 'text-sm',
+      },
     },
     defaultVariants: {
       variant: 'default',
+      size: 'default',
     },
   }
 );


### PR DESCRIPTION
# Description

add font size to link component

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
