### PR TITLE
fix([DST-1054]): Add missing font color in accordion component

### DIFF
--- a/.changeset/green-ties-applaud.md
+++ b/.changeset/green-ties-applaud.md
@@ -1,0 +1,5 @@
+---
+"@marigold/theme-rui": patch
+---
+
+fix([DST-1054]): Add missing font color in accordion component

--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -12,7 +12,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
       variant: 'default',
     },
   }),
-  item: cva('border-b last:border-b-0 border-border ', {
+  item: cva('border-b last:border-b-0 border-border text-foreground', {
     variants: {
       variant: {
         default: '',

--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -12,7 +12,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
       variant: 'default',
     },
   }),
-  item: cva('border-b last:border-b-0 border-border text-foreground', {
+  item: cva('border-b last:border-b-0 border-border', {
     variants: {
       variant: {
         default: '',
@@ -29,7 +29,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
   }),
   header: cva(
     [
-      'flex w-full items-center justify-between gap-4 rounded-md py-2 cursor-pointer',
+      'flex w-full items-center justify-between gap-4 rounded-md py-2 cursor-pointer text-foreground',
       'text-left text-sm font-semibold leading-6 transition-all',
       'hover:no-underline',
       'disabled:cursor-not-allowed disabled:text-disabled-foreground',


### PR DESCRIPTION
# Description

Add missing font color for accordion component

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
