### PR TITLE
feat([DST-1074]): Introduce a `useConfirmation` hook to conveniently open confirmation dialogs

### DIFF
--- a/config/storybook/.storybook/preview.tsx
+++ b/config/storybook/.storybook/preview.tsx
@@ -52,7 +52,9 @@ export const decorators: any = [
         theme={THEME[theme as ThemeNames]}
         className="bg-bg-surface"
       >
-        <div className="h-screen p-6">{Story()}</div>
+        <div className="h-screen p-6">
+          <Story />
+        </div>
       </MarigoldProvider>
     );
   },

--- a/docs/content/components/overlay/dialog/dialog-from-menu.demo.tsx
+++ b/docs/content/components/overlay/dialog/dialog-from-menu.demo.tsx
@@ -1,15 +1,20 @@
-import { useState } from 'react';
-import { ConfirmationDialog, Menu } from '@marigold/components';
+import { Menu, useConfirmation } from '@marigold/components';
 
 export default () => {
-  const [open, setDialogOpen] = useState(false);
-  const handleAction = (action: 'save' | 'delete') => {
+  const confirm = useConfirmation();
+  const handleAction = async (action: 'save' | 'delete') => {
     switch (action) {
       case 'save':
         alert('saved!');
         break;
       case 'delete':
-        setDialogOpen(true);
+        await confirm({
+          variant: 'destructive',
+          title: 'Confirm delete',
+          content:
+            'Are you sure you want to delete this event? This action cannot be undone.',
+          confirmationLabel: 'Delete',
+        });
         break;
       default:
         throw new Error(`Unhandled action "${action}"!`);
@@ -17,24 +22,11 @@ export default () => {
   };
 
   return (
-    <>
-      <Menu onAction={handleAction} label="Settings">
-        <Menu.Item id="save">Save</Menu.Item>
-        <Menu.Item id="delete" variant="destructive">
-          Delete
-        </Menu.Item>
-      </Menu>
-      <ConfirmationDialog
-        variant="destructive"
-        title="Confirm delete"
-        confirmationLabel="Delete"
-        closeButton
-        open={open}
-        onOpenChange={setDialogOpen}
-      >
-        Are you sure you want to delete this event? This action cannot be
-        undone.
-      </ConfirmationDialog>
-    </>
+    <Menu onAction={handleAction} label="Settings">
+      <Menu.Item id="save">Save</Menu.Item>
+      <Menu.Item id="delete" variant="destructive">
+        Delete
+      </Menu.Item>
+    </Menu>
   );
 };

--- a/docs/content/components/overlay/dialog/dialog.mdx
+++ b/docs/content/components/overlay/dialog/dialog.mdx
@@ -104,7 +104,7 @@ A confirmation dialog asks a user to verify an action, preventing accidental and
 
 For an effective dialog, be specific in your prompt. For example, ask "Permanently delete this account?" instead of a generic "Are you sure?". Action buttons should have clear, unambiguous labels like "Delete" and "Cancel". To avoid user fatigue, reserve confirmation dialogs only for actions that truly warrant a second thought, not for minor tasks.
 
-Use the `<ConfirmationDialog>` component for this use case. It looks and behaves like a regular dialog, but its API is specifically tailored to streamline the creation of confirmation prompts. It provides dedicated props for the title, description, and action buttons, which simplifies your code and enforces a consistent layout. You get the full power of the underlying dialog system with a more convenient and declarative interface built for this common pattern.
+Use the `useConfirmation` hook for this use case. This hook provides a simple API to trigger confirmation dialogs programmatically, making it easy to prompt users for confirmation before performing critical actions. It returns a function that opens the dialog and resolves with the user's response, allowing you to handle confirmation logic directly in your code.
 
 <ComponentDemo file="./dialog-from-menu.demo.tsx" />
 

--- a/docs/content/components/overlay/menu/menu-open-dialog.demo.tsx
+++ b/docs/content/components/overlay/menu/menu-open-dialog.demo.tsx
@@ -1,14 +1,16 @@
+import { MessageCircleHeart, User } from 'lucide-react';
 import { useState } from 'react';
-import { Button, Dialog, Menu } from '@marigold/components';
+import { Button, Dialog, Menu, TextArea } from '@marigold/components';
 
 export default () => {
   const [open, setDialogOpen] = useState(false);
-  const handleAction = (action: 'save' | 'delete') => {
+
+  const handleAction = (action: 'profile' | 'feedback') => {
     switch (action) {
-      case 'save':
-        alert('saved!');
+      case 'profile':
+        alert('Profile opened!');
         break;
-      case 'delete':
+      case 'feedback':
         setDialogOpen(true);
         break;
       default:
@@ -18,23 +20,30 @@ export default () => {
 
   return (
     <>
-      <Menu onAction={handleAction} label="Settings">
-        <Menu.Item id="save">Save</Menu.Item>
-        <Menu.Item id="delete" variant="destructive">
-          Delete
+      <Menu onAction={handleAction} label="User Menu">
+        <Menu.Item id="profile">
+          <User /> View Profile
+        </Menu.Item>
+        <Menu.Item id="feedback">
+          <MessageCircleHeart /> Send Feedback
         </Menu.Item>
       </Menu>
-      <Dialog closeButton open={open} onOpenChange={setDialogOpen}>
+      <Dialog
+        size="xsmall"
+        closeButton
+        open={open}
+        onOpenChange={setDialogOpen}
+      >
         {({ close }) => (
           <>
-            <Dialog.Title>Confirm delete</Dialog.Title>
-            <Dialog.Content>Do you really wanna delete this?</Dialog.Content>
+            <Dialog.Title>Send Feedback</Dialog.Title>
+            <Dialog.Content>
+              <TextArea placeholder="Your feedback..." rows={4} />
+            </Dialog.Content>
             <Dialog.Actions>
-              <Button variant="ghost" onPress={close}>
-                Cancel
-              </Button>
-              <Button variant="destructive" onPress={close}>
-                Delete
+              <Button onPress={close}>Cancel</Button>
+              <Button variant="primary" onPress={close}>
+                Submit
               </Button>
             </Dialog.Actions>
           </>

--- a/packages/components/src/Dialog/ConfirmationDialog.stories.tsx
+++ b/packages/components/src/Dialog/ConfirmationDialog.stories.tsx
@@ -1,0 +1,60 @@
+import type { StoryObj } from '@storybook/react';
+import { Button } from '../Button';
+import { Stack } from '../Stack';
+import {
+  ConfirmationDialog,
+  ConfirmationDialogProps,
+} from './ConfirmationDialog';
+import { useConfirmation } from './useConfirmation';
+
+const meta = {
+  title: 'Components/ConfirmationDialog',
+  component: ConfirmationDialog.Trigger,
+};
+
+export default meta;
+
+export const Confirmation: StoryObj<ConfirmationDialogProps> = {
+  render: ({ ...args }) => (
+    <ConfirmationDialog.Trigger {...args}>
+      <Button>Open</Button>
+      <ConfirmationDialog title="Confirmation" confirmationLabel="Confirm">
+        Are you sure you want to proceed with this action?
+      </ConfirmationDialog>
+    </ConfirmationDialog.Trigger>
+  ),
+};
+
+export const UseConfirmation: StoryObj = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const confirm = useConfirmation();
+
+    const onConfirmation = async () => {
+      await confirm({
+        title: 'Enable notifications',
+        content: 'Would you like to receive notifications for upcoming events?',
+        confirmationLabel: 'Enable',
+        cancelLabel: 'Cancel',
+      });
+    };
+
+    const onDelete = async () => {
+      await confirm({
+        variant: 'destructive',
+        title: 'Delete item',
+        content: 'Are you sure you want to delete this item?',
+        confirmationLabel: 'Delete',
+      });
+    };
+
+    return (
+      <Stack space={4} alignX="left">
+        <Button onPress={onConfirmation}>Confirm</Button>
+        <Button variant="destructive" onPress={onDelete}>
+          Delete
+        </Button>
+      </Stack>
+    );
+  },
+};

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -4,10 +4,6 @@ import { Button } from '../Button';
 import { Menu } from '../Menu';
 import { Text } from '../Text';
 import { TextField } from '../TextField';
-import {
-  ConfirmationDialog,
-  ConfirmationDialogProps,
-} from './ConfirmationDialog';
 import { Dialog } from './Dialog';
 
 const meta = {
@@ -104,6 +100,7 @@ export const Form: Story = {
 
 export const OpenFromMenu: Story = {
   render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const [open, setDialogOpen] = useState(false);
     const handleAction = (action: 'save' | 'delete') => {
       switch (action) {
@@ -147,15 +144,4 @@ export const OpenFromMenu: Story = {
       </>
     );
   },
-};
-
-export const Confirmation: StoryObj<ConfirmationDialogProps> = {
-  render: ({ ...args }) => (
-    <ConfirmationDialog.Trigger {...args}>
-      <Button>Open</Button>
-      <ConfirmationDialog title="Confirmation" confirmationLabel="Confirm">
-        Are you sure you want to proceed with this action?
-      </ConfirmationDialog>
-    </ConfirmationDialog.Trigger>
-  ),
 };

--- a/packages/components/src/Dialog/index.ts
+++ b/packages/components/src/Dialog/index.ts
@@ -1,2 +1,4 @@
 export * from './ConfirmationDialog';
 export * from './Dialog';
+
+export * from './useConfirmation';

--- a/packages/components/src/Dialog/useConfirmation.test.tsx
+++ b/packages/components/src/Dialog/useConfirmation.test.tsx
@@ -1,0 +1,73 @@
+import { composeStories } from '@storybook/react';
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as stories from './ConfirmationDialog.stories';
+import { useConfirmation } from './useConfirmation';
+
+const { UseConfirmation } = composeStories(stories);
+const user = userEvent.setup();
+
+test('throw if ConfirmationProvider is missing', () => {
+  expect(() =>
+    renderHook(() => useConfirmation())
+  ).toThrowErrorMatchingInlineSnapshot(
+    `[Error: \`useConfirmation\` must be used within a \`ConfirmationProvider\`]`
+  );
+});
+
+test('open confirmation dialog', async () => {
+  render(<UseConfirmation />);
+
+  const button = screen.getByRole('button', { name: 'Confirm' });
+  await user.click(button);
+
+  expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      'Would you like to receive notifications for upcoming events?'
+    )
+  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+});
+
+test('can open multiple confirmation dialogs sequentially', async () => {
+  render(<UseConfirmation />);
+
+  const button = screen.getByRole('button', { name: 'Confirm' });
+  await user.click(button);
+
+  expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+
+  const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+  await user.click(cancelButton);
+
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+
+  const deleteButton = screen.getByRole('button', { name: 'Delete' });
+  await user.click(deleteButton);
+
+  expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText('Delete item')).toBeInTheDocument();
+});
+
+test('only one confirmation dialog at a time', async () => {
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  render(<UseConfirmation />);
+
+  const button = screen.getByRole('button', { name: 'Confirm' });
+  await user.click(button);
+
+  expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText('Enable notifications')).toBeInTheDocument();
+
+  // Try to open another dialog while one is already open
+  await user.click(button);
+
+  expect(consoleWarnSpy).toHaveBeenCalledWith(
+    'A confirmation dialog is already open. Rejecting new request.'
+  );
+});

--- a/packages/components/src/Dialog/useConfirmation.tsx
+++ b/packages/components/src/Dialog/useConfirmation.tsx
@@ -1,0 +1,92 @@
+import { useContext } from 'react';
+import { createContext, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { ConfirmationDialog } from './ConfirmationDialog';
+import type { ConfirmationDialogProps } from './ConfirmationDialog';
+
+// Types
+// ---------------
+export type ConfirmationResult = 'confirmed' | 'cancelled';
+export interface ConfirmationConfig
+  extends Pick<
+    ConfirmationDialogProps,
+    | 'variant'
+    | 'title'
+    | 'confirmationLabel'
+    | 'cancelLabel'
+    | 'autoFocusButton'
+  > {
+  content?: React.ReactNode;
+}
+
+// Context
+// ---------------
+export type ConfirmationFn = (
+  props: ConfirmationConfig
+) => Promise<ConfirmationResult>;
+export const ConfirmationContext = createContext<ConfirmationFn | null>(null);
+
+// Provider
+// ---------------
+interface ConfirmationState extends ConfirmationConfig {
+  resolve: (status: ConfirmationResult) => void;
+}
+
+export const ConfirmationProvider = ({ children }: PropsWithChildren) => {
+  const [confirmation, setConfirmation] = useState<ConfirmationState | null>(
+    null
+  );
+  const [open, setOpen] = useState(false);
+
+  const confirm = (config: ConfirmationConfig): Promise<ConfirmationResult> => {
+    // Allow only one confirmation dialog at a time. Immediately resolve with a default status.
+    if (open) {
+      console.warn(
+        'A confirmation dialog is already open. Rejecting new request.'
+      );
+      return Promise.resolve('cancelled');
+    }
+
+    return new Promise(resolve => {
+      setConfirmation({ ...config, resolve });
+      setOpen(true);
+    });
+  };
+
+  return (
+    <ConfirmationContext.Provider value={confirm}>
+      {children}
+      <ConfirmationDialog
+        open={open}
+        onOpenChange={setOpen}
+        variant={confirmation?.variant}
+        size="xsmall"
+        title={confirmation?.title || ''}
+        confirmationLabel={confirmation?.confirmationLabel || 'Confirm'}
+        cancelLabel={confirmation?.cancelLabel}
+        onConfirm={() => {
+          confirmation?.resolve('confirmed');
+        }}
+        onCancel={() => {
+          confirmation?.resolve('cancelled');
+        }}
+      >
+        {confirmation?.content}
+      </ConfirmationDialog>
+    </ConfirmationContext.Provider>
+  );
+};
+
+// Hook
+// ---------------
+export const useConfirmation = () => {
+  const confirm = useContext(ConfirmationContext);
+
+  if (confirm === null) {
+    throw new Error(
+      '`useConfirmation` must be used within a `ConfirmationProvider`'
+    );
+  }
+
+  return confirm;
+};

--- a/packages/components/src/Provider/MarigoldProvider.test.tsx
+++ b/packages/components/src/Provider/MarigoldProvider.test.tsx
@@ -34,6 +34,16 @@ test('support cascading themes', () => {
     },
     components: {
       Button: cva(),
+      Modal: cva(),
+      Dialog: {
+        container: cva(),
+        closeButton: cva(),
+        header: cva(),
+        content: cva(),
+        actions: cva(),
+        title: cva(),
+      },
+      Underlay: cva(),
     },
   };
 
@@ -44,6 +54,17 @@ test('support cascading themes', () => {
     },
     components: {
       Text: cva('text-black'),
+      Button: cva(),
+      Modal: cva(),
+      Dialog: {
+        container: cva(),
+        closeButton: cva(),
+        header: cva(),
+        content: cva(),
+        actions: cva(),
+        title: cva(),
+      },
+      Underlay: cva(),
     },
   };
 
@@ -72,7 +93,9 @@ test('support cascading themes', () => {
       "colors": {
         "primary": "coral"
       },
-      "components": {}
+      "components": {
+        "Dialog": {}
+      }
     }"
   `);
   expect(inner.innerHTML).toMatchInlineSnapshot(`
@@ -81,7 +104,9 @@ test('support cascading themes', () => {
       "colors": {
         "primary": "gainsboro"
       },
-      "components": {}
+      "components": {
+        "Dialog": {}
+      }
     }"
   `);
 });
@@ -94,6 +119,16 @@ test('cascading without a selector is allowed when inner theme has not root styl
     },
     components: {
       Button: cva(),
+      Modal: cva(),
+      Dialog: {
+        container: cva(),
+        closeButton: cva(),
+        header: cva(),
+        content: cva(),
+        actions: cva(),
+        title: cva(),
+      },
+      Underlay: cva(),
     },
   };
 
@@ -102,7 +137,19 @@ test('cascading without a selector is allowed when inner theme has not root styl
     colors: {
       primary: 'gainsboro',
     },
-    components: {},
+    components: {
+      Button: cva(),
+      Modal: cva(),
+      Dialog: {
+        container: cva(),
+        closeButton: cva(),
+        header: cva(),
+        content: cva(),
+        actions: cva(),
+        title: cva(),
+      },
+      Underlay: cva(),
+    },
   };
 
   expect(() =>
@@ -122,6 +169,16 @@ test('using classname prop', () => {
     },
     components: {
       Button: cva(),
+      Modal: cva(),
+      Dialog: {
+        container: cva(),
+        closeButton: cva(),
+        header: cva(),
+        content: cva(),
+        actions: cva(),
+        title: cva(),
+      },
+      Underlay: cva(),
     },
   };
 

--- a/packages/components/src/Provider/MarigoldProvider.tsx
+++ b/packages/components/src/Provider/MarigoldProvider.tsx
@@ -1,4 +1,5 @@
 import { Theme, ThemeProvider, ThemeProviderProps } from '@marigold/system';
+import { ConfirmationProvider } from '../Dialog/useConfirmation';
 
 // Props
 // ---------------
@@ -13,7 +14,7 @@ export function MarigoldProvider<T extends Theme>({
 }: MarigoldProviderProps<T>) {
   return (
     <ThemeProvider theme={theme} className={className}>
-      {children}
+      <ConfirmationProvider>{children}</ConfirmationProvider>
     </ThemeProvider>
   );
 }

--- a/packages/components/src/Provider/OverlayContainerProvider.test.tsx
+++ b/packages/components/src/Provider/OverlayContainerProvider.test.tsx
@@ -42,6 +42,15 @@ const theme: Theme = {
     },
     Field: cva(),
     IconButton: cva(),
+    Modal: cva(),
+    Dialog: {
+      container: cva(),
+      closeButton: cva(),
+      header: cva(),
+      content: cva(),
+      actions: cva(),
+      title: cva(),
+    },
   },
 };
 


### PR DESCRIPTION
# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
