### PR TITLE
test: make it possible to write interaction tests for overlay components

### DIFF
--- a/config/storybook/.storybook/preview.tsx
+++ b/config/storybook/.storybook/preview.tsx
@@ -1,6 +1,9 @@
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import { Preview } from '@storybook/react';
-import { MarigoldProvider } from '@marigold/components';
+import {
+  MarigoldProvider,
+  OverlayContainerProvider,
+} from '@marigold/components';
 import rui from '@marigold/theme-rui';
 import './../styles.css';
 
@@ -52,7 +55,9 @@ export const decorators: any = [
         theme={THEME[theme as ThemeNames]}
         className="bg-bg-surface"
       >
-        <div className="h-screen p-6">{Story()}</div>
+        <OverlayContainerProvider container="storybook-root">
+          <div className="h-screen p-6">{Story()}</div>
+        </OverlayContainerProvider>
       </MarigoldProvider>
     );
   },

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 import { useState } from 'storybook/preview-api';
+import { expect, waitFor } from 'storybook/test';
 import { Button } from '../Button';
 import { Menu } from '../Menu';
 import { Text } from '../Text';
@@ -71,6 +72,19 @@ export const Basic: Story = {
       </Dialog>
     </Dialog.Trigger>
   ),
+  play: async ({ canvas, userEvent }) => {
+    const user = userEvent;
+
+    // Open the dialog
+    await user.click(canvas.getByRole('button', { name: 'Open' }));
+    await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
+
+    // Close the dialog
+    await user.click(canvas.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() =>
+      expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+    );
+  },
 };
 
 export const Form: Story = {


### PR DESCRIPTION
# Description

Test helpers only look for elements in side the storybook root, but our overlays are appenended to the body. Since stories are rendered in an iframe the `screen` helpers will not find the elements -> use the `OverlayProvider` to render the overlays in side the storybook iframe.

# Test Instructions:

Checkout the play test of the `<Dialog>`

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
