### PR TITLE
fix([DSTSUP-243]): align CJS export paths in system, icons, and theme-rui

### DIFF
--- a/.changeset/fix-cjs-export-paths.md
+++ b/.changeset/fix-cjs-export-paths.md
@@ -1,0 +1,7 @@
+---
+'@marigold/system': patch
+'@marigold/icons': patch
+'@marigold/theme-rui': patch
+---
+
+Fix CJS export paths pointing to non-existent `.js` files. Since tsdown 0.16.0, output uses `.cjs` extensions but `main`, `types`, and `exports` fields were never updated to match.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,17 +9,22 @@
     "react",
     "svg"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./*": {
-      "require": "./dist/*.js",
+      "require": "./dist/*.cjs",
       "import": "./dist/*.mjs"
     }
   },

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -11,17 +11,22 @@
     "styling",
     "css"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./*": {
-      "require": "./dist/*.js",
+      "require": "./dist/*.cjs",
       "import": "./dist/*.mjs"
     }
   },

--- a/themes/theme-rui/package.json
+++ b/themes/theme-rui/package.json
@@ -9,22 +9,32 @@
     "theme",
     "styles"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.mts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./appearances": {
-      "types": "./dist/appearances.d.mts",
-      "require": "./dist/appearances.js",
-      "import": "./dist/appearances.mjs"
+      "import": {
+        "types": "./dist/appearances.d.mts",
+        "default": "./dist/appearances.mjs"
+      },
+      "require": {
+        "types": "./dist/appearances.d.cts",
+        "default": "./dist/appearances.cjs"
+      }
     },
     "./*": {
-      "require": "./dist/*.js",
+      "require": "./dist/*.cjs",
       "import": "./dist/*.mjs"
     },
     "./styles.css": "./dist/styles.css",


### PR DESCRIPTION
# Description

Since tsdown 0.16.0 (PR #4981, Renovate auto-merge, 2025-12-01), CJS output uses `.cjs`
extensions instead of `.js` due to the `fixedExtension` default change. The
`@marigold/components` package was already corrected in PR #5075, but `@marigold/system`,
`@marigold/icons`, and `@marigold/theme-rui` still referenced `.js` for CJS paths.

This breaks any CJS consumer that does not support the `exports` field with condition-based
resolution (notably Jest <29, older bundlers, and plain `require()` calls), because the
`main` and `exports["."].require` fields point to `./dist/index.js` which does not exist --
only `./dist/index.cjs` is shipped.

The `types` field was also affected, pointing to `./dist/index.d.ts` while only
`./dist/index.d.cts` and `./dist/index.d.mts` exist.

This PR updates `main`, `types`, and `exports` fields in all three packages to point to the
actual files on disk, matching the pattern already used in `@marigold/components`.

# Test Instructions:

- `pnpm build` passes
- `pnpm typecheck:only` passes
- CJS resolution works: `node -e "require('@marigold/system')"`
- ESM resolution works: `node --input-type=module -e "import '@marigold/system'"`

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)