### PR TITLE
refa([DSTSUP-245]): Clean up Calendar styles

### DIFF
--- a/.changeset/clean-calendar-styles.md
+++ b/.changeset/clean-calendar-styles.md
@@ -1,0 +1,9 @@
+---
+"@marigold/components": patch
+"@marigold/theme-rui": patch
+"@marigold/system": patch
+---
+
+refactor([DSTSUP-245]): Clean up Calendar styles
+
+Move hardcoded Tailwind classes from Calendar component files into theme slots, reduce cell padding from `p-2` to `p-1`, and add new `calendarHeading` theme slot.

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -137,15 +137,15 @@ const _Calendar = ({
       >
         <Calendar
           className={cn(
-            'relative flex min-h-[350px] flex-col',
+            'relative flex flex-col',
             twWidth[width],
             classNames.calendar
           )}
           {...props}
         >
-          <div className={cn('flex gap-4', classNames.calendarContainer)}>
+          <div className={classNames.calendarContainer}>
             {[...Array(visibleMonths).keys()].map(i => (
-              <div key={i} className={cn('flex-1', classNames.calendarMonth)}>
+              <div key={i} className={classNames.calendarMonth}>
                 <CalendarHeader
                   monthOffset={i}
                   showPrevious={i === 0}
@@ -172,7 +172,7 @@ const _Calendar = ({
     >
       <Calendar
         className={cn(
-          'relative flex min-h-[350px] flex-col',
+          'relative flex flex-col',
           twWidth[width],
           classNames.calendar
         )}

--- a/packages/components/src/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/Calendar/CalendarGrid.tsx
@@ -4,7 +4,7 @@ import {
   CalendarGrid,
   CalendarGridBody,
 } from 'react-aria-components';
-import { cn, useClassNames } from '@marigold/system';
+import { useClassNames } from '@marigold/system';
 import { CalendarGridHeader } from './CalendarGridHeader';
 
 export interface CalendarGridProps {
@@ -23,13 +23,7 @@ const _CalendarGrid = ({ offset }: CalendarGridProps) => {
       <CalendarGridHeader />
       <CalendarGridBody>
         {date => (
-          <CalendarCell
-            date={date}
-            className={cn(
-              'flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full p-[5.3px] text-sm font-normal aria-disabled:cursor-default',
-              classNames.calendarCell
-            )}
-          />
+          <CalendarCell date={date} className={classNames.calendarCell} />
         )}
       </CalendarGridBody>
     </CalendarGrid>

--- a/packages/components/src/Calendar/CalendarHeader.tsx
+++ b/packages/components/src/Calendar/CalendarHeader.tsx
@@ -1,7 +1,6 @@
 import { useContext } from 'react';
 import { CalendarStateContext, Heading } from 'react-aria-components';
 import { useDateFormatter } from '@react-aria/i18n';
-import { cn } from '@marigold/system';
 import { IconButton } from '../IconButton/IconButton';
 import { ChevronLeft } from '../icons/ChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
@@ -46,10 +45,7 @@ export const CalendarHeader = ({
       <div className="flex-1">
         {showPrevious && (
           <IconButton
-            className={cn(
-              'inline-flex items-center justify-center gap-[0.5ch]',
-              classNames.calendarControllers
-            )}
+            className={classNames.calendarControllers}
             variant="navigation"
             slot="previous"
           >
@@ -57,14 +53,11 @@ export const CalendarHeader = ({
           </IconButton>
         )}
       </div>
-      <Heading className="text-sm font-medium">{formattedMonth}</Heading>
+      <Heading className={classNames.calendarHeading}>{formattedMonth}</Heading>
       <div className="flex flex-1 justify-end">
         {showNext && (
           <IconButton
-            className={cn(
-              'inline-flex items-center justify-center gap-[0.5ch]',
-              classNames.calendarControllers
-            )}
+            className={classNames.calendarControllers}
             variant="navigation"
             slot="next"
           >

--- a/packages/components/src/Calendar/MonthControls.tsx
+++ b/packages/components/src/Calendar/MonthControls.tsx
@@ -1,4 +1,4 @@
-import { cn, useClassNames } from '@marigold/system';
+import { useClassNames } from '@marigold/system';
 import { IconButton } from '../IconButton/IconButton';
 import { ChevronLeft } from '../icons/ChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
@@ -7,21 +7,16 @@ function MonthControls() {
   const classNames = useClassNames({ component: 'Calendar' });
 
   return (
-    <div
-      className={cn(
-        'flex w-full flex-nowrap justify-end gap-[10px] [&_button]:px-2 [&_button]:py-1 [&_button:disabled]:cursor-not-allowed',
-        classNames.calendarControllers
-      )}
-    >
+    <div className="flex w-full flex-nowrap justify-end gap-2.5">
       <IconButton
-        className={cn('inline-flex items-center justify-center gap-[0.5ch]')}
+        className={classNames.calendarControllers}
         variant="navigation"
         slot="previous"
       >
         <ChevronLeft size="20" />
       </IconButton>
       <IconButton
-        className={cn('inline-flex items-center justify-center gap-[0.5ch]')}
+        className={classNames.calendarControllers}
         variant="navigation"
         slot="next"
       >

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -222,6 +222,7 @@ export type Theme = {
       | 'calendarControllers'
       | 'calendarHeader'
       | 'calendarGrid'
+      | 'calendarHeading'
       | 'select',
       ComponentStyleFunction<string, string>
     >;

--- a/themes/theme-rui/src/components/Calendar.styles.ts
+++ b/themes/theme-rui/src/components/Calendar.styles.ts
@@ -3,7 +3,7 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const Calendar: ThemeComponent<'Calendar'> = {
   calendar: cva({
     base: [
-      'ui-surface shadow-elevation-border p-2',
+      'min-h-[350px] ui-surface shadow-elevation-border p-2',
       // In a Popover
       'group-data-trigger/popover:shadow-elevation-overlay',
       // In a Tray
@@ -27,6 +27,7 @@ export const Calendar: ThemeComponent<'Calendar'> = {
   }),
   calendarControllers: cva({
     base: [
+      'inline-flex items-center justify-center gap-[0.5ch]',
       'size-9 rounded-lg',
       'text-muted-foreground',
       'transition-colors',
@@ -39,7 +40,10 @@ export const Calendar: ThemeComponent<'Calendar'> = {
     ],
   }),
   calendarGrid: cva({
-    base: '[&_td]:p-2 [&_td]:group-[[role=dialog]]/tray:p-0.75',
+    base: '[&_td]:p-1 [&_td]:group-[[role=dialog]]/tray:p-0.75',
+  }),
+  calendarHeading: cva({
+    base: 'text-sm font-medium',
   }),
   calendarListboxButton: cva({
     base: [


### PR DESCRIPTION
# Description

Clean up Calendar component styles by moving hardcoded Tailwind classes from component files into the theme file, aligning with the project convention (theme files own appearance, component files own behavior/logic-driven layout).

**Changes:**
- Removed conflicting hardcoded cell styles from `CalendarGrid.tsx` (`h-[30px] w-[30px] rounded-full p-[5.3px]`) -- theme's `calendarCell` slot handles everything
- Removed redundant styles in `Calendar.tsx` that duplicated theme slots (`flex gap-4`, `flex-1`, `min-h-[350px]`)
- Moved `inline-flex items-center justify-center gap-[0.5ch]` from components into the `calendarControllers` theme slot
- Added new `calendarHeading` theme slot for month/year heading typography
- Cleaned up `MonthControls.tsx` child selector overrides, applying `calendarControllers` directly on each IconButton (consistent with `CalendarHeader`)
- Replaced arbitrary `gap-[10px]` with `gap-2.5`
- Reduced cell padding from `p-2` to `p-1`
- Removed unused `cn` imports

# Test Instructions:

- Open Calendar stories in Storybook and verify single-month and multi-month views render correctly
- Check navigation buttons, month/year dropdowns, and cell hover/focus states
- Verify Calendar inside DatePicker (popover) and tray contexts

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)