### PR TITLE
feat([DSTSUP-246]): Add virtualizer to TagField component

### DIFF
--- a/packages/components/src/ListBox/Context.ts
+++ b/packages/components/src/ListBox/Context.ts
@@ -3,6 +3,7 @@ import type { ComponentClassNames } from '@marigold/system';
 
 export interface ListBoxContextProps {
   classNames: ComponentClassNames<'ListBox'>;
+  virtualized?: boolean;
 }
 
 export const ListBoxContext = createContext<ListBoxContextProps>({

--- a/packages/components/src/ListBox/ListBox.tsx
+++ b/packages/components/src/ListBox/ListBox.tsx
@@ -5,7 +5,8 @@ import {
   forwardRef,
 } from 'react';
 import type RAC from 'react-aria-components';
-import { ListBox } from 'react-aria-components';
+import { ListBox, ListLayout, Virtualizer } from 'react-aria-components';
+import type { ListLayoutOptions } from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
 import { ListBoxContext } from './Context';
 import { ListBoxItem } from './ListBoxItem';
@@ -17,7 +18,15 @@ export interface ListBoxProps extends Omit<
 > {
   variant?: string;
   size?: string;
+  virtualized?: boolean;
+  layoutOptions?: ListLayoutOptions;
 }
+
+const defaultLayoutOptions: ListLayoutOptions = {
+  estimatedRowHeight: 32,
+  padding: 4,
+  gap: 1,
+};
 
 interface ListBoxComponent extends ForwardRefExoticComponent<
   ListBoxProps & RefAttributes<HTMLUListElement>
@@ -27,25 +36,39 @@ interface ListBoxComponent extends ForwardRefExoticComponent<
 }
 
 const _ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
-  ({ variant, size, ...props }, ref) => {
+  ({ variant, size, virtualized, layoutOptions, ...props }, ref) => {
     const classNames = useClassNames({ component: 'ListBox', variant, size });
 
     // RAC types are incorrect, this will be passed to the `useListBox` hook
     const listBoxProps: any = { shouldSelectOnPressUp: false };
 
+    const listBox = (
+      <ListBox
+        {...props}
+        className={cn('overflow-y-auto', classNames.list)}
+        ref={ref as Ref<HTMLDivElement>}
+        style={virtualized ? { display: 'block', padding: 0 } : undefined}
+        {...listBoxProps}
+      >
+        {props.children}
+      </ListBox>
+    );
+
     return (
-      <ListBoxContext.Provider value={{ classNames }}>
+      <ListBoxContext value={{ classNames, virtualized }}>
         <div className={classNames.container}>
-          <ListBox
-            {...props}
-            className={cn('overflow-y-auto', classNames.list)}
-            ref={ref as Ref<HTMLDivElement>}
-            {...listBoxProps}
-          >
-            {props.children}
-          </ListBox>
+          {virtualized ? (
+            <Virtualizer
+              layout={ListLayout}
+              layoutOptions={{ ...defaultLayoutOptions, ...layoutOptions }}
+            >
+              {listBox}
+            </Virtualizer>
+          ) : (
+            listBox
+          )}
         </div>
-      </ListBoxContext.Provider>
+      </ListBoxContext>
     );
   }
 ) as ListBoxComponent;

--- a/packages/components/src/ListBox/ListBoxItem.tsx
+++ b/packages/components/src/ListBox/ListBoxItem.tsx
@@ -15,11 +15,12 @@ export type ListBoxItemProps = Omit<
 };
 
 export const _ListBoxItem = ({ ...props }: ListBoxItemProps) => {
-  const { classNames } = useListBoxContext();
+  const { classNames, virtualized } = useListBoxContext();
   return (
     <ListBoxItem
       {...props}
       className={classNames.item}
+      style={virtualized ? { height: '100%', minHeight: 0 } : undefined}
       // textValue needed because ListBoxItem in this case has multiple children
       textValue={props.textValue ?? String(props.children)}
     >

--- a/packages/components/src/TagField/TagField.stories.tsx
+++ b/packages/components/src/TagField/TagField.stories.tsx
@@ -160,6 +160,57 @@ Controlled.test('Remove a tag', async ({ canvas, step }) => {
   });
 });
 
+const LARGE_ITEMS = Array.from({ length: 800 }, (_, i) => ({
+  id: `item-${i + 200}`,
+  label: `Tenant ${i + 200} (item-${i + 200})`,
+}));
+
+export const LargeDataset = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Tenants',
+    placeholder: 'Search tenants...',
+    width: 80,
+  },
+  render: args => (
+    <TagField {...args} items={LARGE_ITEMS}>
+      {(item: (typeof LARGE_ITEMS)[number]) => (
+        <TagField.Option id={item.id}>{item.label}</TagField.Option>
+      )}
+    </TagField>
+  ),
+});
+
+LargeDataset.test(
+  'Search and select from large dataset',
+  async ({ canvas, step, args }) => {
+    await step('Open the dropdown', async () => {
+      const trigger = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
+      await userEvent.click(trigger);
+      await waitFor(() => canvas.getByRole('dialog'));
+    });
+
+    await step('Search for a specific item', async () => {
+      const searchInput = canvas.getByRole('searchbox');
+      await userEvent.type(searchInput, 'item-500');
+    });
+
+    await step('Verify filtered result and select it', async () => {
+      const dialog = canvas.getByRole('dialog');
+      const option = within(dialog).getByText('Tenant 500 (item-500)');
+      expect(option).toBeVisible();
+      await userEvent.click(option);
+    });
+
+    await step('Verify selected item appears as tag', async () => {
+      const tagGroup = canvas.getByRole('grid', {
+        name: /selected items|ausgewählte elemente/i,
+      });
+      expect(within(tagGroup).getByText('Tenant 500 (item-500)')).toBeVisible();
+    });
+  }
+);
+
 export const DisabledItems = Basic.extend({
   args: {
     disabledKeys: ['classical', 'electronic'],

--- a/packages/components/src/TagField/TagField.tsx
+++ b/packages/components/src/TagField/TagField.tsx
@@ -196,6 +196,7 @@ const TagFieldDropdown = ({
       </SearchField>
       <ListBox
         items={items}
+        virtualized
         renderEmptyState={() =>
           emptyState ?? (
             <div className="flex items-center">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,11 @@ export default mergeConfig(
         {
           extends: true,
           plugins: [tsconfigPaths()],
+          define: {
+            // @react-aria/virtualizer references process.env in source
+            'process.env.NODE_ENV': JSON.stringify('test'),
+            'process.env.VIRT_ON': 'undefined',
+          },
           optimizeDeps: {
             include: browserDeps,
           },
@@ -66,6 +71,11 @@ export default mergeConfig(
               },
             }),
           ],
+          define: {
+            // @react-aria/virtualizer references process.env in source
+            'process.env.NODE_ENV': JSON.stringify('test'),
+            'process.env.VIRT_ON': 'undefined',
+          },
           optimizeDeps: {
             include: browserDeps,
           },

--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -25,6 +25,9 @@ export const browserDeps = [
   // App deps used in decorators/stories
   '@tanstack/react-query',
   'react-select',
+  // Virtualizer deps (reference process.env in source)
+  '@react-aria/virtualizer',
+  '@react-stately/layout',
   // Test setup (extends expect at module load time)
   '@testing-library/jest-dom/vitest',
 ];


### PR DESCRIPTION
# Description

Add virtualization to the `<TagField>` dropdown to support large datasets (10k+ items).

Previously, the TagField rendered all items as DOM nodes when the dropdown opened. With 13k items this caused the browser to freeze on open and during filtering. This was reported via a [StackBlitz reproduction](https://stackblitz.com/edit/github-s4wn1l9h).

## Solution

Uses React Aria's built-in `<Virtualizer>` + `ListLayout` (already available in `react-aria-components@1.16.0`) to only render visible items in the DOM. Following [React Spectrum 2's approach](https://react-spectrum.adobe.com/react-aria/Virtualizer.html), virtualization is always-on inside the TagField — consumers don't need to opt in.

### Changes

**ListBox** (`packages/components/src/ListBox/`):
- Added `virtualized` and `layoutOptions` props to `ListBox`
- When `virtualized` is true, wraps the RAC ListBox with `<Virtualizer layout={ListLayout}>`
- `ListBoxItem` applies required virtualizer styles (`height: 100%`, `minHeight: 0`) via context
- Backward-compatible: non-virtualized ListBox behavior is unchanged

**TagField** (`packages/components/src/TagField/`):
- Passes `virtualized` to the ListBox in `TagFieldDropdown`
- Added `LargeDataset` story (800 items) with a component test for visual regression

**Test infra** (`vite.config.ts`, `vitest.config.shared.ts`):
- Added `define` for `process.env.NODE_ENV` / `process.env.VIRT_ON` in vitest browser-mode projects — `@react-aria/virtualizer` references `process.env` which doesn't exist in the browser test environment (Firefox via Playwright)
- Added `@react-aria/virtualizer` and `@react-stately/layout` to `browserDeps` for pre-bundling

# Test Instructions:

1. Run `pnpm sb`, open the **LargeDataset** story → dropdown should open instantly, scrolling should be smooth
2. Search for a specific item (e.g. "item-500") → results filter instantly
3. Select items → tags appear correctly, removal works
4. Verify **Basic** and **Controlled** stories still work as before
5. Run `pnpm test:unit` → all tests pass
6. Run `pnpm test:sb` → story tests pass (including new LargeDataset test)

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [x] Updated visual regression tests (only necessary when ui changes in the PR)