### PR TITLE
feat(DST-1323): enable virtualization for Select, ComboBox, and Autocomplete

### DIFF
--- a/.changeset/listbox-virtualization-everywhere.md
+++ b/.changeset/listbox-virtualization-everywhere.md
@@ -1,0 +1,10 @@
+---
+"@marigold/components": minor
+---
+
+feat(DST-1323): always-on virtualization for `<Select>`, `<ComboBox>`, and `<Autocomplete>` dropdowns
+
+Follow-up to #5307. Large datasets (hundreds to thousands of items) no longer freeze the browser when opening or filtering these components — the internal `<ListBox>` is now virtualized with `react-aria`'s `Virtualizer` + `ListLayout` (same pattern used by `<TagField>`).
+
+- `<Select>`, `<ComboBox>`, `<Autocomplete>`: virtualization is enabled by default on desktop, with no public API change
+- `<ListBox>`: the virtualized list now has a bounded height (`max-h: 24rem`) so the virtualizer has a viewport to clip against when used inside a `<Popover>`

--- a/packages/components/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { useState } from 'react';
 import { Text } from 'react-aria-components';
-import { expect, userEvent, waitFor } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { useAsyncList } from '@react-stately/data';
 import { Center } from '../Center/Center';
@@ -299,6 +299,51 @@ export const DisabledSuggestions: any = meta.story({
       <Autocomplete.Option id="garlic">Garlic</Autocomplete.Option>
     </Autocomplete>
   ),
+});
+
+const LARGE_ITEMS = Array.from({ length: 800 }, (_, i) => ({
+  id: `item-${i + 200}`,
+  label: `Tenant ${i + 200} (item-${i + 200})`,
+}));
+
+export const LargeDataset: any = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Tenants',
+    placeholder: 'Search tenants...',
+    width: 80,
+  },
+  render: args => (
+    <Autocomplete {...args}>
+      {LARGE_ITEMS.map(item => (
+        <Autocomplete.Option key={item.id} id={item.id}>
+          {item.label}
+        </Autocomplete.Option>
+      ))}
+    </Autocomplete>
+  ),
+  play: async ({ canvas, step }: any) => {
+    const input = canvas.getByRole('combobox');
+
+    await step('Type to filter the large dataset', async () => {
+      await userEvent.click(input);
+      await userEvent.type(input, 'item-500');
+      await waitFor(() => canvas.getByRole('listbox'));
+    });
+
+    await step('Verify filtered result is rendered and select it', async () => {
+      const listbox = canvas.getByRole('listbox');
+      const option = within(listbox).getByText('Tenant 500 (item-500)');
+      expect(option).toBeVisible();
+      await userEvent.click(option);
+    });
+
+    await step('Verify selected value appears in the input', async () => {
+      await waitFor(() => {
+        expect(input).toHaveValue('Tenant 500 (item-500)');
+      });
+    });
+  },
 });
 
 export const Mobile: any = meta.story({

--- a/packages/components/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.stories.tsx
@@ -331,11 +331,12 @@ export const LargeDataset: any = meta.story({
       await waitFor(() => canvas.getByRole('listbox'));
     });
 
-    await step('Verify filtered result is rendered and select it', async () => {
+    await step('Verify filter narrowed to a single option', async () => {
       const listbox = canvas.getByRole('listbox');
-      const option = within(listbox).getByText('Tenant 500 (item-500)');
-      expect(option).toBeVisible();
-      await userEvent.click(option);
+      const options = within(listbox).getAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Tenant 500 (item-500)');
+      await userEvent.click(options[0]);
     });
 
     await step('Verify selected value appears in the input', async () => {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -271,6 +271,7 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
             />
             <Popover>
               <ListBox
+                virtualized
                 renderEmptyState={() =>
                   emptyState ?? (
                     <Center>{stringFormatter.format('noResultsFound')}</Center>

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -1,6 +1,6 @@
 import { Key, useState } from 'react';
 import { I18nProvider } from 'react-aria-components';
-import { expect, fn, userEvent, waitFor } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { useAsyncList } from '@react-stately/data';
 import { Stack } from '../Stack/Stack';
@@ -408,6 +408,49 @@ export const OnAction: any = meta.story({
     await userEvent.keyboard('{Enter}');
 
     await waitFor(() => expect(onActionMock).toHaveBeenCalledTimes(3));
+  },
+});
+
+const LARGE_ITEMS = Array.from({ length: 800 }, (_, i) => ({
+  id: `item-${i + 200}`,
+  label: `Tenant ${i + 200} (item-${i + 200})`,
+}));
+
+export const LargeDataset: any = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Tenants',
+    placeholder: 'Search tenants...',
+    width: 80,
+  },
+  render: args => (
+    <ComboBox {...args} items={LARGE_ITEMS}>
+      {(item: (typeof LARGE_ITEMS)[number]) => (
+        <ComboBox.Option id={item.id}>{item.label}</ComboBox.Option>
+      )}
+    </ComboBox>
+  ),
+  play: async ({ canvas, step }: any) => {
+    const input = canvas.getByRole('combobox');
+
+    await step('Open the dropdown by typing', async () => {
+      await userEvent.click(input);
+      await userEvent.type(input, 'item-500');
+      await waitFor(() => canvas.getByRole('listbox'));
+    });
+
+    await step('Verify filtered result is rendered', async () => {
+      const listbox = canvas.getByRole('listbox');
+      const option = within(listbox).getByText('Tenant 500 (item-500)');
+      expect(option).toBeVisible();
+      await userEvent.click(option);
+    });
+
+    await step('Verify selected value appears in the input', async () => {
+      await waitFor(() => {
+        expect(input).toHaveValue('Tenant 500 (item-500)');
+      });
+    });
   },
 });
 

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -424,26 +424,29 @@ export const LargeDataset: any = meta.story({
     width: 80,
   },
   render: args => (
-    <ComboBox {...args} items={LARGE_ITEMS}>
-      {(item: (typeof LARGE_ITEMS)[number]) => (
-        <ComboBox.Option id={item.id}>{item.label}</ComboBox.Option>
-      )}
+    <ComboBox {...args}>
+      {LARGE_ITEMS.map(item => (
+        <ComboBox.Option key={item.id} id={item.id}>
+          {item.label}
+        </ComboBox.Option>
+      ))}
     </ComboBox>
   ),
   play: async ({ canvas, step }: any) => {
     const input = canvas.getByRole('combobox');
 
-    await step('Open the dropdown by typing', async () => {
+    await step('Filter the large dataset by typing', async () => {
       await userEvent.click(input);
       await userEvent.type(input, 'item-500');
       await waitFor(() => canvas.getByRole('listbox'));
     });
 
-    await step('Verify filtered result is rendered', async () => {
+    await step('Verify filter narrowed to a single option', async () => {
       const listbox = canvas.getByRole('listbox');
-      const option = within(listbox).getByText('Tenant 500 (item-500)');
-      expect(option).toBeVisible();
-      await userEvent.click(option);
+      const options = within(listbox).getAllByRole('option');
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent('Tenant 500 (item-500)');
+      await userEvent.click(options[0]);
     });
 
     await step('Verify selected value appears in the input', async () => {

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -180,6 +180,7 @@ const _ComboBox = forwardRef<HTMLInputElement, ComboBoxProps>(
             />
             <Popover>
               <ListBox
+                virtualized
                 renderEmptyState={() =>
                   emptyState ?? (
                     <Center>{stringFormatter.format('noResultsFound')}</Center>

--- a/packages/components/src/ListBox/ListBox.tsx
+++ b/packages/components/src/ListBox/ListBox.tsx
@@ -47,7 +47,14 @@ const _ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
         {...props}
         className={cn('overflow-y-auto', classNames.list)}
         ref={ref as Ref<HTMLDivElement>}
-        style={virtualized ? { display: 'block', padding: 0 } : undefined}
+        // Bound the virtualized list so the Virtualizer has a viewport to
+        // clip against. Without this, the list grows to fit all items and
+        // virtualization has no effect.
+        style={
+          virtualized
+            ? { display: 'block', padding: 0, maxHeight: '24rem' }
+            : undefined
+        }
         {...listBoxProps}
       >
         {props.children}

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -501,6 +501,53 @@ export const WithImages = meta.story({
   },
 });
 
+const LARGE_ITEMS = Array.from({ length: 800 }, (_, i) => ({
+  id: `item-${i + 200}`,
+  label: `Tenant ${i + 200} (item-${i + 200})`,
+}));
+
+export const LargeDataset = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Tenants',
+    placeholder: 'Select a tenant',
+    width: 80,
+  },
+  render: args => (
+    <Select {...args} items={LARGE_ITEMS}>
+      {(item: (typeof LARGE_ITEMS)[number]) => (
+        <Select.Option id={item.id}>{item.label}</Select.Option>
+      )}
+    </Select>
+  ),
+  play: async ({ args, canvas, step }) => {
+    await step('Open the select dropdown', async () => {
+      const button = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
+      await userEvent.click(button);
+      await waitFor(() => canvas.getByRole('listbox'));
+    });
+
+    await step('Verify listbox renders without freezing', async () => {
+      const listbox = canvas.getByRole('listbox');
+      expect(listbox).toBeVisible();
+    });
+
+    await step('Select a visible item from the top of the list', async () => {
+      const listbox = canvas.getByRole('listbox');
+      const option = within(listbox).getByText('Tenant 200 (item-200)');
+      await userEvent.click(option);
+    });
+
+    await step('Verify selected value appears in trigger', async () => {
+      await waitFor(() => {
+        expect(canvas.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+      const button = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
+      expect(within(button).getByText('Tenant 200 (item-200)')).toBeVisible();
+    });
+  },
+});
+
 export const Mobile = meta.story({
   globals: {
     viewport: { value: 'smallScreen' },

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -169,7 +169,9 @@ const SelectBase = (forwardRef as forwardRefType)(function Select<
             <ChevronsVertical size="16" className={classNames.icon} />
           </RACButton>
           <Popover>
-            <ListBox items={items}>{children}</ListBox>
+            <ListBox items={items} virtualized>
+              {children}
+            </ListBox>
           </Popover>
         </>
       )}


### PR DESCRIPTION
## Summary

Follow-up to #5307. Turns on the `<ListBox>` `virtualized` prop for the three remaining ListBox-based components so large datasets (hundreds to thousands of items) no longer freeze the browser on open or filter. Virtualization is always-on — no public API change, matching the `<TagField>` pattern.

- `<Select>`, `<ComboBox>`, `<Autocomplete>`: desktop dropdowns now virtualize
- `<ListBox>`: the virtualized list now has a bounded max-height (24rem / `max-h-96`) so the `Virtualizer` has a viewport to clip against when used inside `<Popover>`. Non-virtualized ListBoxes are unchanged.
- Adds a `LargeDataset` story (800 items) with a component-test play function for each of the three components, mirroring the `<TagField>` `LargeDataset` setup.

Ticket: [DST-1323](https://reservix.atlassian.net/browse/DST-1323)

## Test plan

- [x] `pnpm test:sb` → 116 passed (incl. the three new `LargeDataset` tests)
- [x] `pnpm test:unit` → 1011 passed
- [x] `pnpm typecheck:only` → clean
- [x] `pnpm lint` → 0 errors
- [x] Manual check in Storybook (Firefox): opened each new `LargeDataset` story, dropdown renders instantly, scrolls smoothly, selection works. Verified via devtools that only ~16 of 800 option elements are in the DOM (`listboxClientHeight: 384`, `listboxScrollHeight: 26407`).
- [x] Sanity-checked existing stories: `Basic` / `Sections` / `WithSections` / `LotsOfOptions` / `Mobile` for each component still pass.

## Pull Request Checklist

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change
- [ ] Added/Updated documentation (if it already exists for this component) — n/a, no public API change
- [x] Updated visual regression tests (only necessary when ui changes in the PR)

[DST-1323]: https://reservix.atlassian.net/browse/DST-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ