### PR TITLE
feat(DST-1325): add universal `none` spacing token

### DIFF
--- a/.changeset/no-spacing-token.md
+++ b/.changeset/no-spacing-token.md
@@ -1,0 +1,13 @@
+---
+"@marigold/system": minor
+"@marigold/components": minor
+"@marigold/theme-rui": minor
+---
+
+feat(DST-1257): add universal `none` spacing token
+
+- Introduce `NoSpacingToken = 'none'` shared across all spacing token families
+- Add `'none'` to `SpacingTokens`, `PaddingSpacingTokens`, and `InsetSpacingTokens`
+- Add `--spacing-none: --spacing(0)` CSS custom property to the theme
+
+`'none'` now works wherever a spacing token is accepted: `Stack`/`Inline` gap (`space="none"`), `Inset` axis padding (`spaceX="none"` / `spaceY="none"`), and `Inset` recipes (`space="none"`) — useful for wrappers that should render without adding any spacing (e.g. an edge-to-edge `Table` inside a containing component).

--- a/packages/components/src/Inline/Inline.stories.tsx
+++ b/packages/components/src/Inline/Inline.stories.tsx
@@ -16,7 +16,7 @@ const meta = preview.meta({
       control: {
         type: 'select',
       },
-      options: ['tight', 'related', 'regular', 'group', 'section'],
+      options: ['none', 'tight', 'related', 'regular', 'group', 'section'],
       table: {
         type: { summary: 'text' },
         defaultValue: { summary: 'undefined' },

--- a/packages/components/src/Inset/Inset.stories.tsx
+++ b/packages/components/src/Inset/Inset.stories.tsx
@@ -17,6 +17,7 @@ const meta = preview.meta({
         type: 'select',
       },
       options: [
+        'none',
         'square-tight',
         'square-snug',
         'square-regular',
@@ -40,6 +41,7 @@ const meta = preview.meta({
         type: 'select',
       },
       options: [
+        'none',
         'padding-tight',
         'padding-snug',
         'padding-regular',
@@ -53,6 +55,7 @@ const meta = preview.meta({
         type: 'select',
       },
       options: [
+        'none',
         'padding-tight',
         'padding-snug',
         'padding-regular',

--- a/packages/components/src/Stack/Stack.stories.tsx
+++ b/packages/components/src/Stack/Stack.stories.tsx
@@ -19,7 +19,7 @@ const meta = preview.meta({
       control: {
         type: 'select',
       },
-      options: ['tight', 'related', 'regular', 'group', 'section'],
+      options: ['none', 'tight', 'related', 'regular', 'group', 'section'],
       description: 'Responsive Style Value',
     },
     alignX: {

--- a/packages/system/src/types/tokens.ts
+++ b/packages/system/src/types/tokens.ts
@@ -1,12 +1,25 @@
 /**
+ * Universal "no spacing" token shared across all spacing families.
+ *
+ * Resolves to `0` and works anywhere a spacing token is accepted: relational
+ * spacing (e.g. `Stack` gap), single-axis padding (`spaceX`/`spaceY`), and
+ * inset recipes (`Inset` `space`). Useful when a wrapper should render without
+ * adding any space — e.g. a Panel containing an edge-to-edge Table.
+ */
+export type NoSpacingToken = 'none';
+
+/**
  * Semantic spacing tokens that describe the strength of the relationship between elements.
  *
  * The tighter the space, the stronger the relationship. These tokens follow a relational
  * scale where naming reflects the cognitive connection between objects rather than
  * arbitrary pixel values, allowing interfaces to adapt gracefully across different
  * contexts and density settings.
+ *
+ * Includes the universal `none` token for the no-spacing case.
  */
 export type SpacingTokens =
+  | NoSpacingToken
   | 'tight'
   | 'related'
   | 'regular'
@@ -19,9 +32,11 @@ export type SpacingTokens =
  * Single-value tokens that can be composed to create symmetric or
  * asymmetric padding on any component.
  *
- * Five density levels: tight, snug, regular, relaxed, loose.
+ * Five density levels: tight, snug, regular, relaxed, loose, plus the universal
+ * `none` token for the no-spacing case.
  */
 export type PaddingSpacingTokens =
+  | NoSpacingToken
   | 'padding-tight'
   | 'padding-snug'
   | 'padding-regular'
@@ -32,13 +47,15 @@ export type PaddingSpacingTokens =
  * Inset spacing recipe tokens for the `space` prop on Inset.
  *
  * Multi-value tokens that set padding on all sides at once:
+ * - `none`: No padding (equivalent to 0)
  * - `square-*`: Equal padding on all sides
  * - `squish-*`: More horizontal than vertical padding
  * - `stretch-*`: More vertical than horizontal padding
  *
- * Each category has five density levels: tight, snug, regular, relaxed, loose.
+ * Each `*-*` category has five density levels: tight, snug, regular, relaxed, loose.
  */
 export type InsetSpacingTokens =
+  | NoSpacingToken
   | 'square-tight'
   | 'square-snug'
   | 'square-regular'

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -185,6 +185,9 @@
   --spacing-control-large: 2.5rem;
   --spacing-container: 50rem;
 
+  /* Universal: no spacing (works for gap, padding, and inset recipes) */
+  --spacing-none: --spacing(0);
+
   /* Relational spacing */
   --spacing-tight: --spacing(1.5);
   --spacing-related: --spacing(2);


### PR DESCRIPTION
## Summary

- Introduce a shared `NoSpacingToken = 'none'` and include it in `SpacingTokens`, `PaddingSpacingTokens`, and `InsetSpacingTokens` so `'none'` works for any spacing prop.
- Add `--spacing-none: --spacing(0)` to `themes/theme-rui/src/theme.css`.
- Expose `'none'` in `Stack`, `Inline`, and `Inset` story controls.
- Foundational change for the upcoming `Panel` component, which needs an edge-to-edge content mode for tables.

`'none'` now works for `Stack`/`Inline` gap (`space="none"`), `Inset` axis padding (`spaceX="none"` / `spaceY="none"`), and `Inset` recipes (`space="none"`).

Implements [DST-1325](https://reservix.atlassian.net/browse/DST-1325).

## Test plan

- [ ] `pnpm typecheck:only` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test:unit` passes
- [ ] CI build green
- [ ] Sanity: `<Inset space="none">` and `<Stack space="none">` render with no padding/gap in Storybook

[DST-1325]: https://reservix.atlassian.net/browse/DST-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ