### PR TITLE
[DST-1301]: remove linting warning @eslint-react/no-forward-ref

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.tsx
+++ b/packages/components/src/ActionBar/ActionBar.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
-import type { ForwardRefExoticComponent, ReactNode } from 'react';
-import { forwardRef, useLayoutEffect, useRef, useState } from 'react';
+import type { ReactNode, Ref } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { Toolbar } from 'react-aria-components';
 import { FocusScope } from '@react-aria/focus';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
@@ -53,12 +53,6 @@ export interface ActionBarProps {
   size?: string;
 }
 
-interface ActionBarComponent extends ForwardRefExoticComponent<
-  ActionBarProps & React.RefAttributes<HTMLDivElement>
-> {
-  Button: typeof ActionButton;
-}
-
 // Inner
 // ---------------
 interface ActionBarInnerProps {
@@ -71,163 +65,164 @@ interface ActionBarInnerProps {
   size?: string;
 }
 
-const ActionBarInner = forwardRef<HTMLDivElement, ActionBarInnerProps>(
-  (
-    { id, children, onClearSelection, lastCount, isExiting, variant, size },
-    forwardedRef
-  ) => {
-    const internalRef = useRef<HTMLDivElement>(null);
-    const ref = (forwardedRef ??
-      internalRef) as React.RefObject<HTMLDivElement | null>;
-    const isEntering = useEnterAnimation(ref);
+const ActionBarInner = ({
+  id,
+  children,
+  onClearSelection,
+  lastCount,
+  isExiting,
+  variant,
+  size,
+  ref: forwardedRef,
+}: ActionBarInnerProps & { ref?: Ref<HTMLDivElement> }) => {
+  const internalRef = useRef<HTMLDivElement>(null);
+  const ref = (forwardedRef ??
+    internalRef) as React.RefObject<HTMLDivElement | null>;
+  const isEntering = useEnterAnimation(ref);
 
-    const classNames = useClassNames({
-      component: 'ActionBar',
-      variant,
-      size,
-    });
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  const classNames = useClassNames({
+    component: 'ActionBar',
+    variant,
+    size,
+  });
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    const {
-      keyboardProps: { onKeyDown, onKeyUp },
-    } = useKeyboard({
-      onKeyDown: e => {
-        if (e.key === 'Escape' && onClearSelection) {
-          e.preventDefault();
-          onClearSelection();
-        }
-      },
-    });
+  const {
+    keyboardProps: { onKeyDown, onKeyUp },
+  } = useKeyboard({
+    onKeyDown: e => {
+      if (e.key === 'Escape' && onClearSelection) {
+        e.preventDefault();
+        onClearSelection();
+      }
+    },
+  });
 
-    return (
-      <FocusScope restoreFocus>
-        <motion.div
-          layout
-          ref={ref}
-          id={id}
-          onKeyDown={onKeyDown}
-          onKeyUp={onKeyUp}
-          className={cn(
-            classNames.container,
-            'sticky bottom-(--actionbar-offset,8px) z-30 mx-auto w-max'
-          )}
-          transition={{
-            layout: { type: 'spring', stiffness: 500, damping: 30, mass: 0.5 },
-          }}
-          data-entering={isEntering || undefined}
-          data-exiting={isExiting || undefined}
-        >
-          <div className={classNames.selection}>
-            {onClearSelection && (
-              <IconButton
-                aria-label={stringFormatter.format('clearSelectionAriaLabel')}
-                onPress={onClearSelection}
-                className={classNames.clearButton}
-              >
-                <X />
-              </IconButton>
-            )}
-
-            <div className={classNames.count}>
-              {lastCount === 'all'
-                ? stringFormatter.format('selectedAll')
-                : stringFormatter.format('selectedCount', {
-                    count: lastCount,
-                  })}
-            </div>
-          </div>
-
-          <Toolbar
-            className={classNames.toolbar}
-            aria-label={stringFormatter.format('bulkActionsAriaLabel')}
-          >
-            {children}
-          </Toolbar>
-        </motion.div>
-
-        {/* Screen reader announcement when ActionBar appears */}
-        {!isExiting && (
-          <div className="sr-only" role="status" aria-live="polite">
-            {stringFormatter.format('actionsAvailable')}
-          </div>
+  return (
+    <FocusScope restoreFocus>
+      <motion.div
+        layout
+        ref={ref}
+        id={id}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        className={cn(
+          classNames.container,
+          'sticky bottom-(--actionbar-offset,8px) z-30 mx-auto w-max'
         )}
-      </FocusScope>
-    );
-  }
-);
+        transition={{
+          layout: { type: 'spring', stiffness: 500, damping: 30, mass: 0.5 },
+        }}
+        data-entering={isEntering || undefined}
+        data-exiting={isExiting || undefined}
+      >
+        <div className={classNames.selection}>
+          {onClearSelection && (
+            <IconButton
+              aria-label={stringFormatter.format('clearSelectionAriaLabel')}
+              onPress={onClearSelection}
+              className={classNames.clearButton}
+            >
+              <X />
+            </IconButton>
+          )}
+
+          <div className={classNames.count}>
+            {lastCount === 'all'
+              ? stringFormatter.format('selectedAll')
+              : stringFormatter.format('selectedCount', {
+                  count: lastCount,
+                })}
+          </div>
+        </div>
+
+        <Toolbar
+          className={classNames.toolbar}
+          aria-label={stringFormatter.format('bulkActionsAriaLabel')}
+        >
+          {children}
+        </Toolbar>
+      </motion.div>
+
+      {/* Screen reader announcement when ActionBar appears */}
+      {!isExiting && (
+        <div className="sr-only" role="status" aria-live="polite">
+          {stringFormatter.format('actionsAvailable')}
+        </div>
+      )}
+    </FocusScope>
+  );
+};
 
 // Outer
 // ---------------
-const _ActionBar = forwardRef<HTMLDivElement, ActionBarProps>(
-  (
-    {
-      children,
-      id,
-      onClearSelection: onClearSelectionProp,
-      selectedItemCount: selectedItemCountProp,
-      variant,
-      size,
+const ActionBarBase = ({
+  children,
+  id,
+  onClearSelection: onClearSelectionProp,
+  selectedItemCount: selectedItemCountProp,
+  variant,
+  size,
+  ref: forwardedRef,
+}: ActionBarProps & { ref?: Ref<HTMLDivElement> }) => {
+  const context = useActionBarContext();
+  const selectedItemCount =
+    selectedItemCountProp ?? context?.selectedItemCount ?? 0;
+  const onClearSelection = onClearSelectionProp ?? context?.onClearSelection;
+  const onHeightChange = context?.onHeightChange;
+  const isSSR = useIsSSR();
+
+  // Internal ref for exit animation
+  const internalRef = useRef<HTMLDivElement>(null);
+  const ref = (forwardedRef ??
+    internalRef) as React.RefObject<HTMLDivElement | null>;
+
+  const isOpen = selectedItemCount !== 0;
+  const isExiting = useExitAnimation(ref, isOpen);
+  const shouldRender = !isSSR && (isOpen || isExiting);
+
+  // Report measured height back to useActionBar via context
+  useResizeObserver({
+    ref,
+    onResize: () => {
+      onHeightChange?.(ref.current?.offsetHeight ?? 0);
     },
-    forwardedRef
-  ) => {
-    const context = useActionBarContext();
-    const selectedItemCount =
-      selectedItemCountProp ?? context?.selectedItemCount ?? 0;
-    const onClearSelection = onClearSelectionProp ?? context?.onClearSelection;
-    const onHeightChange = context?.onHeightChange;
-    const isSSR = useIsSSR();
+  });
 
-    // Internal ref for exit animation
-    const internalRef = useRef<HTMLDivElement>(null);
-    const ref = (forwardedRef ??
-      internalRef) as React.RefObject<HTMLDivElement | null>;
+  useLayoutEffect(() => {
+    if (shouldRender) return;
+    onHeightChange?.(0);
+  }, [shouldRender, onHeightChange]);
 
-    const isOpen = selectedItemCount !== 0;
-    const isExiting = useExitAnimation(ref, isOpen);
-    const shouldRender = !isSSR && (isOpen || isExiting);
-
-    // Report measured height back to useActionBar via context
-    useResizeObserver({
-      ref,
-      onResize: () => {
-        onHeightChange?.(ref.current?.offsetHeight ?? 0);
-      },
-    });
-
-    useLayoutEffect(() => {
-      if (shouldRender) return;
-      onHeightChange?.(0);
-    }, [shouldRender, onHeightChange]);
-
-    // Retain last count so we don't flash "0 selected" during exit animation
-    const [lastCount, setLastCount] = useState(selectedItemCount);
-    if (selectedItemCount !== 0 && selectedItemCount !== lastCount) {
-      setLastCount(selectedItemCount);
-    }
-
-    // Nothing to render
-    if (!shouldRender) {
-      return null;
-    }
-
-    return (
-      <ActionBarInner
-        ref={ref}
-        id={id}
-        onClearSelection={onClearSelection}
-        lastCount={lastCount}
-        isExiting={isExiting}
-        variant={variant}
-        size={size}
-      >
-        {children}
-      </ActionBarInner>
-    );
+  // Retain last count so we don't flash "0 selected" during exit animation
+  const [lastCount, setLastCount] = useState(selectedItemCount);
+  if (selectedItemCount !== 0 && selectedItemCount !== lastCount) {
+    setLastCount(selectedItemCount);
   }
-);
 
-const ActionBar = _ActionBar as ActionBarComponent;
-ActionBar.Button = ActionButton;
+  // Nothing to render
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <ActionBarInner
+      ref={ref}
+      id={id}
+      onClearSelection={onClearSelection}
+      lastCount={lastCount}
+      isExiting={isExiting}
+      variant={variant}
+      size={size}
+    >
+      {children}
+    </ActionBarInner>
+  );
+};
+
+const ActionBar = Object.assign(ActionBarBase, {
+  Button: ActionButton,
+});
 
 export { ActionBar };
 export type { ActionButtonProps };

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -1,11 +1,5 @@
-import {
-  ForwardRefExoticComponent,
-  ReactNode,
-  Ref,
-  RefAttributes,
-  forwardRef,
-  use,
-} from 'react';
+import type { ReactNode, Ref } from 'react';
+import { use } from 'react';
 import type RAC from 'react-aria-components';
 import { ComboBox, ComboBoxStateContext, Key } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
@@ -191,104 +185,85 @@ export interface AutocompleteProps
   onSubmit?: (value: string | number | null, key: Key | null) => void;
 }
 
-interface AutocompleteComponent extends ForwardRefExoticComponent<
-  AutocompleteProps & RefAttributes<HTMLInputElement>
-> {
-  /**
-   * Options for the Combobox.
-   */
-  Option: typeof ListBox.Item;
-
-  /**
-   * Section for the Combobox, to put options in.
-   */
-  Section: typeof ListBox.Section;
-}
-
 // Component
 // ---------------
-const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
-  (
-    {
-      children,
-      defaultValue,
-      value,
-      disabled,
-      error,
-      readOnly,
-      required,
-      emptyState,
-      loading,
-      onChange,
-      onClear,
-      onSubmit,
-      ...rest
-    }: AutocompleteProps,
-    ref
-  ) => {
-    const props: RAC.ComboBoxProps<object> = {
-      onSelectionChange: key => key !== null && onSubmit?.(key, null),
-      defaultInputValue: defaultValue,
-      inputValue: value,
-      onInputChange: onChange,
-      allowsCustomValue: true,
-      isDisabled: disabled,
-      isInvalid: error,
-      isReadOnly: readOnly,
-      isRequired: required,
-      ...rest,
-    };
+const AutocompleteBase = ({
+  children,
+  defaultValue,
+  value,
+  disabled,
+  error,
+  readOnly,
+  required,
+  emptyState,
+  loading,
+  onChange,
+  onClear,
+  onSubmit,
+  ref,
+  ...rest
+}: AutocompleteProps & { ref?: Ref<HTMLInputElement> }) => {
+  const props: RAC.ComboBoxProps<object> = {
+    onSelectionChange: key => key !== null && onSubmit?.(key, null),
+    defaultInputValue: defaultValue,
+    inputValue: value,
+    onInputChange: onChange,
+    allowsCustomValue: true,
+    isDisabled: disabled,
+    isInvalid: error,
+    isReadOnly: readOnly,
+    isRequired: required,
+    ...rest,
+  };
 
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
-    const isSmallScreen = useSmallScreen();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  const isSmallScreen = useSmallScreen();
 
-    return (
-      <FieldBase as={ComboBox} ref={ref} {...props}>
-        {isSmallScreen ? (
-          <MobileAutocomplete
-            placeholder={rest.placeholder}
-            label={rest.label}
-            emptyState={emptyState}
-            input={
-              <AutocompleteInput
-                loading={loading}
-                onSubmit={onSubmit}
-                onClear={onClear}
-                ref={ref}
-                autoFocus
-              />
-            }
-          >
-            {children}
-          </MobileAutocomplete>
-        ) : (
-          <>
+  return (
+    <FieldBase as={ComboBox} ref={ref} {...props}>
+      {isSmallScreen ? (
+        <MobileAutocomplete
+          placeholder={rest.placeholder}
+          label={rest.label}
+          emptyState={emptyState}
+          input={
             <AutocompleteInput
               loading={loading}
               onSubmit={onSubmit}
               onClear={onClear}
               ref={ref}
+              autoFocus
             />
-            <Popover>
-              <ListBox
-                virtualized
-                renderEmptyState={() =>
-                  emptyState ?? (
-                    <Center>{stringFormatter.format('noResultsFound')}</Center>
-                  )
-                }
-              >
-                {children}
-              </ListBox>
-            </Popover>
-          </>
-        )}
-      </FieldBase>
-    );
-  }
-) as AutocompleteComponent;
-
-_Autocomplete.Option = ListBox.Item;
-_Autocomplete.Section = ListBox.Section;
-
-export { _Autocomplete as Autocomplete };
+          }
+        >
+          {children}
+        </MobileAutocomplete>
+      ) : (
+        <>
+          <AutocompleteInput
+            loading={loading}
+            onSubmit={onSubmit}
+            onClear={onClear}
+            ref={ref}
+          />
+          <Popover>
+            <ListBox
+              virtualized
+              renderEmptyState={() =>
+                emptyState ?? (
+                  <Center>{stringFormatter.format('noResultsFound')}</Center>
+                )
+              }
+            >
+              {children}
+            </ListBox>
+          </Popover>
+        </>
+      )}
+    </FieldBase>
+  );
+};
+export const Autocomplete = Object.assign(AutocompleteBase, {
+  Option: ListBox.Item,
+  Section: ListBox.Section,
+});

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,5 @@
-import {
-  Children,
-  ForwardRefExoticComponent,
-  ReactNode,
-  RefAttributes,
-  forwardRef,
-  isValidElement,
-  useRef,
-} from 'react';
+import type { ReactNode, Ref } from 'react';
+import { Children, isValidElement, useRef } from 'react';
 import {
   Link,
   Breadcrumb as RACBreadcrumb,
@@ -49,136 +42,133 @@ export interface BreadcrumbsProps extends Omit<
   children: ReactNode | ReactNode[];
 }
 
-export interface BreadcrumbsComponent extends ForwardRefExoticComponent<
-  BreadcrumbsProps & RefAttributes<HTMLOListElement>
-> {
-  Item: typeof BreadcrumbsItem;
-}
+const BreadcrumbsBase = ({
+  children,
+  variant,
+  size,
+  disabled,
+  maxVisibleItems = 'auto',
+  ref,
+  ...props
+}: BreadcrumbsProps & { ref?: Ref<HTMLOListElement> }) => {
+  const {
+    container,
+    item: breadcrumbsItem,
+    link,
+    current,
+  } = useClassNames({
+    component: 'Breadcrumbs',
+    variant,
+    size,
+  });
 
-const _Breadcrumbs = forwardRef<HTMLOListElement, BreadcrumbsProps>(
-  (
-    { children, variant, size, disabled, maxVisibleItems = 'auto', ...props },
-    ref
-  ) => {
-    const {
-      container,
-      item: breadcrumbsItem,
-      link,
-      current,
-    } = useClassNames({
-      component: 'Breadcrumbs',
-      variant,
-      size,
-    });
+  const items = Children.toArray(children);
+  const total = items.length;
 
-    const items = Children.toArray(children);
-    const total = items.length;
+  const objRef = useObjectRef(ref);
+  const hiddenRef = useRef<HTMLDivElement>(null);
 
-    const objRef = useObjectRef(ref);
-    const hiddenRef = useRef<HTMLDivElement>(null);
+  const autoMax = useAutoCollapse(objRef, hiddenRef, total);
 
-    const autoMax = useAutoCollapse(objRef, hiddenRef, total);
+  const effectiveMax = maxVisibleItems === 'auto' ? autoMax : maxVisibleItems;
 
-    const effectiveMax = maxVisibleItems === 'auto' ? autoMax : maxVisibleItems;
+  const shouldCollapse =
+    typeof effectiveMax === 'number' &&
+    effectiveMax >= 2 &&
+    total > effectiveMax;
 
-    const shouldCollapse =
-      typeof effectiveMax === 'number' &&
-      effectiveMax >= 2 &&
-      total > effectiveMax;
+  // When collapsed, show: [first, ellipsis, ...trailing, current]
+  // effectiveMax=2: [ellipsis, current] (no first item)
+  // effectiveMax=3: [first, ellipsis, current]
+  // effectiveMax=4: [first, ellipsis, item(n-1), current]
+  const sliceIndex = shouldCollapse
+    ? effectiveMax === 2
+      ? total - 1
+      : total - (effectiveMax - 2)
+    : 0;
 
-    // When collapsed, show: [first, ellipsis, ...trailing, current]
-    // effectiveMax=2: [ellipsis, current] (no first item)
-    // effectiveMax=3: [first, ellipsis, current]
-    // effectiveMax=4: [first, ellipsis, item(n-1), current]
-    const sliceIndex = shouldCollapse
-      ? effectiveMax === 2
-        ? total - 1
-        : total - (effectiveMax - 2)
-      : 0;
+  const hiddenItems = shouldCollapse
+    ? effectiveMax === 2
+      ? items.slice(0, -1)
+      : items.slice(1, sliceIndex)
+    : [];
 
-    const hiddenItems = shouldCollapse
-      ? effectiveMax === 2
-        ? items.slice(0, -1)
-        : items.slice(1, sliceIndex)
-      : [];
+  const displayedItems = shouldCollapse
+    ? effectiveMax === 2
+      ? [null, ...items.slice(sliceIndex)]
+      : [items[0], null, ...items.slice(sliceIndex)]
+    : items;
 
-    const displayedItems = shouldCollapse
-      ? effectiveMax === 2
-        ? [null, ...items.slice(sliceIndex)]
-        : [items[0], null, ...items.slice(sliceIndex)]
-      : items;
-
-    const breadcrumbs = (
-      <RACBreadcrumbs
-        {...props}
-        ref={objRef}
-        isDisabled={disabled}
-        className={cn(
-          container,
-          maxVisibleItems === 'auto' &&
-            'flex-nowrap overflow-hidden whitespace-nowrap'
-        )}
-      >
-        {displayedItems.map((item, index) => {
-          if (item === null) {
-            return (
-              <RACBreadcrumb key="ellipsis" className={breadcrumbsItem}>
-                <BreadcrumbEllipsis hiddenItems={hiddenItems} />
-                <ChevronRight
-                  aria-hidden="true"
-                  size={16}
-                  data-testid="breadcrumb-chevronright"
-                />
-              </RACBreadcrumb>
-            );
-          }
-
-          if (!isValidElement<BreadcrumbsItemProps>(item)) return null;
-
-          const { href, children: itemChildren, ...ariaProps } = item.props;
-
+  const breadcrumbs = (
+    <RACBreadcrumbs
+      {...props}
+      ref={objRef}
+      isDisabled={disabled}
+      className={cn(
+        container,
+        maxVisibleItems === 'auto' &&
+          'flex-nowrap overflow-hidden whitespace-nowrap'
+      )}
+    >
+      {displayedItems.map((item, index) => {
+        if (item === null) {
           return (
-            <RACBreadcrumb
-              key={`${href}-${index}`}
-              {...ariaProps}
-              className={breadcrumbsItem}
-            >
-              {({ isCurrent }) => (
-                <>
-                  <Link href={href} className={cn(link, isCurrent && current)}>
-                    {itemChildren}
-                  </Link>
-                  {!isCurrent && (
-                    <ChevronRight
-                      aria-hidden="true"
-                      size={16}
-                      data-testid="breadcrumb-chevronright"
-                    />
-                  )}
-                </>
-              )}
+            <RACBreadcrumb key="ellipsis" className={breadcrumbsItem}>
+              <BreadcrumbEllipsis hiddenItems={hiddenItems} />
+              <ChevronRight
+                aria-hidden="true"
+                size={16}
+                data-testid="breadcrumb-chevronright"
+              />
             </RACBreadcrumb>
           );
-        })}
-      </RACBreadcrumbs>
-    );
+        }
 
-    if (maxVisibleItems !== 'auto') {
-      return breadcrumbs;
-    }
+        if (!isValidElement<BreadcrumbsItemProps>(item)) return null;
 
-    return (
-      <HiddenBreadcrumbs
-        items={items}
-        itemClassName={breadcrumbsItem}
-        hiddenRef={hiddenRef}
-      >
-        {breadcrumbs}
-      </HiddenBreadcrumbs>
-    );
+        const { href, children: itemChildren, ...ariaProps } = item.props;
+
+        return (
+          <RACBreadcrumb
+            key={`${href}-${index}`}
+            {...ariaProps}
+            className={breadcrumbsItem}
+          >
+            {({ isCurrent }) => (
+              <>
+                <Link href={href} className={cn(link, isCurrent && current)}>
+                  {itemChildren}
+                </Link>
+                {!isCurrent && (
+                  <ChevronRight
+                    aria-hidden="true"
+                    size={16}
+                    data-testid="breadcrumb-chevronright"
+                  />
+                )}
+              </>
+            )}
+          </RACBreadcrumb>
+        );
+      })}
+    </RACBreadcrumbs>
+  );
+
+  if (maxVisibleItems !== 'auto') {
+    return breadcrumbs;
   }
-) as BreadcrumbsComponent;
 
-_Breadcrumbs.Item = BreadcrumbsItem;
+  return (
+    <HiddenBreadcrumbs
+      items={items}
+      itemClassName={breadcrumbsItem}
+      hiddenRef={hiddenRef}
+    >
+      {breadcrumbs}
+    </HiddenBreadcrumbs>
+  );
+};
 
-export { _Breadcrumbs as Breadcrumbs };
+export const Breadcrumbs = Object.assign(BreadcrumbsBase, {
+  Item: BreadcrumbsItem,
+});

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -1,11 +1,6 @@
-import type {
-  ForwardRefExoticComponent,
-  ReactNode,
-  RefAttributes,
-} from 'react';
-import { forwardRef } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
-import { ComboBox } from 'react-aria-components';
+import { ComboBox as RACComboBox } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { useClassNames, useSmallScreen } from '@marigold/system';
 import { Center } from '../Center/Center';
@@ -105,99 +100,76 @@ export interface ComboBoxProps
   loading?: boolean;
 }
 
-interface ComboBoxComponent extends ForwardRefExoticComponent<
-  ComboBoxProps & RefAttributes<HTMLInputElement>
-> {
-  /**
-   * Options for the Combobox.
-   */
-  Option: typeof ListBox.Item;
-
-  /**
-   * Section for the Combobox, to put options in.
-   */
-  Section: typeof ListBox.Section;
-}
-
 // Component
 // ---------------
-const _ComboBox = forwardRef<HTMLInputElement, ComboBoxProps>(
-  (
-    {
-      variant,
-      size,
-      required,
-      disabled,
-      readOnly,
-      error,
-      defaultValue,
-      value,
-      emptyState,
-      onChange,
-      children,
-      loading,
-      ...rest
-    },
-    ref
-  ) => {
-    const props: RAC.ComboBoxProps<any> = {
-      isDisabled: disabled,
-      isReadOnly: readOnly,
-      isRequired: required,
-      isInvalid: error,
-      defaultInputValue: defaultValue,
-      inputValue: value,
-      onInputChange: onChange,
-      ...rest,
-    };
+const ComboBoxBase = ({
+  variant,
+  size,
+  required,
+  disabled,
+  readOnly,
+  error,
+  defaultValue,
+  value,
+  emptyState,
+  onChange,
+  children,
+  loading,
+  ref,
+  ...rest
+}: ComboBoxProps & { ref?: Ref<HTMLInputElement> }) => {
+  const props: RAC.ComboBoxProps<any> = {
+    isDisabled: disabled,
+    isReadOnly: readOnly,
+    isRequired: required,
+    isInvalid: error,
+    defaultInputValue: defaultValue,
+    inputValue: value,
+    onInputChange: onChange,
+    ...rest,
+  };
 
-    const classNames = useClassNames({ component: 'ComboBox', variant, size });
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
-    const isSmallScreen = useSmallScreen();
+  const classNames = useClassNames({ component: 'ComboBox', variant, size });
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  const isSmallScreen = useSmallScreen();
 
-    return (
-      <FieldBase as={ComboBox} ref={ref} {...props}>
-        {isSmallScreen ? (
-          <MobileComboBox
-            placeholder={rest.placeholder}
-            label={rest.label}
-            emptyState={emptyState}
-          >
-            {children}
-          </MobileComboBox>
-        ) : (
-          <>
-            <Input
-              action={
-                <IconButton className={classNames.icon}>
-                  {loading ? (
-                    <ProgressCircle />
-                  ) : (
-                    <ChevronsVertical size="16" />
-                  )}
-                </IconButton>
+  return (
+    <FieldBase as={RACComboBox} ref={ref} {...props}>
+      {isSmallScreen ? (
+        <MobileComboBox
+          placeholder={rest.placeholder}
+          label={rest.label}
+          emptyState={emptyState}
+        >
+          {children}
+        </MobileComboBox>
+      ) : (
+        <>
+          <Input
+            action={
+              <IconButton className={classNames.icon}>
+                {loading ? <ProgressCircle /> : <ChevronsVertical size="16" />}
+              </IconButton>
+            }
+          />
+          <Popover>
+            <ListBox
+              virtualized
+              renderEmptyState={() =>
+                emptyState ?? (
+                  <Center>{stringFormatter.format('noResultsFound')}</Center>
+                )
               }
-            />
-            <Popover>
-              <ListBox
-                virtualized
-                renderEmptyState={() =>
-                  emptyState ?? (
-                    <Center>{stringFormatter.format('noResultsFound')}</Center>
-                  )
-                }
-              >
-                {children}
-              </ListBox>
-            </Popover>
-          </>
-        )}
-      </FieldBase>
-    );
-  }
-) as ComboBoxComponent;
-
-_ComboBox.Option = ListBox.Item;
-_ComboBox.Section = ListBox.Section;
-
-export { _ComboBox as ComboBox };
+            >
+              {children}
+            </ListBox>
+          </Popover>
+        </>
+      )}
+    </FieldBase>
+  );
+};
+export const ComboBox = Object.assign(ComboBoxBase, {
+  Option: ListBox.Item,
+  Section: ListBox.Section,
+});

--- a/packages/components/src/ContextualHelp/ContextualHelp.tsx
+++ b/packages/components/src/ContextualHelp/ContextualHelp.tsx
@@ -1,10 +1,4 @@
-import {
-  ComponentProps,
-  ForwardRefExoticComponent,
-  ReactNode,
-  RefAttributes,
-  forwardRef,
-} from 'react';
+import type { ComponentProps, ReactNode, Ref } from 'react';
 import {
   Button,
   Dialog,
@@ -23,18 +17,6 @@ const icons = {
   help: CircleQuestionMark,
   info: Info,
 };
-
-interface ContextualHelpComponent extends ForwardRefExoticComponent<
-  ContextualHelpProps & RefAttributes<HTMLInputElement>
-> {
-  /**
-   * Options for the Combobox.
-   */
-
-  Title: typeof ContextualHelpTitle;
-
-  Content: typeof ContextualHelpContent;
-}
 
 type RemovedProps = 'isOpen';
 interface DialogTriggerProps extends Omit<
@@ -96,71 +78,64 @@ export interface ContextualHelpProps {
   ariaLabel?: string;
 }
 
-export const _ContextualHelp = forwardRef<
-  HTMLButtonElement,
-  ContextualHelpProps
->(
-  (
-    {
-      children,
-      variant = 'help',
-      size,
-      width,
-      placement = 'bottom start',
-      offset = 0,
-      defaultOpen,
-      open,
-      onOpenChange,
-      ariaLabel,
-    },
-    ref
-  ) => {
-    const Icon = icons[variant];
-    const classNames = useClassNames({
-      component: 'ContextualHelp',
-      variant,
-      size,
-    });
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+const ContextualHelpBase = ({
+  children,
+  variant = 'help',
+  size,
+  width,
+  placement = 'bottom start',
+  offset = 0,
+  defaultOpen,
+  open,
+  onOpenChange,
+  ariaLabel,
+  ref,
+}: ContextualHelpProps & { ref?: Ref<HTMLButtonElement> }) => {
+  const Icon = icons[variant];
+  const classNames = useClassNames({
+    component: 'ContextualHelp',
+    variant,
+    size,
+  });
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    return (
-      <DialogTrigger
-        defaultOpen={defaultOpen}
-        open={open}
-        onOpenChange={onOpenChange}
+  return (
+    <DialogTrigger
+      defaultOpen={defaultOpen}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <Button
+        ref={ref}
+        className={classNames.trigger}
+        aria-label={
+          ariaLabel ??
+          (variant === 'info'
+            ? stringFormatter.format('moreInfo')
+            : stringFormatter.format('help'))
+        }
       >
-        <Button
-          ref={ref}
-          className={classNames.trigger}
-          aria-label={
-            ariaLabel ??
-            (variant === 'info'
-              ? stringFormatter.format('moreInfo')
-              : stringFormatter.format('help'))
-          }
+        <Icon size={20} />
+      </Button>
+
+      <Popover placement={placement} offset={offset}>
+        <Dialog
+          className={cn(
+            "grid [grid-template-areas:'title'_'content']",
+            classNames.container
+          )}
+          {...{
+            [`data-${width ?? 'medium'}`]: true,
+          }}
         >
-          <Icon size={20} />
-        </Button>
+          {children}
+        </Dialog>
+      </Popover>
+    </DialogTrigger>
+  );
+};
 
-        <Popover placement={placement} offset={offset}>
-          <Dialog
-            className={cn(
-              "grid [grid-template-areas:'title'_'content']",
-              classNames.container
-            )}
-            {...{
-              [`data-${width ?? 'medium'}`]: true,
-            }}
-          >
-            {children}
-          </Dialog>
-        </Popover>
-      </DialogTrigger>
-    );
-  }
-) as ContextualHelpComponent;
-
-_ContextualHelp.Title = ContextualHelpTitle;
-_ContextualHelp.Content = ContextualHelpContent;
-
-export { _ContextualHelp as ContextualHelp };
+export const ContextualHelp = Object.assign(ContextualHelpBase, {
+  Title: ContextualHelpTitle,
+  Content: ContextualHelpContent,
+});

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -1,5 +1,6 @@
 import { CalendarDate } from '@internationalized/date';
-import { ReactElement, forwardRef, use } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { use } from 'react';
 import type RAC from 'react-aria-components';
 import {
   DateField,
@@ -64,44 +65,40 @@ export interface DateFieldProps
   width?: WidthProp['width'];
 }
 
-const _DateField = forwardRef<HTMLInputElement, DateFieldProps>(
-  (
-    {
-      variant,
-      size,
-      action,
-      disabled,
-      required,
-      error,
-      readOnly,
-      onChange,
-      ...rest
-    }: DateFieldProps,
-    ref
-  ) => {
-    const props: RAC.DateFieldProps<DateValue> = {
-      isDisabled: disabled,
-      isReadOnly: readOnly,
-      isInvalid: error,
-      isRequired: required,
-      onChange,
-      ...rest,
-    };
-    return (
-      <FieldBase
-        as={DateField}
-        variant={variant}
-        size={size}
-        ref={ref}
-        {...props}
-      >
-        <DateInputWithPasteWrapper action={action} />
-      </FieldBase>
-    );
-  }
-);
+const DateFieldBase = ({
+  variant,
+  size,
+  action,
+  disabled,
+  required,
+  error,
+  readOnly,
+  onChange,
+  ref,
+  ...rest
+}: DateFieldProps & { ref?: Ref<HTMLInputElement> }) => {
+  const props: RAC.DateFieldProps<DateValue> = {
+    isDisabled: disabled,
+    isReadOnly: readOnly,
+    isInvalid: error,
+    isRequired: required,
+    onChange,
+    ...rest,
+  };
+  return (
+    <FieldBase
+      as={DateField}
+      variant={variant}
+      size={size}
+      ref={ref}
+      {...props}
+    >
+      <DateInputWithPasteWrapper action={action} />
+    </FieldBase>
+  );
+};
 
-export { _DateField as DateField };
+export { DateFieldBase as DateField };
 
 interface DateInputWithPasteWrapperProps {
   onChange?: (value: RAC.DateValue | null) => void;

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -1,5 +1,6 @@
 import { CalendarDate } from '@internationalized/date';
-import { ReactElement, forwardRef, use } from 'react';
+import type { ReactElement, Ref } from 'react';
+import { use } from 'react';
 import type RAC from 'react-aria-components';
 import {
   DatePicker,
@@ -78,83 +79,79 @@ export interface DatePickerProps
   width?: WidthProp['width'];
 }
 
-const _DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
-  (
-    {
-      dateUnavailable,
-      disabled,
-      required,
-      readOnly,
-      error,
-      variant,
-      size,
-      open,
-      granularity = 'day',
-      onChange,
-      ...rest
-    },
-    ref
-  ) => {
-    const props: RAC.DatePickerProps<DateValue> = {
-      isDateUnavailable: dateUnavailable,
-      isDisabled: disabled,
-      isReadOnly: readOnly,
-      isRequired: required,
-      isInvalid: error,
-      isOpen: open,
-      granularity,
-      onChange,
-      ...rest,
-    };
+const DatePickerBase = ({
+  dateUnavailable,
+  disabled,
+  required,
+  readOnly,
+  error,
+  variant,
+  size,
+  open,
+  granularity = 'day',
+  onChange,
+  ref,
+  ...rest
+}: DatePickerProps & { ref?: Ref<HTMLDivElement> }) => {
+  const props: RAC.DatePickerProps<DateValue> = {
+    isDateUnavailable: dateUnavailable,
+    isDisabled: disabled,
+    isReadOnly: readOnly,
+    isRequired: required,
+    isInvalid: error,
+    isOpen: open,
+    granularity,
+    onChange,
+    ...rest,
+  };
 
-    const classNames = useClassNames({
-      component: 'DatePicker',
-      size,
-      variant,
-    });
+  const classNames = useClassNames({
+    component: 'DatePicker',
+    size,
+    variant,
+  });
 
-    const isSmallScreen = useSmallScreen();
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  const isSmallScreen = useSmallScreen();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    return (
-      <FieldBase
-        as={DatePicker}
-        variant={variant}
-        size={size}
-        {...props}
-        ref={ref}
-      >
-        <DatePickerWithPasteWrapper
-          onChange={onChange}
-          action={
-            <IconButton className={classNames}>
-              <CalendarIcon size="16" data-testid="action" />
-            </IconButton>
-          }
-        />
-        {isSmallScreen ? (
-          <Tray>
-            <Tray.Title>{rest.label}</Tray.Title>
-            <Tray.Content>
-              <Calendar disabled={disabled} />
-            </Tray.Content>
-            <Tray.Actions>
-              <Button slot="close">{stringFormatter.format('close')}</Button>
-            </Tray.Actions>
-          </Tray>
-        ) : (
-          <Popover>
-            <Dialog>
-              <Calendar disabled={disabled} />
-            </Dialog>
-          </Popover>
-        )}
-      </FieldBase>
-    );
-  }
-);
+  return (
+    <FieldBase
+      as={DatePicker}
+      variant={variant}
+      size={size}
+      {...props}
+      ref={ref}
+    >
+      <DatePickerWithPasteWrapper
+        onChange={onChange}
+        action={
+          <IconButton className={classNames}>
+            <CalendarIcon size="16" data-testid="action" />
+          </IconButton>
+        }
+      />
+      {isSmallScreen ? (
+        <Tray>
+          <Tray.Title>{rest.label}</Tray.Title>
+          <Tray.Content>
+            <Calendar disabled={disabled} />
+          </Tray.Content>
+          <Tray.Actions>
+            <Button slot="close">{stringFormatter.format('close')}</Button>
+          </Tray.Actions>
+        </Tray>
+      ) : (
+        <Popover>
+          <Dialog>
+            <Calendar disabled={disabled} />
+          </Dialog>
+        </Popover>
+      )}
+    </FieldBase>
+  );
+};
 
-export { _DatePicker as DatePicker };
+export { DatePickerBase as DatePicker };
 
 interface DatePickerWithPasteWrapperProps {
   onChange?: (value: RAC.DateValue | null) => void;

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -1,12 +1,10 @@
-import {
-  ForwardRefExoticComponent,
-  Ref,
-  RefAttributes,
-  forwardRef,
-  use,
-} from 'react';
+import type { Ref } from 'react';
+import { use } from 'react';
 import type RAC from 'react-aria-components';
-import { Dialog, OverlayTriggerStateContext } from 'react-aria-components';
+import {
+  OverlayTriggerStateContext,
+  Dialog as RACDialog,
+} from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
 import { CloseButton } from '../CloseButton/CloseButton';
 import { Modal, ModalProps } from '../Overlay/Modal';
@@ -27,46 +25,47 @@ type InnerDialogProps = Pick<
  * Needed so that the close button and function can be used inside the dialog,
  * when the dialog is controlled and no <Dialog.Trigger> is used.
  */
-const InnerDialog = forwardRef(
-  (
-    { variant, size, closeButton, ...props }: InnerDialogProps,
-    ref: Ref<HTMLElement> | undefined
-  ) => {
-    const state = use(OverlayTriggerStateContext);
-    const classNames = useClassNames({
-      component: 'Dialog',
-      variant,
-      size,
-    });
+const InnerDialog = ({
+  variant,
+  size,
+  closeButton,
+  ref,
+  ...props
+}: InnerDialogProps & { ref?: Ref<HTMLElement> }) => {
+  const state = use(OverlayTriggerStateContext);
+  const classNames = useClassNames({
+    component: 'Dialog',
+    variant,
+    size,
+  });
 
-    const children =
-      typeof props.children === 'function'
-        ? props.children({
-            close: state?.close ?? (() => {}),
-          })
-        : props.children;
+  const children =
+    typeof props.children === 'function'
+      ? props.children({
+          close: state?.close ?? (() => {}),
+        })
+      : props.children;
 
-    return (
-      <Dialog
-        {...props}
-        ref={ref}
-        className={cn(
-          'relative mx-auto max-h-[80vh] max-w-[90vw] outline-hidden',
-          "grid [grid-template-areas:'title'_'content'_'actions']",
-          classNames.container
-        )}
-      >
-        {closeButton && (
-          <CloseButton
-            className={classNames.closeButton}
-            onPress={state?.close}
-          />
-        )}
-        {children}
-      </Dialog>
-    );
-  }
-);
+  return (
+    <RACDialog
+      {...props}
+      ref={ref}
+      className={cn(
+        'relative mx-auto max-h-[80vh] max-w-[90vw] outline-hidden',
+        "grid [grid-template-areas:'title'_'content'_'actions']",
+        classNames.container
+      )}
+    >
+      {closeButton && (
+        <CloseButton
+          className={classNames.closeButton}
+          onPress={state?.close}
+        />
+      )}
+      {children}
+    </RACDialog>
+  );
+};
 
 // Props
 // ---------------
@@ -82,43 +81,35 @@ export interface DialogProps
   closeButton?: boolean;
 }
 
-interface DialogComponent extends ForwardRefExoticComponent<
-  DialogProps & RefAttributes<HTMLInputElement>
-> {
-  Trigger: typeof DialogTrigger;
-  Title: typeof DialogTitle;
-  Content: typeof DialogContent;
-  Actions: typeof DialogActions;
-}
-
 // Component
 // ---------------
-const _Dialog = forwardRef(
-  (
-    { open, onOpenChange, children, ...props }: DialogProps,
-    ref: Ref<HTMLElement> | undefined
-  ) => {
-    const ctx = use(DialogContext);
+const DialogBase = ({
+  open,
+  onOpenChange,
+  children,
+  ref,
+  ...props
+}: DialogProps & { ref?: Ref<HTMLElement> }) => {
+  const ctx = use(DialogContext);
 
-    return (
-      <Modal
-        size={props.size}
-        dismissable={ctx.isDismissable}
-        keyboardDismissable={ctx.isKeyboardDismissDisabled}
-        open={typeof open === 'boolean' ? open : undefined}
-        onOpenChange={onOpenChange}
-      >
-        <InnerDialog ref={ref} {...props}>
-          {children}
-        </InnerDialog>
-      </Modal>
-    );
-  }
-) as DialogComponent;
+  return (
+    <Modal
+      size={props.size}
+      dismissable={ctx.isDismissable}
+      keyboardDismissable={ctx.isKeyboardDismissDisabled}
+      open={typeof open === 'boolean' ? open : undefined}
+      onOpenChange={onOpenChange}
+    >
+      <InnerDialog ref={ref} {...props}>
+        {children}
+      </InnerDialog>
+    </Modal>
+  );
+};
 
-_Dialog.Trigger = DialogTrigger;
-_Dialog.Title = DialogTitle;
-_Dialog.Content = DialogContent;
-_Dialog.Actions = DialogActions;
-
-export { _Dialog as Dialog };
+export const Dialog = Object.assign(DialogBase, {
+  Trigger: DialogTrigger,
+  Title: DialogTitle,
+  Content: DialogContent,
+  Actions: DialogActions,
+});

--- a/packages/components/src/ListBox/ListBox.tsx
+++ b/packages/components/src/ListBox/ListBox.tsx
@@ -1,11 +1,10 @@
-import {
-  ForwardRefExoticComponent,
-  Ref,
-  RefAttributes,
-  forwardRef,
-} from 'react';
+import type { Ref } from 'react';
 import type RAC from 'react-aria-components';
-import { ListBox, ListLayout, Virtualizer } from 'react-aria-components';
+import {
+  ListLayout,
+  ListBox as RACListBox,
+  Virtualizer,
+} from 'react-aria-components';
 import type { ListLayoutOptions } from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
 import { ListBoxContext } from './Context';
@@ -28,59 +27,57 @@ const defaultLayoutOptions: ListLayoutOptions = {
   gap: 1,
 };
 
-interface ListBoxComponent extends ForwardRefExoticComponent<
-  ListBoxProps & RefAttributes<HTMLUListElement>
-> {
-  Item: typeof ListBoxItem;
-  Section: typeof Section;
-}
+const ListBoxBase = ({
+  variant,
+  size,
+  virtualized,
+  layoutOptions,
+  ref,
+  ...props
+}: ListBoxProps & { ref?: Ref<HTMLUListElement> }) => {
+  const classNames = useClassNames({ component: 'ListBox', variant, size });
 
-const _ListBox = forwardRef<HTMLUListElement, ListBoxProps>(
-  ({ variant, size, virtualized, layoutOptions, ...props }, ref) => {
-    const classNames = useClassNames({ component: 'ListBox', variant, size });
+  // RAC types are incorrect, this will be passed to the `useListBox` hook
+  const listBoxProps: any = { shouldSelectOnPressUp: false };
 
-    // RAC types are incorrect, this will be passed to the `useListBox` hook
-    const listBoxProps: any = { shouldSelectOnPressUp: false };
+  const listBox = (
+    <RACListBox
+      {...props}
+      className={cn('overflow-y-auto', classNames.list)}
+      ref={ref as Ref<HTMLDivElement>}
+      // Bound the virtualized list so the Virtualizer has a viewport to
+      // clip against. Without this, the list grows to fit all items and
+      // virtualization has no effect.
+      style={
+        virtualized
+          ? { display: 'block', padding: 0, maxHeight: '24rem' }
+          : undefined
+      }
+      {...listBoxProps}
+    >
+      {props.children}
+    </RACListBox>
+  );
 
-    const listBox = (
-      <ListBox
-        {...props}
-        className={cn('overflow-y-auto', classNames.list)}
-        ref={ref as Ref<HTMLDivElement>}
-        // Bound the virtualized list so the Virtualizer has a viewport to
-        // clip against. Without this, the list grows to fit all items and
-        // virtualization has no effect.
-        style={
-          virtualized
-            ? { display: 'block', padding: 0, maxHeight: '24rem' }
-            : undefined
-        }
-        {...listBoxProps}
-      >
-        {props.children}
-      </ListBox>
-    );
+  return (
+    <ListBoxContext value={{ classNames, virtualized }}>
+      <div className={classNames.container}>
+        {virtualized ? (
+          <Virtualizer
+            layout={ListLayout}
+            layoutOptions={{ ...defaultLayoutOptions, ...layoutOptions }}
+          >
+            {listBox}
+          </Virtualizer>
+        ) : (
+          listBox
+        )}
+      </div>
+    </ListBoxContext>
+  );
+};
 
-    return (
-      <ListBoxContext value={{ classNames, virtualized }}>
-        <div className={classNames.container}>
-          {virtualized ? (
-            <Virtualizer
-              layout={ListLayout}
-              layoutOptions={{ ...defaultLayoutOptions, ...layoutOptions }}
-            >
-              {listBox}
-            </Virtualizer>
-          ) : (
-            listBox
-          )}
-        </div>
-      </ListBoxContext>
-    );
-  }
-) as ListBoxComponent;
-
-_ListBox.Item = ListBoxItem;
-_ListBox.Section = Section;
-
-export { _ListBox as ListBox };
+export const ListBox = Object.assign(ListBoxBase, {
+  Item: ListBoxItem,
+  Section: Section,
+});

--- a/packages/components/src/Overlay/Modal.tsx
+++ b/packages/components/src/Overlay/Modal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import type RAC from 'react-aria-components';
 import { Modal } from 'react-aria-components';
 import { useClassNames } from '@marigold/system';
@@ -24,39 +24,32 @@ export interface ModalProps extends Omit<RAC.ModalOverlayProps, 'render'> {
 
 // Component
 // ---------------
-const _Modal = forwardRef<
-  HTMLDivElement,
-  Omit<
-    ModalProps,
-    'isOpen' | 'isDismissable' | 'isKeyboardDismissDisabled' | 'className'
-  >
->(
-  (
-    {
-      size,
-      open,
-      dismissable,
-      keyboardDismissable,
-      onOpenChange,
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    const className = useClassNames({ component: 'Modal', size });
-    return (
-      <Underlay
-        dismissable={dismissable}
-        keyboardDismissable={keyboardDismissable}
-        open={open}
-        onOpenChange={onOpenChange}
-      >
-        <Modal {...props} className={className} ref={ref}>
-          {children}
-        </Modal>
-      </Underlay>
-    );
-  }
-);
+const ModalBase = ({
+  size,
+  open,
+  dismissable,
+  keyboardDismissable,
+  onOpenChange,
+  children,
+  ref,
+  ...props
+}: Omit<
+  ModalProps,
+  'isOpen' | 'isDismissable' | 'isKeyboardDismissDisabled' | 'className'
+> & { ref?: Ref<HTMLDivElement> }) => {
+  const className = useClassNames({ component: 'Modal', size });
+  return (
+    <Underlay
+      dismissable={dismissable}
+      keyboardDismissable={keyboardDismissable}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <Modal {...props} className={className} ref={ref}>
+        {children}
+      </Modal>
+    </Underlay>
+  );
+};
 
-export { _Modal as Modal };
+export { ModalBase as Modal };

--- a/packages/components/src/Overlay/NonModal.tsx
+++ b/packages/components/src/Overlay/NonModal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, use } from 'react';
+import { use } from 'react';
 import {
   OverlayTriggerStateContext,
   Provider,
@@ -152,37 +152,35 @@ export interface NonModalProps
 
 // Component
 // ---------------
-export const NonModal = forwardRef<HTMLElement, NonModalProps>(
-  ({ open, ...rest }, ref) => {
-    const props = {
-      isOpen: open,
-      ...rest,
-    };
+export const NonModal = ({ open, ref: refProp, ...rest }: NonModalProps) => {
+  const props = {
+    isOpen: open,
+    ...rest,
+  };
 
-    ref = useObjectRef(ref);
-    const contextState = use(OverlayTriggerStateContext);
-    const localState = useOverlayTriggerState(props);
-    const state =
-      props.isOpen != null || props.defaultOpen != null || !contextState
-        ? localState
-        : contextState;
+  const ref = useObjectRef(refProp);
+  const contextState = use(OverlayTriggerStateContext);
+  const localState = useOverlayTriggerState(props);
+  const state =
+    props.isOpen != null || props.defaultOpen != null || !contextState
+      ? localState
+      : contextState;
 
-    const isExiting =
-      useExitAnimation(ref, state.isOpen) || props.isExiting || false;
+  const isExiting =
+    useExitAnimation(ref, state.isOpen) || props.isExiting || false;
 
-    const isSSR = useIsSSR();
+  const isSSR = useIsSSR();
 
-    if ((state && !state.isOpen && !isExiting) || isSSR) {
-      return null;
-    }
-
-    return (
-      <NonModalInner
-        {...props}
-        nonModalRef={ref}
-        state={state}
-        isExiting={isExiting}
-      />
-    );
+  if ((state && !state.isOpen && !isExiting) || isSSR) {
+    return null;
   }
-);
+
+  return (
+    <NonModalInner
+      {...props}
+      nonModalRef={ref}
+      state={state}
+      isExiting={isExiting}
+    />
+  );
+};

--- a/packages/components/src/Overlay/Overlay.stories.tsx
+++ b/packages/components/src/Overlay/Overlay.stories.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { Menu, MenuItem, MenuTrigger } from 'react-aria-components';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
@@ -16,31 +16,35 @@ const meta = preview.meta({
 });
 
 // imported from RAC
-const TestTray = forwardRef<HTMLDivElement, { open: boolean }>(
-  ({ open }, ref) => {
-    return (
-      <Stack space={12} alignX="left">
-        <MenuTrigger isOpen={open}>
-          <Button>Button</Button>
-          <Popover ref={ref}>
-            <Menu>
-              <MenuItem key="edit">Edit</MenuItem>
-              <MenuItem key="duplicate">Duplicate</MenuItem>
-              <MenuItem key="delete">Delete</MenuItem>
-            </Menu>
-          </Popover>
-        </MenuTrigger>
-        <SectionMessage>
-          <SectionMessage.Title>Note</SectionMessage.Title>
-          <SectionMessage.Content>
-            This is a simple example of an overlay using the Popover component
-            using plain React Aria components without styling.
-          </SectionMessage.Content>
-        </SectionMessage>
-      </Stack>
-    );
-  }
-);
+const TestTray = ({
+  open,
+  ref,
+}: {
+  open: boolean;
+  ref?: Ref<HTMLDivElement>;
+}) => {
+  return (
+    <Stack space={12} alignX="left">
+      <MenuTrigger isOpen={open}>
+        <Button>Button</Button>
+        <Popover ref={ref}>
+          <Menu>
+            <MenuItem key="edit">Edit</MenuItem>
+            <MenuItem key="duplicate">Duplicate</MenuItem>
+            <MenuItem key="delete">Delete</MenuItem>
+          </Menu>
+        </Popover>
+      </MenuTrigger>
+      <SectionMessage>
+        <SectionMessage.Title>Note</SectionMessage.Title>
+        <SectionMessage.Content>
+          This is a simple example of an overlay using the Popover component
+          using plain React Aria components without styling.
+        </SectionMessage.Content>
+      </SectionMessage>
+    </Stack>
+  );
+};
 
 export const OverlayTray = meta.story({
   render: () => {

--- a/packages/components/src/Overlay/Popover.tsx
+++ b/packages/components/src/Overlay/Popover.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, forwardRef } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
 import { Popover } from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
@@ -30,36 +30,39 @@ export interface PopoverProps extends Omit<
 
 // Component
 // ---------------
-const _Popover = forwardRef<HTMLDivElement, PopoverProps>(
-  (
-    { keyboardDismissDisabled, placement, offset = 0, open, children, ...rest },
-    ref
-  ) => {
-    const props: RAC.PopoverProps = {
-      isKeyboardDismissDisabled: keyboardDismissDisabled,
-      isOpen: open,
-      placement,
-      ...rest,
-    };
-    const classNames = useClassNames({
-      component: 'Popover',
-      variant: placement,
-      // Make Popover as wide as trigger element
-      className: 'min-w-(--trigger-width)',
-    });
+const PopoverBase = ({
+  keyboardDismissDisabled,
+  placement,
+  offset = 0,
+  open,
+  children,
+  ref,
+  ...rest
+}: PopoverProps & { ref?: Ref<HTMLDivElement> }) => {
+  const props: RAC.PopoverProps = {
+    isKeyboardDismissDisabled: keyboardDismissDisabled,
+    isOpen: open,
+    placement,
+    ...rest,
+  };
+  const classNames = useClassNames({
+    component: 'Popover',
+    variant: placement,
+    // Make Popover as wide as trigger element
+    className: 'min-w-(--trigger-width)',
+  });
 
-    return (
-      <Popover
-        ref={ref}
-        {...props}
-        className={cn('z-30 flex', classNames)}
-        placement={placement}
-        offset={offset}
-      >
-        {children}
-      </Popover>
-    );
-  }
-);
+  return (
+    <Popover
+      ref={ref}
+      {...props}
+      className={cn('z-30 flex', classNames)}
+      placement={placement}
+      offset={offset}
+    >
+      {children}
+    </Popover>
+  );
+};
 
-export { _Popover as Popover };
+export { PopoverBase as Popover };

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
 import {
@@ -7,7 +7,6 @@ import {
   SelectValue,
 } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
-import { forwardRefType } from '@react-types/shared';
 import { WidthProp, cn, useClassNames, useSmallScreen } from '@marigold/system';
 import { Button } from '../Button/Button';
 import { FieldBase } from '../FieldBase/FieldBase';
@@ -86,26 +85,21 @@ export interface SelectProps<
   error?: boolean;
 }
 
-const SelectBase = (forwardRef as forwardRefType)(function Select<
-  T extends object,
-  M extends SelectionMode = 'single',
->(
-  {
-    disabled,
-    required,
-    items,
-    variant,
-    size,
-    error,
-    open,
-    label,
-    children,
-    selectionMode,
-    onChange,
-    ...rest
-  }: SelectProps<T, M>,
-  ref: Ref<HTMLButtonElement>
-) {
+function SelectBase<T extends object, M extends SelectionMode = 'single'>({
+  disabled,
+  required,
+  items,
+  variant,
+  size,
+  error,
+  open,
+  label,
+  children,
+  selectionMode,
+  onChange,
+  ref,
+  ...rest
+}: SelectProps<T, M> & { ref?: Ref<HTMLButtonElement> }) {
   const isSingleSelect = !selectionMode || selectionMode === 'single';
   const [trayOpen, setTrayOpen] = useState(false);
 
@@ -177,7 +171,7 @@ const SelectBase = (forwardRef as forwardRefType)(function Select<
       )}
     </FieldBase>
   );
-});
+}
 
 export const Select = Object.assign(SelectBase, {
   Option: ListBox.Item,

--- a/packages/components/src/SelectList/SelectList.tsx
+++ b/packages/components/src/SelectList/SelectList.tsx
@@ -1,13 +1,6 @@
-import {
-  Dispatch,
-  ForwardRefExoticComponent,
-  Ref,
-  RefAttributes,
-  SetStateAction,
-  forwardRef,
-} from 'react';
+import type { Dispatch, Ref, SetStateAction } from 'react';
 import type RAC from 'react-aria-components';
-import { GridList as SelectList } from 'react-aria-components';
+import { GridList as RACSelectList } from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
 import { SelectListContext } from './Context';
 import { SelectListAction } from './SelectListAction';
@@ -31,46 +24,45 @@ export interface SelectListProps extends Omit<
     | Dispatch<SetStateAction<any>>;
 }
 
-interface SelectListComponent extends ForwardRefExoticComponent<
-  SelectListProps & RefAttributes<HTMLUListElement>
-> {
-  /**
-   * Items of the SelectList.
-   */
+const SelectListBase = ({
+  onChange,
+  ref,
+  ...rest
+}: SelectListProps & { ref?: Ref<HTMLUListElement> }) => {
+  const classNames = useClassNames({ component: 'ListBox' });
+
+  const props: RAC.GridListProps<object> = {
+    onSelectionChange: onChange as any,
+    ...rest,
+  };
+
+  return (
+    <SelectListContext.Provider value={{ classNames }}>
+      <div className={classNames.container}>
+        <RACSelectList
+          {...props}
+          layout="grid"
+          ref={ref as Ref<HTMLDivElement>}
+          className={cn(
+            'group/list overflow-y-auto sm:max-h-[75vh] lg:max-h-[45vh]',
+            classNames.list
+          )}
+        >
+          {props.children}
+        </RACSelectList>
+      </div>
+    </SelectListContext.Provider>
+  );
+};
+
+interface SelectListComponent {
+  (props: SelectListProps & { ref?: Ref<HTMLUListElement> }): React.JSX.Element;
   Item: typeof SelectListItem;
   Action: typeof SelectListAction;
 }
 
-const _SelectList = forwardRef<HTMLUListElement, SelectListProps>(
-  ({ onChange, ...rest }, ref) => {
-    const classNames = useClassNames({ component: 'ListBox' });
+const SelectList = SelectListBase as SelectListComponent;
+SelectList.Item = SelectListItem;
+SelectList.Action = SelectListAction;
 
-    const props: RAC.GridListProps<object> = {
-      onSelectionChange: onChange as any,
-      ...rest,
-    };
-
-    return (
-      <SelectListContext.Provider value={{ classNames }}>
-        <div className={classNames.container}>
-          <SelectList
-            {...props}
-            layout="grid"
-            ref={ref as Ref<HTMLDivElement>}
-            className={cn(
-              'group/list overflow-y-auto sm:max-h-[75vh] lg:max-h-[45vh]',
-              classNames.list
-            )}
-          >
-            {props.children}
-          </SelectList>
-        </div>
-      </SelectListContext.Provider>
-    );
-  }
-) as SelectListComponent;
-
-_SelectList.Item = SelectListItem;
-_SelectList.Action = SelectListAction;
-
-export { _SelectList as SelectList };
+export { SelectList };

--- a/packages/components/src/SelectList/SelectListItem.tsx
+++ b/packages/components/src/SelectList/SelectListItem.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, forwardRef } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
 import { GridListItem as SelectListItem } from 'react-aria-components';
 import { cn } from '@marigold/system';
@@ -35,31 +35,34 @@ const SelectionIndicator = ({ selectionMode }: SelectionIndicatorProps) => {
   }
 };
 
-const _SelectListItem = forwardRef<HTMLDivElement, SelectListItemProps>(
-  ({ children, disabled, ...props }, ref) => {
-    let textValue = typeof children === 'string' ? children : undefined;
+const SelectListItemBase = ({
+  children,
+  disabled,
+  ref,
+  ...props
+}: SelectListItemProps & { ref?: Ref<HTMLDivElement> }) => {
+  let textValue = typeof children === 'string' ? children : undefined;
 
-    const { classNames } = useSelectListContext();
-    return (
-      <SelectListItem
-        isDisabled={disabled}
-        textValue={textValue}
-        {...props}
-        className={cn(
-          classNames?.item,
-          'grid grid-flow-col [grid-template-columns:min-content_1fr]'
-        )}
-        ref={ref}
-      >
-        {({ selectionMode }) => (
-          <div className="selection-indicator contents">
-            <SelectionIndicator selectionMode={selectionMode} />
-            {children}
-          </div>
-        )}
-      </SelectListItem>
-    );
-  }
-);
+  const { classNames } = useSelectListContext();
+  return (
+    <SelectListItem
+      isDisabled={disabled}
+      textValue={textValue}
+      {...props}
+      className={cn(
+        classNames?.item,
+        'grid grid-flow-col [grid-template-columns:min-content_1fr]'
+      )}
+      ref={ref}
+    >
+      {({ selectionMode }) => (
+        <div className="selection-indicator contents">
+          <SelectionIndicator selectionMode={selectionMode} />
+          {children}
+        </div>
+      )}
+    </SelectListItem>
+  );
+};
 
-export { _SelectListItem as SelectListItem };
+export { SelectListItemBase as SelectListItem };

--- a/packages/components/src/Sidebar/Sidebar.tsx
+++ b/packages/components/src/Sidebar/Sidebar.tsx
@@ -1,9 +1,4 @@
-import { forwardRef } from 'react';
-import type {
-  ForwardRefExoticComponent,
-  ReactNode,
-  RefAttributes,
-} from 'react';
+import type { ReactNode, Ref } from 'react';
 import { Modal, ModalOverlay } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { cn } from '@marigold/system';
@@ -24,20 +19,10 @@ export interface SidebarProps {
   children?: ReactNode;
 }
 
-interface SidebarComponent extends ForwardRefExoticComponent<
-  SidebarProps & RefAttributes<HTMLElement>
-> {
-  Provider: typeof SidebarProvider;
-  Header: typeof SidebarHeader;
-  Footer: typeof SidebarFooter;
-  GroupLabel: typeof SidebarGroupLabel;
-  Nav: typeof SidebarNav;
-  Item: typeof SidebarItem;
-  Separator: typeof SidebarSeparator;
-  Toggle: typeof SidebarToggle;
-}
-
-const _Sidebar = forwardRef<HTMLElement, SidebarProps>(({ children }, ref) => {
+const SidebarBase = ({
+  children,
+  ref,
+}: SidebarProps & { ref?: Ref<HTMLElement> }) => {
   const { isMobile, state, toggleSidebar, classNames } = useSidebar();
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
@@ -95,15 +80,15 @@ const _Sidebar = forwardRef<HTMLElement, SidebarProps>(({ children }, ref) => {
       </div>
     </aside>
   );
-}) as SidebarComponent;
+};
 
-_Sidebar.Provider = SidebarProvider;
-_Sidebar.Header = SidebarHeader;
-_Sidebar.Footer = SidebarFooter;
-_Sidebar.GroupLabel = SidebarGroupLabel;
-_Sidebar.Nav = SidebarNav;
-_Sidebar.Item = SidebarItem;
-_Sidebar.Separator = SidebarSeparator;
-_Sidebar.Toggle = SidebarToggle;
-
-export { _Sidebar as Sidebar };
+export const Sidebar = Object.assign(SidebarBase, {
+  Provider: SidebarProvider,
+  Header: SidebarHeader,
+  Footer: SidebarFooter,
+  GroupLabel: SidebarGroupLabel,
+  Nav: SidebarNav,
+  Item: SidebarItem,
+  Separator: SidebarSeparator,
+  Toggle: SidebarToggle,
+});

--- a/packages/components/src/Sidebar/SidebarNav.tsx
+++ b/packages/components/src/Sidebar/SidebarNav.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, useCallback } from 'react';
-import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+import type { ReactNode, Ref } from 'react';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { cn } from '@marigold/system';
 import { intlMessages } from '../intl/messages';
@@ -15,54 +15,57 @@ export interface SidebarNavProps {
   'aria-label'?: string;
 }
 
-const SidebarNav = forwardRef<HTMLElement, SidebarNavProps>(
-  ({ children, 'aria-label': ariaLabel }, forwardedRef) => {
-    const { classNames } = useSidebar();
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+const SidebarNav = ({
+  children,
+  'aria-label': ariaLabel,
+  ref,
+}: SidebarNavProps & { ref?: Ref<HTMLElement> }) => {
+  const { classNames } = useSidebar();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    const { collection, branchNodes, stack, setOpenBranch } =
-      useSidebarNavState({ children });
+  const { collection, branchNodes, stack, setOpenBranch } = useSidebarNavState({
+    children,
+  });
 
-    const handleBack = useCallback(() => setOpenBranch(null), [setOpenBranch]);
+  const handleBack = useCallback(() => setOpenBranch(null), [setOpenBranch]);
 
-    // Track previous open branch so root panel can return focus to the branch trigger.
-    const currentOpenBranch = stack[0] ?? null;
-    const prevOpenBranch = useLastDistinctValue(currentOpenBranch);
-    const returnFocusKey =
-      currentOpenBranch === null && prevOpenBranch != null
-        ? prevOpenBranch
-        : null;
+  // Track previous open branch so root panel can return focus to the branch trigger.
+  const currentOpenBranch = stack[0] ?? null;
+  const prevOpenBranch = useLastDistinctValue(currentOpenBranch);
+  const returnFocusKey =
+    currentOpenBranch === null && prevOpenBranch != null
+      ? prevOpenBranch
+      : null;
 
-    return (
-      <nav
-        ref={forwardedRef}
-        aria-label={ariaLabel || stringFormatter.format('appNavigation')}
-        className={cn(
-          'min-h-0 overflow-y-auto [grid-area:content]',
-          classNames.nav
-        )}
-      >
-        <div className="relative shrink-0 overflow-hidden">
+  return (
+    <nav
+      ref={ref}
+      aria-label={ariaLabel || stringFormatter.format('appNavigation')}
+      className={cn(
+        'min-h-0 overflow-y-auto [grid-area:content]',
+        classNames.nav
+      )}
+    >
+      <div className="relative shrink-0 overflow-hidden">
+        <SidebarPanel
+          nodes={collection.rootNodes}
+          position={panelPosition('root', stack)}
+          onBranchClick={setOpenBranch}
+          autoFocusKey={returnFocusKey}
+        />
+        {branchNodes.map(branch => (
           <SidebarPanel
-            nodes={collection.rootNodes}
-            position={panelPosition('root', stack)}
+            key={branch.key}
+            nodes={branch.children}
+            position={panelPosition(branch.key, stack)}
+            onBack={handleBack}
             onBranchClick={setOpenBranch}
-            autoFocusKey={returnFocusKey}
+            backLabel={branch.textValue}
           />
-          {branchNodes.map(branch => (
-            <SidebarPanel
-              key={branch.key}
-              nodes={branch.children}
-              position={panelPosition(branch.key, stack)}
-              onBack={handleBack}
-              onBranchClick={setOpenBranch}
-              backLabel={branch.textValue}
-            />
-          ))}
-        </div>
-      </nav>
-    );
-  }
-);
+        ))}
+      </div>
+    </nav>
+  );
+};
 
 export { SidebarNav };

--- a/packages/components/src/Sidebar/SidebarSlots.tsx
+++ b/packages/components/src/Sidebar/SidebarSlots.tsx
@@ -1,5 +1,4 @@
-import { forwardRef } from 'react';
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 import { cn } from '@marigold/system';
 import { useSidebar } from './Context';
 
@@ -8,30 +7,32 @@ export interface SidebarSlotProps {
   children?: ReactNode;
 }
 
-export const SidebarHeader = forwardRef<HTMLDivElement, SidebarSlotProps>(
-  ({ children }, ref) => {
-    const { classNames } = useSidebar();
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'flex h-14 items-center [grid-area:header]',
-          classNames.header
-        )}
-      >
-        {children}
-      </div>
-    );
-  }
-);
+export const SidebarHeader = ({
+  children,
+  ref,
+}: SidebarSlotProps & { ref?: Ref<HTMLDivElement> }) => {
+  const { classNames } = useSidebar();
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'flex h-14 items-center [grid-area:header]',
+        classNames.header
+      )}
+    >
+      {children}
+    </div>
+  );
+};
 
-export const SidebarFooter = forwardRef<HTMLDivElement, SidebarSlotProps>(
-  ({ children }, ref) => {
-    const { classNames } = useSidebar();
-    return (
-      <div ref={ref} className={cn('[grid-area:footer]', classNames.footer)}>
-        {children}
-      </div>
-    );
-  }
-);
+export const SidebarFooter = ({
+  children,
+  ref,
+}: SidebarSlotProps & { ref?: Ref<HTMLDivElement> }) => {
+  const { classNames } = useSidebar();
+  return (
+    <div ref={ref} className={cn('[grid-area:footer]', classNames.footer)}>
+      {children}
+    </div>
+  );
+};

--- a/packages/components/src/Tabs/TabList.tsx
+++ b/packages/components/src/Tabs/TabList.tsx
@@ -1,7 +1,7 @@
-import type RAC from 'react-aria-components';
 import { LayoutGroup } from 'motion/react';
-import { TabList } from 'react-aria-components';
 import { useId } from 'react';
+import type RAC from 'react-aria-components';
+import { TabList } from 'react-aria-components';
 import { cn } from '@marigold/system';
 import { useTabContext } from './Context';
 

--- a/packages/components/src/TagField/TagField.tsx
+++ b/packages/components/src/TagField/TagField.tsx
@@ -1,5 +1,5 @@
 import type { Key, ReactNode, Ref } from 'react';
-import { forwardRef, use, useLayoutEffect, useRef, useState } from 'react';
+import { use, useLayoutEffect, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import {
   Autocomplete,
@@ -13,7 +13,6 @@ import {
   useFilter,
 } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
-import { forwardRefType } from '@react-types/shared';
 import {
   type WidthProp,
   cn,
@@ -207,24 +206,20 @@ const TagFieldDropdown = ({
 
 // Component
 // ---------------
-const _TagField = (forwardRef as forwardRefType)(function TagField<
-  T extends object,
->(
-  {
-    disabled,
-    required,
-    items,
-    variant,
-    size,
-    error,
-    open,
-    children,
-    placeholder,
-    emptyState,
-    ...rest
-  }: TagFieldProps<T>,
-  ref: Ref<HTMLDivElement>
-) {
+function TagFieldBase<T extends object>({
+  disabled,
+  required,
+  items,
+  variant,
+  size,
+  error,
+  open,
+  children,
+  placeholder,
+  emptyState,
+  ref,
+  ...rest
+}: TagFieldProps<T> & { ref?: Ref<HTMLDivElement> }) {
   const triggerRef = useRef<HTMLDivElement | null>(null);
   const [triggerWidth, setTriggerWidth] = useState(0);
   const isSmallScreen = useSmallScreen();
@@ -316,9 +311,9 @@ const _TagField = (forwardRef as forwardRefType)(function TagField<
       )}
     </FieldBase>
   );
-});
+}
 
-export const TagField = Object.assign(_TagField, {
+export const TagField = Object.assign(TagFieldBase, {
   Option: ListBox.Item,
   Section: ListBox.Section,
 });

--- a/packages/components/src/TopNavigation/TopNavigation.tsx
+++ b/packages/components/src/TopNavigation/TopNavigation.tsx
@@ -1,5 +1,4 @@
-import type { ForwardRefExoticComponent, ReactNode, Ref } from 'react';
-import { forwardRef } from 'react';
+import type { ReactNode, Ref } from 'react';
 import { cn, useClassNames } from '@marigold/system';
 import { TopNavigationContext } from './Context';
 import { TopNavigationEnd } from './TopNavigationEnd';
@@ -24,46 +23,40 @@ export interface TopNavigationProps {
 
 // Component
 // ---------------
-interface TopNavigationComponent extends ForwardRefExoticComponent<
-  TopNavigationProps & React.RefAttributes<HTMLElement>
-> {
-  Start: typeof TopNavigationStart;
-  Middle: typeof TopNavigationMiddle;
-  End: typeof TopNavigationEnd;
-}
+const TopNavigationBase = ({
+  variant,
+  size,
+  sticky = true,
+  children,
+  ref,
+  ...props
+}: TopNavigationProps & { ref?: Ref<HTMLElement> }) => {
+  const classNames = useClassNames({
+    component: 'TopNavigation',
+    variant,
+    size,
+  });
 
-const _TopNavigation = forwardRef(
-  (
-    { variant, size, sticky = true, children, ...props }: TopNavigationProps,
-    ref: Ref<HTMLElement>
-  ) => {
-    const classNames = useClassNames({
-      component: 'TopNavigation',
-      variant,
-      size,
-    });
+  return (
+    <TopNavigationContext.Provider value={{ variant, size, classNames }}>
+      <header
+        ref={ref}
+        className={cn(
+          "grid grid-cols-[auto_1fr_auto] [grid-template-areas:'start_middle_end']",
+          'w-full [grid-area:header]',
+          sticky && 'bg-background sticky top-0 z-1',
+          classNames.container
+        )}
+        {...props}
+      >
+        {children}
+      </header>
+    </TopNavigationContext.Provider>
+  );
+};
 
-    return (
-      <TopNavigationContext.Provider value={{ variant, size, classNames }}>
-        <header
-          ref={ref}
-          className={cn(
-            "grid grid-cols-[auto_1fr_auto] [grid-template-areas:'start_middle_end']",
-            'w-full [grid-area:header]',
-            sticky && 'bg-background sticky top-0 z-1',
-            classNames.container
-          )}
-          {...props}
-        >
-          {children}
-        </header>
-      </TopNavigationContext.Provider>
-    );
-  }
-) as TopNavigationComponent;
-
-_TopNavigation.Start = TopNavigationStart;
-_TopNavigation.Middle = TopNavigationMiddle;
-_TopNavigation.End = TopNavigationEnd;
-
-export { _TopNavigation as TopNavigation };
+export const TopNavigation = Object.assign(TopNavigationBase, {
+  Start: TopNavigationStart,
+  Middle: TopNavigationMiddle,
+  End: TopNavigationEnd,
+});

--- a/packages/components/src/TopNavigation/TopNavigationEnd.tsx
+++ b/packages/components/src/TopNavigation/TopNavigationEnd.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode, Ref } from 'react';
-import { forwardRef } from 'react';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { alignment, cn } from '@marigold/system';
 import { intlMessages } from '../intl/messages';
@@ -22,34 +21,30 @@ export interface TopNavigationEndProps {
   children?: ReactNode;
 }
 
-export const TopNavigationEnd = forwardRef(
-  (
-    {
-      'aria-label': ariaLabel,
-      alignY = 'center',
-      children,
-      ...props
-    }: TopNavigationEndProps,
-    ref: Ref<HTMLElement>
-  ) => {
-    const { classNames } = useTopNavigationContext();
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+export const TopNavigationEnd = ({
+  'aria-label': ariaLabel,
+  alignY = 'center',
+  children,
+  ref,
+  ...props
+}: TopNavigationEndProps & { ref?: Ref<HTMLElement> }) => {
+  const { classNames } = useTopNavigationContext();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    return (
-      <nav
-        ref={ref}
-        aria-label={
-          ariaLabel ?? stringFormatter.format('globalNavigationUtilities')
-        }
-        className={cn(
-          'min-w-0 [grid-area:end]',
-          classNames.end,
-          alignY && alignment.horizontal.alignmentY[alignY]
-        )}
-        {...props}
-      >
-        {children}
-      </nav>
-    );
-  }
-);
+  return (
+    <nav
+      ref={ref}
+      aria-label={
+        ariaLabel ?? stringFormatter.format('globalNavigationUtilities')
+      }
+      className={cn(
+        'min-w-0 [grid-area:end]',
+        classNames.end,
+        alignY && alignment.horizontal.alignmentY[alignY]
+      )}
+      {...props}
+    >
+      {children}
+    </nav>
+  );
+};

--- a/packages/components/src/TopNavigation/TopNavigationMiddle.tsx
+++ b/packages/components/src/TopNavigation/TopNavigationMiddle.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode, Ref } from 'react';
-import { forwardRef } from 'react';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { alignment, cn } from '@marigold/system';
 import { intlMessages } from '../intl/messages';
@@ -26,34 +25,30 @@ export interface TopNavigationMiddleProps {
   children?: ReactNode;
 }
 
-export const TopNavigationMiddle = forwardRef(
-  (
-    {
-      'aria-label': ariaLabel,
-      alignX,
-      alignY = 'center',
-      children,
-      ...props
-    }: TopNavigationMiddleProps,
-    ref: Ref<HTMLElement>
-  ) => {
-    const { classNames } = useTopNavigationContext();
-    const stringFormatter = useLocalizedStringFormatter(intlMessages);
+export const TopNavigationMiddle = ({
+  'aria-label': ariaLabel,
+  alignX,
+  alignY = 'center',
+  children,
+  ref,
+  ...props
+}: TopNavigationMiddleProps & { ref?: Ref<HTMLElement> }) => {
+  const { classNames } = useTopNavigationContext();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
-    return (
-      <nav
-        ref={ref}
-        aria-label={ariaLabel ?? stringFormatter.format('globalNavigation')}
-        className={cn(
-          'min-w-0 [grid-area:middle]',
-          classNames.middle,
-          alignX && alignment.horizontal.alignmentX[alignX],
-          alignY && alignment.horizontal.alignmentY[alignY]
-        )}
-        {...props}
-      >
-        {children}
-      </nav>
-    );
-  }
-);
+  return (
+    <nav
+      ref={ref}
+      aria-label={ariaLabel ?? stringFormatter.format('globalNavigation')}
+      className={cn(
+        'min-w-0 [grid-area:middle]',
+        classNames.middle,
+        alignX && alignment.horizontal.alignmentX[alignX],
+        alignY && alignment.horizontal.alignmentY[alignY]
+      )}
+      {...props}
+    >
+      {children}
+    </nav>
+  );
+};

--- a/packages/components/src/TopNavigation/TopNavigationStart.tsx
+++ b/packages/components/src/TopNavigation/TopNavigationStart.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode, Ref } from 'react';
-import { forwardRef } from 'react';
 import { alignment, cn } from '@marigold/system';
 import { useTopNavigationContext } from './Context';
 
@@ -15,25 +14,25 @@ export interface TopNavigationStartProps {
   children?: ReactNode;
 }
 
-export const TopNavigationStart = forwardRef(
-  (
-    { alignY = 'center', children, ...props }: TopNavigationStartProps,
-    ref: Ref<HTMLDivElement>
-  ) => {
-    const { classNames } = useTopNavigationContext();
+export const TopNavigationStart = ({
+  alignY = 'center',
+  children,
+  ref,
+  ...props
+}: TopNavigationStartProps & { ref?: Ref<HTMLDivElement> }) => {
+  const { classNames } = useTopNavigationContext();
 
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'min-w-0 [grid-area:start]',
-          classNames.start,
-          alignY && alignment.horizontal.alignmentY[alignY]
-        )}
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  }
-);
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'min-w-0 [grid-area:start]',
+        classNames.start,
+        alignY && alignment.horizontal.alignmentY[alignY]
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/components/src/Tray/Tray.test.tsx
+++ b/packages/components/src/Tray/Tray.test.tsx
@@ -65,11 +65,11 @@ vi.mock('motion/react', async () => {
       React.createElement(React.Fragment, null, children),
     motion: {
       create: (Component: React.ComponentType<any>) =>
-        React.forwardRef(function MotionWrapper(props: any, ref: any) {
+        function MotionWrapper({ ref, ...props }: any) {
           const { onDragEnd, ...rest } = props;
           if (onDragEnd) dragState.onDragEnd = onDragEnd;
           return React.createElement(Component, { ...rest, ref });
-        }),
+        },
     },
     useMotionValue: () => ({ get: () => 0, set: () => {} }),
     animate: mockAnimate,


### PR DESCRIPTION
## Summary
- Remove `forwardRef` wrappers from 25 component files, replacing with React 19 ref-as-prop pattern
- Replace `ForwardRefExoticComponent` interfaces on compound components with `Object.assign` pattern
- Alias RAC imports where names conflict (e.g. `ComboBox as RACComboBox`) and rename internal functions to PascalCase (`XBase`) to satisfy `rules-of-hooks`

## Explanation

In React 19, `forwardRef` is no longer needed. Previously, `ref` was special — you couldn't pass it as a regular prop, so React provided `forwardRef` as a wrapper to thread it through. React 19 removes that restriction: `ref` is now just a normal prop.

**Before (React 18 pattern):**
```tsx
const Button = forwardRef<HTMLButtonElement, ButtonProps>(
  (props, ref) => {
    return <button ref={ref} {...props} />;
  }
);
```

**After (React 19 pattern):**
```tsx
const Button = ({ ref, ...props }: ButtonProps & { ref?: Ref<HTMLButtonElement> }) => {
  return <button ref={ref} {...props} />;
};
```

### What changed

1. **Removed `forwardRef` wrappers** — moved `ref` into the props destructuring instead.

2. **Removed `ForwardRefExoticComponent` interfaces** from compound components (components with sub-components like `Dialog.Title`, `ListBox.Item`). Replaced them with `Object.assign`:
   ```tsx
   // Before
   interface DialogComponent extends ForwardRefExoticComponent<...> {
     Title: typeof DialogTitle;
   }
   const _Dialog = forwardRef(...) as DialogComponent;
   _Dialog.Title = DialogTitle;

   // After
   const DialogBase = ({ ref, ...props }) => { ... };
   export const Dialog = Object.assign(DialogBase, {
     Title: DialogTitle,
   });
   ```

3. **Renamed `_X` → `XBase`** (e.g. `_ComboBox` → `ComboBoxBase`) because `eslint-plugin-react-hooks` doesn't recognize `_`-prefixed functions as valid components for calling hooks.

4. **Aliased RAC imports** where names conflicted with the new export (e.g. `import { ListBox as RACListBox }`), since the old `_ListBox` / `export { _ListBox as ListBox }` pattern no longer applies.

5. **Removed `forwardRefType`** from the generic components (`Select`, `TagField`) — that cast was only needed to make `forwardRef` work with generics.

## Test plan
- [ ] `pnpm typecheck:only` passes
- [ ] `pnpm lint` shows 0 `@eslint-react/no-forward-ref` warnings
- [ ] `pnpm test:unit --run` — all 1023 tests pass
- [ ] `pnpm format` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)