### PR TITLE
Fix: update label and datefield styles

### DIFF
--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -31,7 +31,7 @@ test('check classname slots', () => {
     `"group/field flex min-w-0 flex-col w-auto"`
   );
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive-accent in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive-accent in-field:mb-1.5 inline-flex"`
   );
 });
 

--- a/packages/components/src/DateField/DateField.test.tsx
+++ b/packages/components/src/DateField/DateField.test.tsx
@@ -55,7 +55,7 @@ test('renders correctly', () => {
       style="--container-width: 100%; --field-width: 100%;"
     >
       <span
-        class="items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive-accent in-field:mb-1.5 inline-flex"
+        class="items-center gap-1 text-sm font-medium text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive-accent in-field:mb-1.5 inline-flex"
         id="react-aria-_r_1_"
       >
         My Label
@@ -89,7 +89,7 @@ test('renders correctly', () => {
             aria-valuenow="1"
             aria-valuetext="1"
             autocorrect="off"
-            class="group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
+            class="group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
             contenteditable="true"
             data-rac=""
             data-type="day"
@@ -111,7 +111,7 @@ test('renders correctly', () => {
           </span>
           <span
             aria-hidden="true"
-            class="group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
+            class="group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
             data-rac=""
             data-type="literal"
           >
@@ -131,7 +131,7 @@ test('renders correctly', () => {
             aria-valuenow="1"
             aria-valuetext="1 – Januar"
             autocorrect="off"
-            class="group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
+            class="group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
             contenteditable="true"
             data-rac=""
             data-type="month"
@@ -153,7 +153,7 @@ test('renders correctly', () => {
           </span>
           <span
             aria-hidden="true"
-            class="group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
+            class="group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
             data-rac=""
             data-type="literal"
           >
@@ -173,7 +173,7 @@ test('renders correctly', () => {
             aria-valuenow="2026"
             aria-valuetext="2026"
             autocorrect="off"
-            class="group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
+            class="group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent text-foreground data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0 data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground disabled:cursor-not-allowed disabled:text-disabled disabled:bg-disabled-surface data-placeholder:disabled:text-disabled invalid:text-destructive-accent invalid:data-focused:bg-destructive-bold invalid:data-focused:text-destructive-bold-foreground invalid:data-focused:data-placeholder:text-destructive-bold-foreground"
             contenteditable="true"
             data-rac=""
             data-type="year"

--- a/themes/theme-rui/src/components/DateField.styles.ts
+++ b/themes/theme-rui/src/components/DateField.styles.ts
@@ -15,7 +15,7 @@ export const DateField: ThemeComponent<'DateField'> = {
   input: cva({ base: ['ui-input', 'cursor-text'] }),
   segment: cva({
     base: [
-      'group/segment inline rounded leading-none whitespace-pre p-0.5 outline-0 caret-transparent',
+      'group/segment inline rounded whitespace-pre p-0.5 outline-0 caret-transparent',
       'text-foreground',
       'data-placeholder:text-placeholder type-literal:text-placeholder type-literal:px-0',
       'data-focused:bg-focus-highlight-bold data-focused:text-foreground data-focused:data-placeholder:text-foreground',

--- a/themes/theme-rui/src/components/Label.styles.ts
+++ b/themes/theme-rui/src/components/Label.styles.ts
@@ -3,7 +3,7 @@ import { type ThemeComponent, cva } from '@marigold/system';
 export const Label: ThemeComponent<'Label'> = cva({
   base: [
     'flex items-center gap-1',
-    'text-sm font-medium leading-none text-foreground',
+    'text-sm font-medium text-foreground',
     'group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled',
 
     // required indicator


### PR DESCRIPTION
# Description

Noticed that there was `leading-none` set to label and datefield which caused unwanted styles: 

<img width="695" height="372" alt="Bildschirmfoto 2026-04-14 um 15 38 26" src="https://github.com/user-attachments/assets/37d6f6a6-ccf0-4487-bdd7-bdb7d7df6786" />

# Test Instructions:

- test fields with label
- test datesegment in datefield/picker

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)
