### PR TITLE
fix(DST-1334): prevent --ui-*-color CSS vars from cascading into nested surfaces

### DIFF
--- a/.changeset/ui-surface-non-inheriting.md
+++ b/.changeset/ui-surface-non-inheriting.md
@@ -1,0 +1,9 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix: register `--ui-background-color`, `--ui-border-color`, and `--ui-highlight-color` as non-inheriting custom properties
+
+Previously, setting one of these variables on a themed surface (e.g. a destructive Panel overriding `--ui-border-color`) would cascade the value into every nested element that also reads `ui-surface`, tinting Inputs, Buttons, Cards, etc. with the parent's color.
+
+These three custom properties are now registered via `@property { inherits: false }`, so each surface resolves its own fallback via the existing `var(..., var(--color-…))` pattern and nested surfaces keep their defaults.

--- a/packages/components/src/Styles.stories.tsx
+++ b/packages/components/src/Styles.stories.tsx
@@ -48,6 +48,26 @@ export const Surface = meta.story({
           contrast / overlay
         </Base>
       </Inline>
+      <Headline level="3">Nested Surfaces</Headline>
+      <p className="text-secondary max-w-prose text-sm">
+        <code>--ui-border-color</code>, <code>--ui-background-color</code> and{' '}
+        <code>--ui-highlight-color</code> are registered as non-inheriting, so a
+        themed parent surface does not bleed its colors into nested surfaces.
+      </p>
+      <Inline space="regular">
+        <div className="ui-surface shadow-elevation-raised flex h-32 w-64 flex-col items-center justify-center gap-2 [--ui-border-color:var(--color-destructive-accent)]">
+          <span className="text-xs">parent: --ui-border-color</span>
+          <div className="ui-surface shadow-elevation-border px-3 py-1 text-xs">
+            nested child
+          </div>
+        </div>
+        <div className="ui-surface-contrast flex h-32 w-64 flex-col items-center justify-center gap-2 [--ui-background-color:var(--color-access-master-accent)] [--ui-border-color:var(--color-access-master-accent)]">
+          <span className="text-xs">parent: --ui-background-color</span>
+          <div className="ui-surface shadow-elevation-border text-foreground px-3 py-1 text-xs">
+            nested child
+          </div>
+        </div>
+      </Inline>
       <Headline level="3">UI State</Headline>
       <Inline space="regular">
         <Base className="ui-surface shadow-elevation-border ui-state-error">

--- a/themes/theme-rui/src/ui.css
+++ b/themes/theme-rui/src/ui.css
@@ -24,9 +24,28 @@
 /*          Surface          */
 /* ========================= */
 
-/* 
+/*
+ * Register surface custom properties as non-inheriting so that a themed
+ * surface (e.g. a destructive Panel setting --ui-border-color) does not
+ * cascade its colors into nested surfaces (Inputs, Buttons, Cards, …).
+ * Each surface resolves its own value via the `var(..., fallback)` pattern.
+ */
+@property --ui-background-color {
+  syntax: '*';
+  inherits: false;
+}
+@property --ui-border-color {
+  syntax: '*';
+  inherits: false;
+}
+@property --ui-highlight-color {
+  syntax: '*';
+  inherits: false;
+}
+
+/*
  * Use for interactive UI elements like inputs, selects, and cards. Anything that
- * sits on the page background and needs a clear visual boundary. 
+ * sits on the page background and needs a clear visual boundary.
  */
 @utility ui-surface {
   @apply rounded-surface relative transition-[background,border,box-shadow];


### PR DESCRIPTION
Jira: [DST-1334](https://reservix.atlassian.net/browse/DST-1334)

## Summary

- Registers `--ui-background-color`, `--ui-border-color`, and `--ui-highlight-color` with `@property { syntax: '*'; inherits: false }` in `themes/theme-rui/src/ui.css` so these custom properties no longer cascade from a themed parent surface into nested surfaces.
- Adds a **Nested Surfaces** section to the `Styles/RUI > Surface` story as a visual regression guard.
- Includes a changeset (`@marigold/theme-rui: patch`).

## Problem

`ui-surface` (and the related `ui-surface-contrast` / `ui-state-focus` / `ui-state-readonly` utilities) read their colors via `var(--ui-border-color, var(--color-border))`. Because CSS custom properties inherit by default, as soon as any ancestor sets one of those variables — a destructive Panel overriding `--ui-border-color`, or a hovered Button inline-setting `--ui-background-color` via `hover:[--ui-background-color:...]` — every descendant with `ui-surface` picks up that value. The `var(..., fallback)` never fires because the property is defined (inherited), not absent.

Concrete example: a destructive Panel wrapping a default Input would tint the Input red.

## Fix

```css
@property --ui-background-color { syntax: '*'; inherits: false; }
@property --ui-border-color     { syntax: '*'; inherits: false; }
@property --ui-highlight-color  { syntax: '*'; inherits: false; }
```

With `syntax: '*'` and no `initial-value`, the initial is the guaranteed-invalid value, so children resolve the `var(..., fallback)` normally. No changes needed at any call site — every `ui-surface`, hover override, focus/readonly state already uses the fallback pattern.

Browser support is fine for the theme's baseline (Chromium 85+, Safari 16.4+, Firefox 128+).

## Test plan

- [ ] Storybook: open **Styles / RUI → Surface**, scroll to **Nested Surfaces**; parent surfaces render with destructive/master accent colors, inner `ui-surface` children render neutral.
- [ ] Storybook: open **Components / Panel → Basic** and verify all variants (`default`, `master`, `admin`, `destructive`) still render correctly, with no tinting on any nested Input/Button/Card.
- [ ] Storybook: open the standard focus, readonly, and hover stories for Input/Button/Menu — colors look unchanged.
- [ ] `pnpm test:sb` — existing story tests pass.


[DST-1334]: https://reservix.atlassian.net/browse/DST-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ