### PR TITLE
refactor(DST-1335): adopt `Sidebar.Nav` `current` prop in demos and stories

### DIFF
--- a/.changeset/adopt-sidebar-current-prop.md
+++ b/.changeset/adopt-sidebar-current-prop.md
@@ -1,0 +1,9 @@
+---
+'@marigold/docs': patch
+---
+
+refactor: adopt `Sidebar.Nav` `current` prop in demos and stories
+
+Replaces the hand-rolled `active={currentPath === '/...'}` pattern across Sidebar and AppLayout demos (documentation) and the `AppLayout` Storybook story with the new `current` prop on `Sidebar.Nav` (shipped in DST-1322 / #5306). The order-detail demo additionally leverages the new prefix-match semantics, so `/orders/:id` routes automatically highlight the `/orders` nav item without a regex fallback.
+
+No consumer-facing package behavior changes — only demos and an internal story.

--- a/docs/app/(examples)/pattern/app-shell/(shell)/layout.tsx
+++ b/docs/app/(examples)/pattern/app-shell/(shell)/layout.tsx
@@ -67,33 +67,19 @@ const ShellLayout = ({ children }: PropsWithChildren) => {
                 </Text>
               </Inline>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item href="/" active={slug === ''}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="/analytics" active={slug === 'analytics'}>
-                Analytics
-              </Sidebar.Item>
+            <Sidebar.Nav current={pathname.replace(BASE, '') || '/'}>
+              <Sidebar.Item href="/">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/analytics">Analytics</Sidebar.Item>
               <Sidebar.Separator />
               <Sidebar.Item id="management" textValue="Management">
                 Management
-                <Sidebar.Item href="/users" active={slug === 'users'}>
-                  Users
-                </Sidebar.Item>
-                <Sidebar.Item href="/teams" active={slug === 'teams'}>
-                  Teams
-                </Sidebar.Item>
-                <Sidebar.Item href="/billing" active={slug === 'billing'}>
-                  Billing
-                </Sidebar.Item>
+                <Sidebar.Item href="/users">Users</Sidebar.Item>
+                <Sidebar.Item href="/teams">Teams</Sidebar.Item>
+                <Sidebar.Item href="/billing">Billing</Sidebar.Item>
               </Sidebar.Item>
               <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
-              <Sidebar.Item href="/general" active={slug === 'general'}>
-                General
-              </Sidebar.Item>
-              <Sidebar.Item href="/security" active={slug === 'security'}>
-                Security
-              </Sidebar.Item>
+              <Sidebar.Item href="/general">General</Sidebar.Item>
+              <Sidebar.Item href="/security">Security</Sidebar.Item>
             </Sidebar.Nav>
             <Sidebar.Footer>
               <Text fontSize="xs">v1.0.0</Text>

--- a/docs/content/components/navigation/sidebar/sidebar-active-branch.demo.tsx
+++ b/docs/content/components/navigation/sidebar/sidebar-active-branch.demo.tsx
@@ -13,41 +13,16 @@ export default () => {
             <Sidebar.Header>
               <Text weight="bold">Shop Admin</Text>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={currentPath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
               <Sidebar.Item id="products" textValue="Products">
                 Products
-                <Sidebar.Item
-                  href="/all-products"
-                  active={currentPath === '/all-products'}
-                >
-                  All products
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/categories"
-                  active={currentPath === '/categories'}
-                >
-                  Categories
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/inventory"
-                  active={currentPath === '/inventory'}
-                >
-                  Inventory
-                </Sidebar.Item>
+                <Sidebar.Item href="/all-products">All products</Sidebar.Item>
+                <Sidebar.Item href="/categories">Categories</Sidebar.Item>
+                <Sidebar.Item href="/inventory">Inventory</Sidebar.Item>
               </Sidebar.Item>
               <Sidebar.Separator />
-              <Sidebar.Item
-                href="/settings"
-                active={currentPath === '/settings'}
-              >
-                Settings
-              </Sidebar.Item>
+              <Sidebar.Item href="/settings">Settings</Sidebar.Item>
             </Sidebar.Nav>
           </Sidebar>
           <main className="flex-1 p-4">

--- a/docs/content/components/navigation/sidebar/sidebar-appearance.demo.tsx
+++ b/docs/content/components/navigation/sidebar/sidebar-appearance.demo.tsx
@@ -13,45 +13,19 @@ export default (props: SidebarProviderProps) => {
             <Sidebar.Header>
               <Text weight="bold">Acme Inc.</Text>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={currentPath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="/orders" active={currentPath === '/orders'}>
-                Orders
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/orders">Orders</Sidebar.Item>
               <Sidebar.Item id="products" textValue="Products">
                 Products
-                <Sidebar.Item
-                  href="/all-products"
-                  active={currentPath === '/all-products'}
-                >
-                  All products
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/categories"
-                  active={currentPath === '/categories'}
-                >
-                  Categories
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/inventory"
-                  active={currentPath === '/inventory'}
-                >
-                  Inventory
-                </Sidebar.Item>
+                <Sidebar.Item href="/all-products">All products</Sidebar.Item>
+                <Sidebar.Item href="/categories">Categories</Sidebar.Item>
+                <Sidebar.Item href="/inventory">Inventory</Sidebar.Item>
               </Sidebar.Item>
               <Sidebar.Separator />
               <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
-              <Sidebar.Item href="/account" active={currentPath === '/account'}>
-                Account
-              </Sidebar.Item>
-              <Sidebar.Item href="/billing" active={currentPath === '/billing'}>
-                Billing
-              </Sidebar.Item>
+              <Sidebar.Item href="/account">Account</Sidebar.Item>
+              <Sidebar.Item href="/billing">Billing</Sidebar.Item>
             </Sidebar.Nav>
             <Sidebar.Footer>
               <Text fontSize="xs">jane@acme.com</Text>

--- a/docs/content/components/navigation/sidebar/sidebar-basic.demo.tsx
+++ b/docs/content/components/navigation/sidebar/sidebar-basic.demo.tsx
@@ -13,30 +13,14 @@ export default () => {
             <Sidebar.Header>
               <Text weight="bold">Acme Inc.</Text>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={currentPath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="/orders" active={currentPath === '/orders'}>
-                Orders
-              </Sidebar.Item>
-              <Sidebar.Item
-                href="/products"
-                active={currentPath === '/products'}
-              >
-                Products
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/orders">Orders</Sidebar.Item>
+              <Sidebar.Item href="/products">Products</Sidebar.Item>
               <Sidebar.Separator />
               <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
-              <Sidebar.Item href="/account" active={currentPath === '/account'}>
-                Account
-              </Sidebar.Item>
-              <Sidebar.Item href="/billing" active={currentPath === '/billing'}>
-                Billing
-              </Sidebar.Item>
+              <Sidebar.Item href="/account">Account</Sidebar.Item>
+              <Sidebar.Item href="/billing">Billing</Sidebar.Item>
             </Sidebar.Nav>
             <Sidebar.Footer>
               <Text fontSize="xs">jane@acme.com</Text>

--- a/docs/content/components/navigation/sidebar/sidebar-detail-page.demo.tsx
+++ b/docs/content/components/navigation/sidebar/sidebar-detail-page.demo.tsx
@@ -86,22 +86,10 @@ export default () => {
             <Sidebar.Header>
               <Text weight="bold">My App</Text>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={activePath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="/orders" active={activePath === '/orders'}>
-                Orders
-              </Sidebar.Item>
-              <Sidebar.Item
-                href="/customers"
-                active={activePath === '/customers'}
-              >
-                Customers
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/orders">Orders</Sidebar.Item>
+              <Sidebar.Item href="/customers">Customers</Sidebar.Item>
             </Sidebar.Nav>
           </Sidebar>
           <main className="grid flex-1 grid-rows-[auto_1fr] gap-8 overflow-auto pl-4">

--- a/docs/content/components/navigation/sidebar/sidebar-drilldown.demo.tsx
+++ b/docs/content/components/navigation/sidebar/sidebar-drilldown.demo.tsx
@@ -13,43 +13,18 @@ export default () => {
             <Sidebar.Header>
               <Text weight="bold">My App</Text>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={currentPath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="/orders" active={currentPath === '/orders'}>
-                Orders
-              </Sidebar.Item>
-              <Sidebar.Item
-                href="/customers"
-                active={currentPath === '/customers'}
-              >
-                Customers
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/orders">Orders</Sidebar.Item>
+              <Sidebar.Item href="/customers">Customers</Sidebar.Item>
               <Sidebar.Separator />
               <Sidebar.Item id="settings" textValue="Settings">
                 Settings
-                <Sidebar.Item
-                  href="/settings/profile"
-                  active={currentPath === '/settings/profile'}
-                >
-                  Profile
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/settings/notifications"
-                  active={currentPath === '/settings/notifications'}
-                >
+                <Sidebar.Item href="/settings/profile">Profile</Sidebar.Item>
+                <Sidebar.Item href="/settings/notifications">
                   Notifications
                 </Sidebar.Item>
-                <Sidebar.Item
-                  href="/settings/security"
-                  active={currentPath === '/settings/security'}
-                >
-                  Security
-                </Sidebar.Item>
+                <Sidebar.Item href="/settings/security">Security</Sidebar.Item>
               </Sidebar.Item>
             </Sidebar.Nav>
           </Sidebar>

--- a/packages/components/src/AppLayout/AppLayout.stories.tsx
+++ b/packages/components/src/AppLayout/AppLayout.stories.tsx
@@ -100,45 +100,19 @@ const LShapeLayout = ({
                 />
               </svg>
             </Sidebar.Header>
-            <Sidebar.Nav>
-              <Sidebar.Item
-                href="/dashboard"
-                active={currentPath === '/dashboard'}
-              >
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item
-                href="/analytics"
-                active={currentPath === '/analytics'}
-              >
-                Analytics
-              </Sidebar.Item>
+            <Sidebar.Nav current={currentPath}>
+              <Sidebar.Item href="/dashboard">Dashboard</Sidebar.Item>
+              <Sidebar.Item href="/analytics">Analytics</Sidebar.Item>
               <Sidebar.Separator />
               <Sidebar.Item id="management" textValue="Management">
                 Management
-                <Sidebar.Item href="/users" active={currentPath === '/users'}>
-                  Users
-                </Sidebar.Item>
-                <Sidebar.Item href="/teams" active={currentPath === '/teams'}>
-                  Teams
-                </Sidebar.Item>
-                <Sidebar.Item
-                  href="/billing"
-                  active={currentPath === '/billing'}
-                >
-                  Billing
-                </Sidebar.Item>
+                <Sidebar.Item href="/users">Users</Sidebar.Item>
+                <Sidebar.Item href="/teams">Teams</Sidebar.Item>
+                <Sidebar.Item href="/billing">Billing</Sidebar.Item>
               </Sidebar.Item>
               <Sidebar.GroupLabel>Settings</Sidebar.GroupLabel>
-              <Sidebar.Item href="/general" active={currentPath === '/general'}>
-                General
-              </Sidebar.Item>
-              <Sidebar.Item
-                href="/security"
-                active={currentPath === '/security'}
-              >
-                Security
-              </Sidebar.Item>
+              <Sidebar.Item href="/general">General</Sidebar.Item>
+              <Sidebar.Item href="/security">Security</Sidebar.Item>
             </Sidebar.Nav>
             <Sidebar.Footer>
               <Text fontSize="xs">v1.0.0</Text>


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `active={currentPath === '/...'}` per-item boilerplate across 6 Sidebar/AppLayout demos and the `AppLayout` Storybook story with the new `current` prop on `Sidebar.Nav` (shipped in #5306 / DST-1322).
- Removes the bespoke regex in the order-detail demo: the prop's longest-prefix semantics auto-highlight `/orders` when the user is on `/orders/:id`.
- Net: **+56 / −191** lines. No consumer-facing package behavior change — only demos and one story.

## Files changed

| File | Change |
| --- | --- |
| `docs/content/components/navigation/sidebar/sidebar-basic.demo.tsx` | 6 items → `current` |
| `docs/content/components/navigation/sidebar/sidebar-active-branch.demo.tsx` | 5 items → `current` |
| `docs/content/components/navigation/sidebar/sidebar-drilldown.demo.tsx` | 6 items → `current` |
| `docs/content/components/navigation/sidebar/sidebar-appearance.demo.tsx` | 8 items → `current` |
| `docs/content/components/navigation/sidebar/sidebar-detail-page.demo.tsx` | 3 items → `current`; prefix-match replaces regex normalisation |
| `docs/app/(examples)/pattern/app-shell/(shell)/layout.tsx` | 7 items → `current={pathname.replace(BASE, '') \|\| '/'}` |
| `packages/components/src/AppLayout/AppLayout.stories.tsx` | 7 items → `current` |

## Test plan

- [x] `pnpm typecheck:only` — green
- [x] `pnpm test:unit --run` — 1046/1046 passing
- [x] `pnpm test:sb --run` — 121/121 passing
- [ ] Reviewer: run `pnpm sb` and confirm the Sidebar/AppLayout stories still highlight the active item and auto-open the active branch
- [ ] Reviewer: run `pnpm start`, visit `/pattern/app-shell` routes, confirm the active nav tracks `usePathname()`
- [ ] Reviewer: in the order-detail demo, click an order row and confirm "Orders" stays highlighted on the detail route

## Related

- Jira: [DST-1335](https://reservix.atlassian.net/browse/DST-1335)
- Builds on #5306 (DST-1322 — original `current` prop)

[DST-1335]: https://reservix.atlassian.net/browse/DST-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ