### PR TITLE
feat(DST-1341): add `/vrt` command to trigger Chromatic VRT

### DIFF
--- a/.claude/commands/vrt.md
+++ b/.claude/commands/vrt.md
@@ -1,0 +1,42 @@
+---
+description: Trigger Visual Regression Tests (Chromatic) on the current or a given branch
+allowed-tools: Bash(gh workflow run *), Bash(gh run list *), Bash(gh run watch *), Bash(git branch --show-current), Bash(git rev-parse *), Bash(gh run view *)
+---
+
+# Trigger Visual Regression Tests
+
+Trigger the "Visual-Regression-Tests" GitHub Actions workflow via `workflow_dispatch`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+- If a branch name is provided, use it as the target branch.
+- If no arguments are provided, use the **current git branch**.
+
+## Workflow
+
+### Step 1: Determine the branch
+
+If `$ARGUMENTS` is empty, run:
+```
+git branch --show-current
+```
+Otherwise, use the provided branch name.
+
+### Step 2: Trigger the workflow
+
+Run:
+```
+gh workflow run "Visual-Regression-Tests" --ref <branch>
+```
+
+Report the branch name to the user.
+
+### Step 3: Confirm the run started
+
+Wait a few seconds, then list recent runs to confirm it was queued:
+```
+gh run list --workflow="Visual-Regression-Tests" --limit=1
+```
+
+Share the run URL with the user so they can monitor progress.


### PR DESCRIPTION
## Summary
- Adds a Claude Code slash command (`.claude/commands/vrt.md`) that triggers the `Visual-Regression-Tests` GitHub Actions workflow via `gh workflow run`
- Supports current branch (default) or a specific branch as argument (e.g. `/vrt` or `/vrt my-branch`)
- Removes the need to manually navigate GitHub Actions or name branches with `ui-` prefix just to run Chromatic

Jira: [DST-1341](https://reservix.atlassian.net/browse/DST-1341)

## Test plan
- [ ] Run `/vrt` on current branch and verify workflow is dispatched
- [ ] Run `/vrt <branch-name>` with a specific branch and verify it targets the correct ref
- [ ] Confirm the run URL is returned after triggering

[DST-1341]: https://reservix.atlassian.net/browse/DST-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ