### PR TITLE
feat(DST-1342): add `background` prop to ComponentDemo and AppearanceDemo

### DIFF
--- a/docs/content/components/layout/app-layout/index.mdx
+++ b/docs/content/components/layout/app-layout/index.mdx
@@ -37,7 +37,7 @@ badge: beta
 </Sidebar.Provider>
 ```
 
-<ComponentDemo name="app-layout-basic" />
+<ComponentDemo name="app-layout-basic" background="page" />
 
 ### Sidebar.Provider
 

--- a/docs/content/components/navigation/sidebar/index.mdx
+++ b/docs/content/components/navigation/sidebar/index.mdx
@@ -29,7 +29,7 @@ A sidebar consists of a panel alongside the main content area. The panel is orga
 
 ## Appearance
 
-<AppearanceDemo component="Sidebar" />
+<AppearanceDemo component="Sidebar" background="page" />
 <AppearanceTable component="Sidebar" />
 
 ## Usage
@@ -85,7 +85,7 @@ Don't use drill-down just to shorten a long list. Every branch adds a click, so 
 
 The sidebar supports one level of nesting. More levels would force users to remember where they are in a deep hierarchy, and navigating back through multiple levels gets tedious fast. If your content needs more depth, reconsider how you organize your sections rather than adding more nesting.
 
-<ComponentDemo name="sidebar-drilldown" />
+<ComponentDemo name="sidebar-drilldown" background="page" />
 
 ### Active item
 
@@ -124,7 +124,7 @@ Do not add individual records as sidebar items. A sidebar that lists every order
 
 For hierarchies deeper than two levels, pair the sidebar with [breadcrumbs](/components/navigation/breadcrumbs). The sidebar lets users move between sections, breadcrumbs show the path back (e.g. Orders > ORD-4712).
 
-<ComponentDemo name="sidebar-detail-page" />
+<ComponentDemo name="sidebar-detail-page" background="page" />
 
 <GuidelineTiles>
   <Dont>

--- a/docs/content/components/navigation/topnavigation/index.mdx
+++ b/docs/content/components/navigation/topnavigation/index.mdx
@@ -27,7 +27,7 @@ The `<TopNavigation>` component uses a compound component pattern with three slo
 
 ## Appearance
 
-<AppearanceDemo component={'TopNavigation'} />
+<AppearanceDemo component={'TopNavigation'} background="page" />
 
 <AppearanceTable component={'TopNavigation'} />
 
@@ -39,7 +39,7 @@ The `<TopNavigation>` component organizes the top-level navigation of an applica
 
 Some layouts call for centered content in the navigation bar, such as a search field. Use the `alignX` prop on `<TopNavigation.Middle>` to horizontally center its content within the available space. Note that `alignX` only applies to the Middle slot — Start and End are always aligned to their respective edges.
 
-<ComponentDemo name="topnavigation-search" />
+<ComponentDemo name="topnavigation-search" background="page" />
 
 ### Sticky navigation
 
@@ -47,7 +47,7 @@ By default, `<TopNavigation>` sticks to the top of the viewport when users scrol
 
 If the navigation bar is not needed while scrolling (e.g., on compact pages where content fits within the viewport), you can disable sticky behavior by setting `sticky={false}`.
 
-<ComponentDemo name="topnavigation-sticky" />
+<ComponentDemo name="topnavigation-sticky" background="page" />
 
 ### Combining with Sidebar
 

--- a/docs/ui/AppearanceDemo.tsx
+++ b/docs/ui/AppearanceDemo.tsx
@@ -75,11 +75,20 @@ export interface AppearanceDemoProps {
     variant?: string[];
     size?: string[];
   };
+  /**
+   * Background color of the preview area.
+   * 'surface' uses white, 'page' uses the theme's background color.
+   */
+  background?: 'surface' | 'page';
 }
 
 // Component
 // ---------------
-export const AppearanceDemo = ({ component, exclude }: AppearanceDemoProps) => {
+export const AppearanceDemo = ({
+  component,
+  exclude,
+  background = 'surface',
+}: AppearanceDemoProps) => {
   const name = `${component.toLowerCase()}-appearance` as RegistryKey;
 
   if (!registry[name]) {
@@ -170,8 +179,14 @@ export const AppearanceDemo = ({ component, exclude }: AppearanceDemoProps) => {
         </div>
         <div data-theme="rui">
           <OverlayContainerProvider container="portalContainer">
-            <MarigoldProvider theme={ruiTheme} className="bg-white">
-              <div className="not-prose flex size-full min-h-56 items-center justify-center overflow-x-auto px-4 pt-24 pb-10">
+            <MarigoldProvider
+              theme={ruiTheme}
+              className={cn(
+                'min-h-56',
+                background === 'page' ? 'bg-background' : 'bg-white'
+              )}
+            >
+              <div className="not-prose flex size-full items-center justify-center overflow-x-auto px-4 pt-24 pb-10">
                 <Demo {...selected} />
               </div>
             </MarigoldProvider>

--- a/docs/ui/ComponentDemo.tsx
+++ b/docs/ui/ComponentDemo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { type RegistryKey, registry } from '@/.registry/demos';
+import { cn } from '@/lib/cn';
 import { track } from '@vercel/analytics';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
@@ -29,6 +30,11 @@ export interface ComponentDemoProps {
    * 'full' shows both in tabs (default)
    */
   mode?: 'preview' | 'code' | 'full';
+  /**
+   * Background color of the preview area.
+   * 'surface' uses white, 'page' uses the theme's background color.
+   */
+  background?: 'surface' | 'page';
   children?: ReactNode;
 }
 
@@ -46,18 +52,27 @@ function fileToRegistryKey(file: string): string {
 
 // Preview wrapper component
 // ---------------
-const Preview = ({ name }: { name: RegistryKey }) => {
+const Preview = ({
+  name,
+  background = 'surface',
+}: {
+  name: RegistryKey;
+  background?: 'surface' | 'page';
+}) => {
   const Demo: ComponentType<any> = registry[name].demo;
 
   return (
     <div
       data-theme="rui"
-      className="flex min-h-[150px] w-full flex-col justify-center overflow-hidden [&>*:first-child]:flex [&>*:first-child]:place-items-center"
+      className="flex w-full flex-col justify-center overflow-hidden [&>*:first-child]:flex [&>*:first-child]:place-items-center"
     >
       <OverlayContainerProvider container="portalContainer">
         <MarigoldProvider
           theme={ruiTheme}
-          className="h-inherit w-full bg-white"
+          className={cn(
+            'min-h-37.5 w-full',
+            background === 'page' ? 'bg-background' : 'bg-white'
+          )}
         >
           <div className="not-prose w-full overflow-x-auto p-4">
             <Demo />
@@ -74,6 +89,7 @@ export const ComponentDemo = ({
   name,
   file,
   mode = 'full',
+  background,
 }: ComponentDemoProps) => {
   // Resolve the registry key from either name or file prop
   const registryKey = name ?? (file ? fileToRegistryKey(file) : undefined);
@@ -95,8 +111,8 @@ export const ComponentDemo = ({
   // Preview only mode
   if (mode === 'preview') {
     return (
-      <div className="overflow-hidden rounded-xl">
-        <Preview name={key} />
+      <div className="overflow-hidden rounded-xl border">
+        <Preview name={key} background={background} />
       </div>
     );
   }
@@ -110,7 +126,7 @@ export const ComponentDemo = ({
   return (
     <DemoTabs demoKey={key}>
       <Tab value="Preview" className="p-0">
-        <Preview name={key} />
+        <Preview name={key} background={background} />
       </Tab>
       <Tab value="Code">
         <DynamicCodeBlock lang="tsx" code={codeString} />


### PR DESCRIPTION
# Description

Add a `background` prop (`'surface' | 'page'`) to `ComponentDemo` and `AppearanceDemo`. When set to `"page"`, the MarigoldProvider uses `bg-background` (theme page color) instead of `bg-white`, enabling full-bleed page backgrounds without wrapper div hacks.

**Changes:**
- `docs/ui/ComponentDemo.tsx` -- new `background` prop, moved `min-h` to MarigoldProvider so background fills the preview area, added `border` on preview-only mode
- `docs/ui/AppearanceDemo.tsx` -- same `background` prop with matching behavior
- Updated MDX for Sidebar, TopNavigation, and AppLayout to use `background="page"`

**Usage in MDX:**
```mdx
<ComponentDemo name="sidebar-drilldown" background="page" />
<AppearanceDemo component="Sidebar" background="page" />
```

# Test Instructions:

1. Run `pnpm start` and navigate to:
   - `/components/navigation/sidebar` -- demos and appearance should have gray page background
   - `/components/navigation/topnavigation` -- same
   - `/components/layout/app-layout` -- same
   - `/components/actions/button` -- should be unchanged (white background)
2. Run `pnpm typecheck:only` -- passes clean

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)