### PR TITLE
docs(DST-1345): add release notes for v17.1, v17.3, and v17.4

### DIFF
--- a/docs/content/releases/blog/release-2026-02-19.mdx
+++ b/docs/content/releases/blog/release-2026-02-19.mdx
@@ -1,0 +1,31 @@
+---
+title: Marigold v17.1.0
+date: 2026-02-19
+type: Blog
+changed:
+  - components/form/tagfield
+  - components/actions/button
+  - components/content/badge
+  - components/actions/actionbar
+  - components/overlay/contextual-help
+  - components/overlay/tray
+  - components/collection/table
+---
+
+Just two days after v17.0.0, we're shipping a small follow-up to smooth out a couple of rough edges from the surface refactor. Nothing sweeping, but a nicer click target for `<TagField>` and a cleaner theme under the hood.
+
+## Components
+
+### TagField
+
+Clicking anywhere on a [`<TagField>`](/components/form/tag-field) -- not just the chevron button -- now opens the dropdown. The field previously only responded to clicks on the chevron or directly on the input, which made the component feel unresponsive compared to `<Select>` and `<ComboBox>`. The full field now acts as a single, generous click target.
+
+## Design
+
+### Finishing the `util-*` → `ui-*` migration
+
+v17.0.0 introduced a new state utility system (`ui-state-focus`, `ui-state-disabled`, `ui-state-error`, `ui-state-readonly`) and deprecated the old `util-focus-*` / `util-disabled` helpers. A few theme files -- `<ActionBar>`, `<Badge>`, `<Button>`, `<ContextualHelp>`, `<Multiselect>`, `<Table>`, `<Toast>`, and `<Tray>` -- were still reaching for the old utilities. They've all been migrated so the deprecated classes can be fully retired in a future release without surprise regressions.
+
+---
+
+Short and sweet. Back to our regularly scheduled programming!

--- a/docs/content/releases/blog/release-2026-03-25.mdx
+++ b/docs/content/releases/blog/release-2026-03-25.mdx
@@ -1,0 +1,76 @@
+---
+title: Marigold v17.3.0
+date: 2026-03-25
+type: Blog
+changed:
+  - components/layout/app-layout
+  - components/navigation/sidebar
+  - components/navigation/top-navigation
+  - components/overlay/toast
+  - components/overlay/menu
+  - components/collection/tag
+  - components/form/slider
+---
+
+Spring is in full swing, and so is Marigold. v17.3.0 continues the navigation story we started with `<Sidebar>` and `<TopNavigation>` in v17.2.0 -- this time by giving you a ready-made shell to compose them into.
+
+## Components
+
+### AppLayout (beta)
+
+A new [`<AppLayout>`](/components/layout/app-layout) component provides a standardized App Shell layout using CSS Grid. It exposes three slots -- `<AppLayout.Sidebar>`, `<AppLayout.Header>`, and `<AppLayout.Main>` -- that compose the navigation primitives from v17.2.0 into a complete page chrome.
+
+Before `<AppLayout>`, teams had to hand-roll grid templates, `100dvh` height containers, and sticky-header logic every time they wired `<Sidebar>` and `<TopNavigation>` together. Getting scroll behavior right (only `<Main>` should scroll, sidebar and header stay put) was fiddly and easy to get subtly wrong. `<AppLayout>` encapsulates that layout so you can focus on content.
+
+```tsx
+<Sidebar.Provider defaultOpen>
+  <AppLayout>
+    <AppLayout.Sidebar>
+      <Sidebar.Header>{/* Logo */}</Sidebar.Header>
+      <Sidebar.Nav>{/* Navigation items */}</Sidebar.Nav>
+    </AppLayout.Sidebar>
+    <AppLayout.Header>
+      <TopNavigation.Start>
+        <Sidebar.Toggle />
+      </TopNavigation.Start>
+      <TopNavigation.Middle>{/* Breadcrumbs, search */}</TopNavigation.Middle>
+      <TopNavigation.End>{/* User menu */}</TopNavigation.End>
+    </AppLayout.Header>
+    <AppLayout.Main>{/* Scrollable page content */}</AppLayout.Main>
+  </AppLayout>
+</Sidebar.Provider>
+```
+
+The grid fills `100dvh`, the header is a fixed `3.5rem` tall, and only `<AppLayout.Main>` scrolls. The sidebar header height was also aligned with the `<AppLayout>` header so logos and navigation items line up cleanly. See the new [App Shell pattern](/patterns/app-shell) for a step-by-step guide covering providers, responsive behavior, and where to place content.
+
+## System
+
+### Stable `useToast` callbacks
+
+`addToast`, `clearToasts`, and `removeToast` from [`useToast`](/components/overlay/toast) are now wrapped in `useCallback`. Previously, these functions got a new identity on every render, which meant including them in a `useEffect` dependency array would trigger the effect on every render. Now the references are stable across renders and safe to use as dependencies.
+
+```tsx
+const { addToast } = useToast();
+
+useEffect(() => {
+  if (saveSucceeded) {
+    addToast({ title: 'Saved!', variant: 'success' });
+  }
+}, [saveSucceeded, addToast]); // Safe now — addToast is stable
+```
+
+## Design
+
+- Replaced hardcoded values with semantic tokens across multiple theme files, including `<Tag>` and `<Slider>`. Hardcoded values drift from the token system over time and make custom themes harder to override -- moving them into tokens keeps the design language consistent.
+
+## Bug fixes
+
+- **v17.2.1**: Fixed a broken icon color inside `<Menu.Item>`. A malformed Tailwind selector (`[&_svg]:text-muted-foreground:opacity-60`) collapsed two modifiers into one, so nested `<svg>` icons lost their muted color. Split into `[&_svg]:text-muted-foreground [&_svg]:opacity-60`.
+
+## Documentation
+
+- Refactored the [`<Calendar>`](/components/form/calendar) documentation for clarity around the new `visibleDuration` and `pageBehavior` props introduced in v17.0.0.
+
+---
+
+A small release that makes a big difference if you're building app shells. As always, feedback is welcome!

--- a/docs/content/releases/blog/release-2026-04-15.mdx
+++ b/docs/content/releases/blog/release-2026-04-15.mdx
@@ -1,0 +1,119 @@
+---
+title: Marigold v17.4.0
+date: 2026-04-15
+type: Blog
+changed:
+  - components/form/select
+  - components/form/combobox
+  - components/form/autocomplete
+  - components/content/card
+  - components/layout/inset
+  - components/form/calendar
+  - components/collection/table
+  - components/overlay/menu
+  - components/overlay/dialog
+  - components/navigation/accordion
+  - components/overlay/contextual-help
+---
+
+April showers bring… faster dropdowns and smaller bundles. v17.4.0 is a performance-and-polish release: long option lists no longer freeze the browser, icon payload drops by roughly a third, and the semantic spacing migration rolls onward to `<Card>` and `<Inset>`.
+
+## Performance
+
+### Always-on virtualization for `<Select>`, `<ComboBox>`, and `<Autocomplete>`
+
+Following up on the `<TagField>` virtualization in v17.3, [`<Select>`](/components/form/select), [`<ComboBox>`](/components/form/combobox), and [`<Autocomplete>`](/components/form/autocomplete) now virtualize their internal `<ListBox>` on desktop.
+
+Hundreds to thousands of options used to lock up the browser when opening or filtering these components because every option rendered into the DOM. The virtualizer (built on react-aria's `Virtualizer` + `ListLayout` -- the same pattern powering `<TagField>`) only renders the items currently in view, so performance stays constant no matter how large the dataset. There's no public API change: virtualization is on by default on desktop and transparent to your code.
+
+To give the virtualizer a viewport to clip against inside a `<Popover>`, `<ListBox>` now has a bounded height of `max-h: 24rem`.
+
+### Smaller icon bundle with `lucide-react` v1.x
+
+We upgraded [`lucide-react`](https://lucide.dev) from v0.575.0 to v1.x, the stable v1 API. This cuts icon bundle size by **roughly 32%** and applies `aria-hidden` to icons by default, which is the right behavior for decorative usage and prevents redundant announcements in screen readers. No brand icons from Lucide are used in Marigold, so no rename or removal affects your code.
+
+## Semantic Spacing (continued)
+
+The spacing migration introduced in v17.0.0 and refined in v17.2.0 now reaches two more components. This keeps the rhythm consistent across your UI -- container spacing now speaks the same semantic language as the gaps between elements.
+
+### Card
+
+[`<Card>`](/components/content/card) padding props now accept semantic inset tokens instead of numeric-only values:
+
+- `p` (all sides) accepts `InsetSpacingTokens` (`square-*`, `squish-*`, `stretch-*`) plus numeric scale values
+- `px`/`py`/`pt`/`pb`/`pl`/`pr` accept single-axis `PaddingSpacingTokens` (`padding-tight`, `padding-snug`, `padding-regular`, `padding-relaxed`, `padding-loose`) plus numeric scale values
+- `space` (gap between children) continues to accept relational `SpacingTokens` (`tight`, `related`, `regular`, `group`, `section`)
+
+```tsx
+<Card p="square-regular" space="related">
+  <Headline level="3">Weekly report</Headline>
+  <Text>Last 7 days at a glance.</Text>
+</Card>
+```
+
+### Inset
+
+The [`<Inset>`](/components/layout/inset) component got the same treatment:
+
+- `space` accepts inset recipe tokens (`square-*`, `squish-*`, `stretch-*`)
+- `spaceX`/`spaceY` accept single-axis padding tokens (`padding-tight`, `padding-snug`, `padding-regular`, `padding-relaxed`, `padding-loose`)
+
+New `--spacing-padding-*` CSS custom properties were added to the theme, and two matching types -- `InsetSpacingTokens` and `PaddingSpacingTokens` -- are now exported for use in your own components.
+
+## Design
+
+### Focus rings now use CSS `outline`
+
+Focus indicators have been switched from `box-shadow` (Tailwind's `ring-*`) to CSS `outline`. Two reasons:
+
+1. **No more clipping inside scrollable containers.** `box-shadow` rings were cut off by `overflow: hidden` or `overflow: auto` parents, leading to focus indicators that vanished inside cards, dialogs, or scrollable lists. `outline` paints outside the element's box and is never clipped.
+2. **Better Windows High Contrast Mode support.** `outline` is honored by forced-colors modes, while `box-shadow` is ignored -- so keyboard users on Windows High Contrast now see focus clearly.
+
+As a follow-up, padding was redistributed from compound-component containers to individual sub-components in `<Dialog>`, `<ContextualHelp>`, and `<Accordion>` so the outline has breathing room inside overflow boundaries. `transition-all` and `transition-colors` were also replaced with explicit `transition-[color,background-color]` to prevent the outline color from animating during focus.
+
+### Calendar cleanup
+
+[`<Calendar>`](/components/form/calendar) styles were consolidated: hardcoded Tailwind classes have moved from the component files into theme slots, cell padding was reduced from `p-2` to `p-1` for a tighter grid, and a new `calendarHeading` theme slot was added. Calendar day cells are now centered via a dedicated class instead of utility-level alignment.
+
+### Other design polish
+
+- Unified `<Table>` row hover styles so rows with `href` and rows inside `selectionMode` look identical on hover -- previously they used slightly different treatments.
+- Improved `<Table.EditableCell>` hover/focus affordance via a new `data-editable` attribute so the editable state is visually distinct from read-only cells.
+- Removed the muted text color from the `<Dialog>` content slot for better readability. Dialog body text now reads at the default foreground color.
+
+## Components
+
+### Cleaner mobile Menu tray
+
+On small screens, `<Menu>` opens in a bottom-sheet `<Tray>`. Previously, the menu's `label` prop was rendered twice -- once on the trigger button and once as the tray title -- which duplicated the label the user just tapped. For `<ActionMenu>` with an icon-only trigger, this sometimes rendered an `aria-label` text like "more actions" as a tray title, which wasn't useful either. The label has been removed from the tray title. Form components (`<Select>`, `<ComboBox>`, `<DatePicker>`) keep their label because it describes the field's purpose beyond the trigger.
+
+## Infrastructure
+
+### Public API cleanup
+
+A few subcomponent exports have been removed from the public `@marigold/components` entry point: `AccordionItem`, `ListBoxItem`, `SelectListItem`, and `ProgressCircleSvg`. Each is already accessible via its compound parent (`<Accordion.Item>`, `<ListBox.Item>`, `<SelectList.Item>`) or was an internal implementation detail. Keeping the compound-component form as the single canonical entry point makes the API easier to learn and removes the risk of inconsistent imports across teams.
+
+### Internal refactor
+
+Removed a local `useRenderProps` hook and replaced it with the export from `react-aria-components`, eliminating duplicate code now that RAC ships the same utility upstream.
+
+### Fixed CJS export paths
+
+The `main`, `types`, and `exports` fields in `@marigold/system`, `@marigold/icons`, `@marigold/theme-rui`, and `@marigold/components` pointed to non-existent `.js` files. Since `tsdown` 0.16.0, CommonJS output uses the `.cjs` extension, but our `package.json` exports never caught up. CJS consumers now resolve correctly.
+
+## Bug fixes
+
+- **v17.3.1**: Fixed a CSS parsing error in Next.js with LightningCSS caused by an arbitrary Tailwind variant in `<Table.EditableCell>`. Replaced with the built-in `group` variant.
+
+## Documentation
+
+- New [Component Principles](/foundations/component-principles) foundations page explaining the four pillars of Marigold's component design: accessibility, theming, composition, and layout.
+- Replaced the "Governance Process" and "Governance Principles" pages with a single [How to Contribute](/getting-started/how-to-contribute) page, and simplified the "Get in touch" page so it focuses solely on getting help. The old split was confusing -- most people just wanted to know how to file feedback.
+- Added structured **Appearance** variant tables (`Variant | Description | When to use`) to 14 component pages -- Button, SectionMessage, Badge, Card, Text, Accordion, Toast, Tooltip, Link, LinkButton, Divider, Loader, Menu, and Table. Prop tables tell you what values are allowed, but not when to pick one over another. The new tables close that gap.
+- Complete [ToggleButton](/components/actions/toggle-button) documentation with anatomy diagrams, usage demos (standalone toggle, formatting toolbar, filter toggles, disabled state), Do/Don't guidelines, and an alternative-components section. `<ToggleButtonGroup>` is now documented on the same page.
+- New `/api/manifest.json` route returning a JSON index of all documentation pages, designed for AI agent discovery.
+- The Markdown endpoint for documentation pages moved from `/mcp/{page-path}.md` to `/{page-path}.md`. If you've been using the AI-facing Markdown output introduced in v17.2.0, update your URLs accordingly.
+
+---
+
+That's a wrap on v17.4.0. The combination of virtualized dropdowns and a slimmer icon bundle should be immediately noticeable in real apps. As always, let us know how it feels!


### PR DESCRIPTION
## Summary

- Backfill missing release notes for v17.1.0, v17.3.0, and v17.4.0 under `docs/content/releases/blog/`.
- Patch-only releases (v17.0.1, v17.2.1, v17.3.1) are folded into the next minor note instead of getting their own post — matches how earlier versions were published.
- Each change includes a short reason so readers know _why_ it shipped, not just what changed (sourced from package `CHANGELOG.md` and changeset descriptions).

Files added:

- `docs/content/releases/blog/release-2026-02-19.mdx` — v17.1.0 (TagField click area, `util-*` → `ui-*` theme cleanup)
- `docs/content/releases/blog/release-2026-03-25.mdx` — v17.3.0 (AppLayout beta, `useToast` stability, v17.2.1 Menu icon fix)
- `docs/content/releases/blog/release-2026-04-15.mdx` — v17.4.0 (virtualized Select/ComboBox/Autocomplete, lucide-react v1, spacing migration for Card/Inset, focus ring → CSS outline, v17.3.1 TableEditableCell fix)

Linked ticket: [DST-1345](https://reservix.atlassian.net/browse/DST-1345)

## Test plan

- [ ] `pnpm start` → open <http://localhost:3000/releases/overview> and confirm the three new entries render.
- [ ] Spot-check each post for broken internal links (e.g. `/components/layout/app-layout`, `/patterns/app-shell`, `/components/form/select`, etc.).
- [ ] Verify frontmatter `changed:` lists render correctly in the docs UI.
- [ ] Re-read the "why" framing on the items flagged in the PR thread and adjust if the reasoning doesn't match what actually motivated the change.

[DST-1345]: https://reservix.atlassian.net/browse/DST-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ