### PR TITLE
fix(DST-1346): Table Column alignX not applied to first column

### DIFF
--- a/.changeset/table-alignx-first-column.md
+++ b/.changeset/table-alignx-first-column.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix: apply `alignX` from `Table.Column` to first column cells
+
+`TableCellContent` used a truthy check on `columnIndex`, causing it to skip the `alignX` lookup when `columnIndex` was `0` (first column). Replaced with a nullish check so all columns correctly inherit their alignment.

--- a/packages/components/src/Table/Table.stories.tsx
+++ b/packages/components/src/Table/Table.stories.tsx
@@ -1575,3 +1575,57 @@ export const DragPreview = meta.story({
     });
   },
 });
+
+export const ColumnAlignment = meta.story({
+  tags: ['component-test'],
+  render: args => (
+    <Table aria-label="Column alignment" {...args}>
+      <Table.Header>
+        <Table.Column alignX="right">ID</Table.Column>
+        <Table.Column alignX="center">Name</Table.Column>
+        <Table.Column alignX="right">Balance</Table.Column>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row key="1">
+          <Table.Cell>001</Table.Cell>
+          <Table.Cell>Hans</Table.Cell>
+          <Table.Cell>
+            <NumericFormat style="currency" currency="EUR" value={1250.75} />
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row key="2">
+          <Table.Cell>002</Table.Cell>
+          <Table.Cell>Fritz</Table.Cell>
+          <Table.Cell>
+            <NumericFormat style="currency" currency="EUR" value={980.5} />
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  ),
+  play: async ({ canvas, step }) => {
+    await step(
+      'First column (index 0) inherits alignX from Column',
+      async () => {
+        const cells = canvas.getAllByRole('gridcell');
+        const firstCellContent = cells[0].querySelector(
+          '[data-cell-content]'
+        ) as HTMLElement;
+
+        expect(firstCellContent).toHaveClass('text-right');
+      }
+    );
+
+    await step(
+      'Second column (index 1) inherits alignX from Column',
+      async () => {
+        const cells = canvas.getAllByRole('gridcell');
+        const secondCellContent = cells[1].querySelector(
+          '[data-cell-content]'
+        ) as HTMLElement;
+
+        expect(secondCellContent).toHaveClass('text-center');
+      }
+    );
+  },
+});

--- a/packages/components/src/Table/TableCellContent.tsx
+++ b/packages/components/src/Table/TableCellContent.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useContext } from 'react';
+import { type ReactNode, use } from 'react';
 import { TableStateContext } from 'react-aria-components';
 import { cn, textAlign } from '@marigold/system';
 import { useTableContext } from './Context';
@@ -55,7 +55,7 @@ export const TableCellContent = ({
     overflow: tableOverflow,
     allowTextSelection: tableAllowTextSelection,
   } = useTableContext();
-  const state = useContext(TableStateContext);
+  const state = use(TableStateContext);
 
   // Cell-level overrides table-level
   const overflow = cellOverflow ?? tableOverflow;
@@ -64,10 +64,11 @@ export const TableCellContent = ({
   const selectable = allowTextSelection ?? tableAllowTextSelection;
 
   // Get alignX prop from column
-  const columnAlign = columnIndex
-    ? (state?.collection.columns[columnIndex].props
-        .alignX as keyof typeof textAlign)
-    : undefined;
+  const columnAlign =
+    columnIndex != null
+      ? (state?.collection.columns[columnIndex].props
+          .alignX as keyof typeof textAlign)
+      : undefined;
 
   return (
     <div


### PR DESCRIPTION
# Description

`Table.Column alignX` was ignored for the first column (index 0) because `TableCellContent` used a truthy check on `columnIndex`. Since `0` is falsy in JavaScript, the column's `alignX` prop was never read for the first column.

**Fix:** Replace `columnIndex ? ...` with `columnIndex != null ? ...`

[DST-1346](https://reservix.atlassian.net/browse/DST-1346)

# Test Instructions:

- Open Storybook → Components/Table/Column Alignment
- Verify the first column (ID) is right-aligned
- Verify the second column (Name) is center-aligned
- Run `pnpm test:sb` to execute the story play function

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)

[DST-1346]: https://reservix.atlassian.net/browse/DST-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ