### PR TITLE
fix(DST-1352): use correct outline for focus + error state in compound fields

### DIFF
--- a/.changeset/flat-ghosts-talk.md
+++ b/.changeset/flat-ghosts-talk.md
@@ -1,0 +1,6 @@
+---
+"@marigold/components": patch
+"@marigold/theme-rui": patch
+---
+
+fix(DST-1352): use correct outline for focus + error state in compound fields

--- a/packages/components/src/DateField/DateField.test.tsx
+++ b/packages/components/src/DateField/DateField.test.tsx
@@ -63,7 +63,7 @@ test('renders correctly', () => {
       <div
         aria-describedby="react-aria-description-0 react-aria-_r_3_"
         aria-labelledby="react-aria-_r_1_"
-        class="ui-surface shadow-elevation-border h-input flex items-center disabled:ui-state-disabled group-read-only/field:ui-state-readonly has-focus:ui-state-focus has-invalid:ui-state-error has-focus:has-invalid:ring-destructive/20 w-(--field-width) max-w-full min-w-0 overflow-hidden"
+        class="ui-surface shadow-elevation-border h-input flex items-center disabled:ui-state-disabled group-read-only/field:ui-state-readonly has-focus:ui-state-focus has-invalid:ui-state-error has-focus:has-invalid:outline-destructive/20 has-focus:has-invalid:[--ui-border-color:var(--color-destructive)] w-(--field-width) max-w-full min-w-0 overflow-hidden"
         data-rac=""
         data-react-aria-pressable="true"
         id="react-aria-_r_0_"

--- a/themes/theme-rui/src/components/DateField.styles.ts
+++ b/themes/theme-rui/src/components/DateField.styles.ts
@@ -8,8 +8,7 @@ export const DateField: ThemeComponent<'DateField'> = {
       'disabled:ui-state-disabled',
       'group-read-only/field:ui-state-readonly',
       'has-focus:ui-state-focus',
-      // Need to set error ring manually to override focus ring
-      'has-invalid:ui-state-error has-focus:has-invalid:ring-destructive/20',
+      'has-invalid:ui-state-error has-focus:has-invalid:outline-destructive/20 has-focus:has-invalid:[--ui-border-color:var(--color-destructive)]',
     ],
   }),
   input: cva({ base: ['ui-input', 'cursor-text'] }),

--- a/themes/theme-rui/src/components/NumberField.styles.ts
+++ b/themes/theme-rui/src/components/NumberField.styles.ts
@@ -8,6 +8,7 @@ export const NumberField: ThemeComponent<'NumberField'> = {
       'group-data-disabled/field:ui-state-disabled',
       'group-read-only/field:ui-state-readonly',
       'has-focus:ui-state-focus outline-none',
+      'has-focus:has-invalid:outline-destructive/20 has-focus:has-invalid:[--ui-border-color:var(--color-destructive)]',
     ],
   }),
   stepper: cva({

--- a/themes/theme-rui/src/components/TagField.styles.ts
+++ b/themes/theme-rui/src/components/TagField.styles.ts
@@ -7,9 +7,9 @@ export const TagField: ThemeComponent<'TagField'> = {
       'cursor-pointer py-1',
       'group-disabled/field:ui-state-disabled',
       '[&:has(>button[data-focus-visible])]:ui-state-focus',
-      // Need to set error ring manually to override focus ring
       'group-invalid/field:ui-state-error',
-      '[&:has(>button[data-focus-visible])]:group-invalid/field:ring-destructive/20',
+      '[&:has(>button[data-focus-visible])]:group-invalid/field:outline-destructive/20',
+      '[&:has(>button[data-focus-visible])]:group-invalid/field:[--ui-border-color:var(--color-destructive)]',
     ],
   }),
   tagGroup: cva({ base: 'flex flex-1 flex-wrap items-center gap-1' }),


### PR DESCRIPTION
# Description

DateField, NumberField, and TagField detect child focus via `has-focus:` or `[&:has(...)]` variants instead of `focus:` directly on the element. This means `ui-state-error`'s built-in `focus:outline-destructive/20` override never matches on these components.

The previous workaround used `ring-destructive/20`, which targets box-shadow -- but `ui-state-focus` sets an `outline`, so the blue focus outline was never actually replaced by the destructive color.

**Fix:** Override both `outline-destructive/20` and `--ui-border-color` in the compound focus+invalid state so the outline and gradient border correctly switch to destructive.

**Affected components:**
- `DateField` -- had incorrect `ring-destructive/20` workaround
- `TagField` -- had same incorrect workaround
- `NumberField` -- was missing the compound override entirely

# Test Instructions:

1. Open Storybook and navigate to DateField, NumberField, or TagField
2. Set the field to an invalid/error state
3. Focus the field (click into it or tab)
4. Verify the focus ring is red/destructive (not the default blue)
5. Verify the border also turns destructive

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)