### PR TITLE
fix(DST-1355): widen Loader and ProgressCircle variant/size prop types

### DIFF
--- a/.changeset/widen-loader-prop-types.md
+++ b/.changeset/widen-loader-prop-types.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1355): widen `variant` and `size` prop types on `Loader` and `ProgressCircle` to accept arbitrary strings via `| (string & {})`. Matches the pattern already used by `Button`, `Panel`, and other components, and lets consumer themes register their own variant/size tokens without TypeScript errors while preserving IDE autocomplete for the built-in RUI values.

--- a/packages/components/src/Loader/BaseLoader.tsx
+++ b/packages/components/src/Loader/BaseLoader.tsx
@@ -17,8 +17,8 @@ export interface BaseLoaderProps extends Pick<
    * Children of the component that will make up the label.
    */
   children?: ReactNode;
-  variant?: 'default' | 'inverted';
-  size?: 'default' | 'large' | 'fit';
+  variant?: 'default' | 'inverted' | (string & {});
+  size?: 'default' | 'large' | 'fit' | (string & {});
   loaderType?: LoaderVisualType;
 }
 

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -9,8 +9,8 @@ export interface ProgressCircleProps extends RAC.ProgressBarProps {
    * Defines the height and width of the component
    * @default 16
    */
-  size?: string | 'default' | 'large' | 'fit';
-  variant?: 'default' | 'inverted';
+  size?: 'default' | 'large' | 'fit' | (string & {});
+  variant?: 'default' | 'inverted' | (string & {});
 }
 
 export const ProgressCircleSvg = ({


### PR DESCRIPTION
## Summary

- Add `| (string & {})` to `variant` and `size` on `BaseLoaderProps` (`packages/components/src/Loader/BaseLoader.tsx`) so consumer themes can define their own variant/size tokens without TypeScript errors.
- Apply the same widening to `ProgressCircleProps` (`packages/components/src/ProgressCircle/ProgressCircle.tsx`) — `BaseLoader` forwards `variant` to `ProgressCircleSvg`, so widening only one side would break type-checking. Also normalizes `size` from `string | 'default' | …` to the idiomatic `'default' | … | (string & {})` form.
- Matches the pattern already used by `Button`, `Panel`, `Dialog`, `Drawer`, `Table`, and ~10 other themable components. IDE autocomplete for `'default' | 'inverted' | 'large' | 'fit'` is preserved.
- No runtime behavior change: `cva` in `theme-rui` already accepts arbitrary string keys; this only relaxes the TypeScript interface.

Ticket: [DST-1355](https://reservix.atlassian.net/browse/DST-1355)

## Test plan

- [x] `pnpm typecheck:only` passes
- [x] `pnpm lint` passes (0 errors; only pre-existing warnings)
- [x] No changes to stories/tests needed — `Loader.stories.tsx` already uses free-text controls and tests don't assert on the TS interface
- [x] No theme style changes needed — `cva` already accepts arbitrary keys at runtime

[DST-1355]: https://reservix.atlassian.net/browse/DST-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ