### PR TITLE
chore: remove unused obsidian color palette

### DIFF
--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -43,20 +43,6 @@
   --color-charcoal-800: oklch(0.32 0.008 54);
   --color-charcoal-900: oklch(0.22 0.008 54);
   --color-charcoal-950: oklch(0.15 0.008 54);
-
-  /* high-contrast obsidian (warm neutral, hue 54, wider contrast range) */
-  --color-obsidian-50: oklch(0.99 0.002 54);
-  --color-obsidian-100: oklch(0.97 0.003 54);
-  --color-obsidian-200: oklch(0.94 0.004 54);
-  --color-obsidian-300: oklch(0.88 0.005 54);
-  --color-obsidian-400: oklch(0.75 0.005 54);
-  --color-obsidian-500: oklch(0.6 0.006 54);
-  --color-obsidian-600: oklch(0.45 0.006 54);
-  --color-obsidian-700: oklch(0.32 0.006 54);
-  --color-obsidian-800: oklch(0.2 0.006 54);
-  --color-obsidian-900: oklch(0.12 0.006 54);
-  --color-obsidian-950: oklch(0.08 0.006 54);
-
   /* ====================== */
   /*    SEMANTIC COLORS     */
   /* ====================== */


### PR DESCRIPTION
# Description

Removes the unused obsidian color palette from `theme.css`. The 11 custom properties (`--color-obsidian-50` through `--color-obsidian-950`) were defined but never referenced anywhere in the codebase.

# Test Instructions:

1. Verify no component or style references `--color-obsidian-*` (grep confirms zero usage)
2. Run `pnpm build:themes` to ensure the theme still builds

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)