### PR TITLE
fix(DST-1359): align ActionBar button spacing with Button

### DIFF
--- a/.changeset/actionbar-button-spacing.md
+++ b/.changeset/actionbar-button-spacing.md
@@ -1,0 +1,5 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1359): align `ActionBar` action button spacing with the regular `Button`. The `actionButton` style in `theme-rui` was missing `gap-2 items-center justify-center`, which caused icons and labels inside ActionBar buttons to render without the proper spacing/alignment used by the ghost/default `Button`. Adding these utilities restores visual parity across the design system.

--- a/themes/theme-rui/src/components/ActionBar.styles.ts
+++ b/themes/theme-rui/src/components/ActionBar.styles.ts
@@ -39,7 +39,7 @@ export const ActionBar: ThemeComponent<'ActionBar'> = {
   }),
   actionButton: cva({
     base: [
-      'ui-button-base',
+      'ui-button-base gap-2 items-center justify-center',
       'hover:bg-current/10',
       'text-sm h-button p-squish-relaxed [&_svg]:size-4',
     ],


### PR DESCRIPTION
## Summary

- The action buttons inside `ActionBar` did not visually match the regular `Button` component — icons and labels were rendered without proper spacing and alignment.
- Root cause: `ActionBar.actionButton` in `theme-rui` was missing `gap-2 items-center justify-center`, which `Button.styles.ts` applies as part of the ghost/default variant composition.
- Added those utilities to `actionButton.base` so ActionBar buttons space and center their content like a ghost/default `Button`.

Jira: [DST-1359](https://reservix.atlassian.net/browse/DST-1359)

## Test plan

- [ ] Visual check in Storybook: `Components / ActionBar / Basic` — icons and labels are correctly spaced and centered
- [ ] Compare side-by-side with a regular ghost/default `Button`
- [ ] `pnpm typecheck:only` passes
- [ ] `pnpm test` passes

[DST-1359]: https://reservix.atlassian.net/browse/DST-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ