### PR TITLE
docs(DST-1361): fix column alignment in Table demos

### DIFF
--- a/.changeset/table-demo-alignment.md
+++ b/.changeset/table-demo-alignment.md
@@ -1,0 +1,5 @@
+---
+'@marigold/docs': patch
+---
+
+docs(DST-1361): fix column alignment in Table documentation demos. Several demos contradicted the alignment guidelines described in the Table docs (numeric right, text left, center only for icons/status). The action-menu demo centered its row actions with `<Inline alignX="center">` while the column header was left-aligned, and the `table-editable`, `table-links`, and `table-sticky` demos had numeric Rating / Capacity columns rendered left-aligned. The demos now match the documented alignment rules.

--- a/docs/content/components/collection/table/table-action-menu.demo.tsx
+++ b/docs/content/components/collection/table/table-action-menu.demo.tsx
@@ -26,7 +26,7 @@ export default () => (
           </Table.Cell>
           <Table.Cell>{item.rating}</Table.Cell>
           <Table.Cell>
-            <Inline space={1} alignX="center" noWrap>
+            <Inline space={1} noWrap>
               <Tooltip.Trigger>
                 <Button size="small">
                   <Edit />

--- a/docs/content/components/collection/table/table-editable.demo.tsx
+++ b/docs/content/components/collection/table/table-editable.demo.tsx
@@ -42,7 +42,9 @@ export default () => {
       <Table.Header>
         <Table.Column rowHeader>Venue</Table.Column>
         <Table.Column>Amenities</Table.Column>
-        <Table.Column width={100}>Rating</Table.Column>
+        <Table.Column width={100} alignX="right">
+          Rating
+        </Table.Column>
       </Table.Header>
       <Table.Body>
         {data.map(venue => (

--- a/docs/content/components/collection/table/table-links.demo.tsx
+++ b/docs/content/components/collection/table/table-links.demo.tsx
@@ -6,7 +6,7 @@ export default () => (
     <Table.Header>
       <Table.Column rowHeader>Venue</Table.Column>
       <Table.Column>Address</Table.Column>
-      <Table.Column>Rating</Table.Column>
+      <Table.Column alignX="right">Rating</Table.Column>
     </Table.Header>
     <Table.Body>
       {venues.slice(0, 4).map(venue => (

--- a/docs/content/components/collection/table/table-sticky.demo.tsx
+++ b/docs/content/components/collection/table/table-sticky.demo.tsx
@@ -8,7 +8,7 @@ export default () => {
         <Table.Header sticky>
           <Table.Column rowHeader>Venue</Table.Column>
           <Table.Column>City</Table.Column>
-          <Table.Column>Capacity</Table.Column>
+          <Table.Column alignX="right">Capacity</Table.Column>
         </Table.Header>
         <Table.Body>
           {venues.map(venue => (


### PR DESCRIPTION
## Summary

Aligns the Table documentation demos with the alignment rules [documented in the Table docs](https://www.marigold-ui.io/components/collection/table) ("Align content": numeric right, text left, center only for icons/status).

- `table-action-menu`: drop `alignX="center"` on the actions `<Inline>` so the buttons follow the left-aligned column header instead of centering inside the cell.
- `table-editable`: right-align the numeric Rating column.
- `table-links`: right-align the numeric Rating column.
- `table-sticky`: right-align the numeric Capacity column (rendered via `NumericFormat`).

No runtime component changes — docs only.

Jira: [DST-1361](https://reservix.atlassian.net/browse/DST-1361)

## Test plan

- [ ] `pnpm start` → open each affected demo on localhost:3000 and confirm numeric columns are right-aligned and action buttons are left-aligned under a left-aligned header.
- [ ] `pnpm typecheck:docs` passes (no new errors introduced by this change).

[DST-1361]: https://reservix.atlassian.net/browse/DST-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ