### PR TITLE
feat(DST-1375): make Panel.Header optional for title-only Panels

### DIFF
--- a/.changeset/panel-header-optional.md
+++ b/.changeset/panel-header-optional.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+`Panel.Title` may now be used as a direct child of `Panel` when the Panel has only a title (no description, no actions) — `Panel.Header` is the layout wrapper for title + description + actions, but a title-only Panel doesn't need it. Accessibility (`aria-labelledby`) and horizontal panel padding still resolve correctly. `Panel.Description` and `Panel.HeaderActions` continue to require a `Panel.Header` wrapper. No change to existing usages.

--- a/docs/app/(examples)/examples/billing/page.tsx
+++ b/docs/app/(examples)/examples/billing/page.tsx
@@ -278,9 +278,7 @@ const BillingPage = () => (
         </Panel>
 
         <Panel variant="destructive">
-          <Panel.Header>
-            <Panel.Title>Danger zone</Panel.Title>
-          </Panel.Header>
+          <Panel.Title>Danger zone</Panel.Title>
           <Panel.Content>
             <Stack space={1}>
               <Text weight="semibold">Cancel subscription</Text>

--- a/docs/app/(examples)/examples/form/eventDetails.tsx
+++ b/docs/app/(examples)/examples/form/eventDetails.tsx
@@ -12,9 +12,7 @@ import {
 
 export const EventDetails = () => (
   <Panel size="form">
-    <Panel.Header>
-      <Panel.Title>Event Details</Panel.Title>
-    </Panel.Header>
+    <Panel.Title>Event Details</Panel.Title>
     <Panel.Content>
       <Stack space="regular">
         <TextField

--- a/docs/app/(examples)/examples/form/locationSettings.tsx
+++ b/docs/app/(examples)/examples/form/locationSettings.tsx
@@ -20,9 +20,7 @@ export const LocationSettings = () => {
   );
   return (
     <Panel size="form">
-      <Panel.Header>
-        <Panel.Title>Location & Capacity</Panel.Title>
-      </Panel.Header>
+      <Panel.Title>Location & Capacity</Panel.Title>
       <Panel.Content>
         <Stack space="group">
           <TextField

--- a/docs/app/(examples)/examples/form/organizerInfo.tsx
+++ b/docs/app/(examples)/examples/form/organizerInfo.tsx
@@ -16,9 +16,7 @@ import {
 
 export const OrganizerInfo = () => (
   <Panel size="form">
-    <Panel.Header>
-      <Panel.Title>Organizer Information</Panel.Title>
-    </Panel.Header>
+    <Panel.Title>Organizer Information</Panel.Title>
     <Panel.Content>
       <Stack space="regular">
         <Inline space="related" noWrap>

--- a/docs/app/(examples)/examples/form/registrationSettings.tsx
+++ b/docs/app/(examples)/examples/form/registrationSettings.tsx
@@ -14,9 +14,7 @@ import {
 
 export const RegistrationSettings = () => (
   <Panel size="form">
-    <Panel.Header>
-      <Panel.Title>Registration Settings</Panel.Title>
-    </Panel.Header>
+    <Panel.Title>Registration Settings</Panel.Title>
     <Panel.Content>
       <Stack space="regular">
         <Checkbox label="Require registration approval" />

--- a/docs/app/(examples)/examples/general/page.tsx
+++ b/docs/app/(examples)/examples/general/page.tsx
@@ -157,9 +157,7 @@ const GeneralPage = () => (
           </Panel>
 
           <Panel size="form" variant="destructive">
-            <Panel.Header>
-              <Panel.Title>Danger zone</Panel.Title>
-            </Panel.Header>
+            <Panel.Title>Danger zone</Panel.Title>
             <Panel.Content>
               <Stack space={1}>
                 <Text weight="semibold">Delete this workspace</Text>

--- a/docs/app/(examples)/examples/inventory/OurMission.tsx
+++ b/docs/app/(examples)/examples/inventory/OurMission.tsx
@@ -2,9 +2,7 @@ import { Columns, Panel, Stack, Text } from '@marigold/components';
 
 export const OurMission = () => (
   <Panel>
-    <Panel.Header>
-      <Panel.Title>Our Mission</Panel.Title>
-    </Panel.Header>
+    <Panel.Title>Our Mission</Panel.Title>
     <Panel.Content>
       <Columns columns={[2, 1]} space={20} collapseAt="1000px">
         <Stack space={4}>

--- a/docs/app/(examples)/examples/security/page.tsx
+++ b/docs/app/(examples)/examples/security/page.tsx
@@ -187,9 +187,7 @@ const SecurityPage = () => (
         </Panel>
 
         <Panel variant="destructive">
-          <Panel.Header>
-            <Panel.Title>Danger zone</Panel.Title>
-          </Panel.Header>
+          <Panel.Title>Danger zone</Panel.Title>
           <Panel.Content>
             <Stack space={1}>
               <Text weight="semibold">Revoke all API keys</Text>

--- a/docs/content/components/layout/panel/index.mdx
+++ b/docs/content/components/layout/panel/index.mdx
@@ -254,9 +254,7 @@ If the Panel lives under an existing `<h2>` on the page (inside a Tabs panel, fo
 
 ```tsx
 <Panel headingLevel={3}>
-  <Panel.Header>
-    <Panel.Title>…</Panel.Title> {/* renders as <h3> */}
-  </Panel.Header>
+  <Panel.Title>…</Panel.Title> {/* renders as <h3> */}
   <Panel.Collapsible>
     <Panel.CollapsibleHeader>
       <Panel.CollapsibleTitle>… {/* renders as <h4> */}</Panel.CollapsibleTitle>

--- a/docs/content/components/layout/panel/index.mdx
+++ b/docs/content/components/layout/panel/index.mdx
@@ -113,6 +113,14 @@ The title is how a user finds this section when they scan the page. Aim for a sh
 
 A description is a single-sentence subtitle directly under the title. Include one when the title alone doesn't tell the user what's at stake, or when the section introduces a concept they may not have seen before. Skip it when the title already says it. A description that restates the heading adds reading weight without adding information.
 
+#### Title-only Panels can drop the header
+
+`Panel.Header` is the layout wrapper that arranges title, description, and actions in a grid. When a Panel has only a title (no description, no actions) you can place `Panel.Title` as a direct child of `Panel` and skip the wrapper. Accessibility wires up the same way, and the title still aligns with the panel's horizontal padding.
+
+<ComponentDemo name="panel-without-header" />
+
+`Panel.Description` and `Panel.HeaderActions` always sit inside `Panel.Header`. As soon as a Panel needs supporting copy or actions next to its title, reach for the full header.
+
 ### Content
 
 The content area is the body of the Panel. It's deliberately open, and in practice most sections you'll build are one of three shapes:

--- a/docs/content/components/layout/panel/panel-without-header.demo.tsx
+++ b/docs/content/components/layout/panel/panel-without-header.demo.tsx
@@ -1,0 +1,13 @@
+import { Panel, Stack, TextField } from '@marigold/components';
+
+export default () => (
+  <Panel>
+    <Panel.Title>Quick settings</Panel.Title>
+    <Panel.Content>
+      <Stack space="regular">
+        <TextField label="Display name" defaultValue="Marigold Events" />
+        <TextField label="Support email" defaultValue="hello@marigold-ui.io" />
+      </Stack>
+    </Panel.Content>
+  </Panel>
+);

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -110,7 +110,6 @@ Basic.test(
 
 export const TitleOnlyWithoutHeader = meta.story({
   args: { children: null as never },
-  tags: ['component-test'],
   render: args => (
     <Panel {...args}>
       <Panel.Title>Quick Settings</Panel.Title>
@@ -121,14 +120,6 @@ export const TitleOnlyWithoutHeader = meta.story({
       </Panel.Content>
     </Panel>
   ),
-  play: async ({ canvas }) => {
-    const title = canvas.getByRole('heading', { name: 'Quick Settings' });
-    const region = canvas.getByRole('region', { name: 'Quick Settings' });
-
-    expect(title.tagName).toBe('H2');
-    expect(region.getAttribute('aria-labelledby')).toBe(title.id);
-    expect(title.closest('[data-panel-header]')).toBeNull();
-  },
 });
 
 export const WithHeaderActions = meta.story(() => (

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -108,6 +108,33 @@ Basic.test(
   }
 );
 
+export const TitleOnlyWithoutHeader = meta.story({
+  args: { children: null as never },
+  tags: ['component-test'],
+  render: args => (
+    <Panel {...args}>
+      <Panel.Title>Quick Settings</Panel.Title>
+      <Panel.Content>
+        <Stack space="regular">
+          <TextField label="Display name" defaultValue="Marigold Events" />
+        </Stack>
+      </Panel.Content>
+    </Panel>
+  ),
+});
+
+TitleOnlyWithoutHeader.test(
+  'renders a labelled region without a Panel.Header wrapper',
+  async ({ canvas }) => {
+    const title = canvas.getByRole('heading', { name: 'Quick Settings' });
+    const region = canvas.getByRole('region', { name: 'Quick Settings' });
+
+    expect(title.tagName).toBe('H2');
+    expect(region.getAttribute('aria-labelledby')).toBe(title.id);
+    expect(title.closest('[data-panel-header]')).toBeNull();
+  }
+);
+
 export const WithHeaderActions = meta.story(() => (
   <Stack space="section">
     <Panel>

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -121,27 +121,15 @@ export const TitleOnlyWithoutHeader = meta.story({
       </Panel.Content>
     </Panel>
   ),
-});
-
-TitleOnlyWithoutHeader.test(
-  'renders a labelled region without a Panel.Header wrapper',
-  async ({ canvas }) => {
+  play: async ({ canvas }) => {
     const title = canvas.getByRole('heading', { name: 'Quick Settings' });
     const region = canvas.getByRole('region', { name: 'Quick Settings' });
 
     expect(title.tagName).toBe('H2');
     expect(region.getAttribute('aria-labelledby')).toBe(title.id);
-  }
-);
-
-TitleOnlyWithoutHeader.test(
-  'headerless title is not inside a Panel.Header wrapper',
-  async ({ canvas }) => {
-    const title = canvas.getByRole('heading', { name: 'Quick Settings' });
-
     expect(title.closest('[data-panel-header]')).toBeNull();
-  }
-);
+  },
+});
 
 export const WithHeaderActions = meta.story(() => (
   <Stack space="section">

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -131,6 +131,14 @@ TitleOnlyWithoutHeader.test(
 
     expect(title.tagName).toBe('H2');
     expect(region.getAttribute('aria-labelledby')).toBe(title.id);
+  }
+);
+
+TitleOnlyWithoutHeader.test(
+  'headerless title is not inside a Panel.Header wrapper',
+  async ({ canvas }) => {
+    const title = canvas.getByRole('heading', { name: 'Quick Settings' });
+
     expect(title.closest('[data-panel-header]')).toBeNull();
   }
 );

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -6,7 +6,6 @@ import {
   Basic,
   CustomPadding,
   TableInside,
-  TitleOnlyWithoutHeader,
   Variants,
   WithHeaderActions,
 } from './Panel.stories';
@@ -304,26 +303,6 @@ describe('Panel.Content', () => {
     const contentWrapper = table.parentElement!;
 
     expect(contentWrapper.className).not.toContain('px-(--panel-px)');
-  });
-});
-
-describe('Title-only Panel (Panel.Header omitted)', () => {
-  test('renders a labelled region without a Panel.Header wrapper', () => {
-    render(<TitleOnlyWithoutHeader.Component />);
-
-    const title = screen.getByRole('heading', { name: 'Quick Settings' });
-    const region = screen.getByRole('region', { name: 'Quick Settings' });
-
-    expect(title.tagName).toBe('H2');
-    expect(region).toHaveAttribute('aria-labelledby', title.id);
-  });
-
-  test('headerless title is not inside a Panel.Header wrapper', () => {
-    render(<TitleOnlyWithoutHeader.Component />);
-
-    const title = screen.getByRole('heading', { name: 'Quick Settings' });
-
-    expect(title.closest('[data-panel-header]')).toBeNull();
   });
 });
 

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -6,6 +6,7 @@ import {
   Basic,
   CustomPadding,
   TableInside,
+  TitleOnlyWithoutHeader,
   Variants,
   WithHeaderActions,
 } from './Panel.stories';
@@ -230,6 +231,17 @@ describe('Panel.Title', () => {
     const title = screen.getByRole('heading', { name: 'Organizer Profile' });
 
     expect(title.closest('[data-panel-header]')).not.toBeNull();
+  });
+
+  test('labels the panel region when used without a Panel.Header', () => {
+    render(<TitleOnlyWithoutHeader.Component />);
+
+    const title = screen.getByRole('heading', { name: 'Quick Settings' });
+    const region = screen.getByRole('region', { name: 'Quick Settings' });
+
+    expect(title.tagName).toBe('H2');
+    expect(region).toHaveAttribute('aria-labelledby', title.id);
+    expect(title.closest('[data-panel-header]')).toBeNull();
   });
 
   test('defaults to an <h2>', () => {

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -6,6 +6,7 @@ import {
   Basic,
   CustomPadding,
   TableInside,
+  TitleOnlyWithoutHeader,
   Variants,
   WithHeaderActions,
 } from './Panel.stories';
@@ -224,6 +225,14 @@ describe('Panel.Title', () => {
     expect(renderOrphan).toThrow(/must be used within a <Panel>/);
   });
 
+  test('sits inside the Panel.Header wrapper so its own padding is suppressed', () => {
+    render(<Basic.Component />);
+
+    const title = screen.getByRole('heading', { name: 'Organizer Profile' });
+
+    expect(title.closest('[data-panel-header]')).not.toBeNull();
+  });
+
   test('defaults to an <h2>', () => {
     render(<Basic.Component />);
 
@@ -295,6 +304,26 @@ describe('Panel.Content', () => {
     const contentWrapper = table.parentElement!;
 
     expect(contentWrapper.className).not.toContain('px-(--panel-px)');
+  });
+});
+
+describe('Title-only Panel (Panel.Header omitted)', () => {
+  test('renders a labelled region without a Panel.Header wrapper', () => {
+    render(<TitleOnlyWithoutHeader.Component />);
+
+    const title = screen.getByRole('heading', { name: 'Quick Settings' });
+    const region = screen.getByRole('region', { name: 'Quick Settings' });
+
+    expect(title.tagName).toBe('H2');
+    expect(region).toHaveAttribute('aria-labelledby', title.id);
+  });
+
+  test('headerless title is not inside a Panel.Header wrapper', () => {
+    render(<TitleOnlyWithoutHeader.Component />);
+
+    const title = screen.getByRole('heading', { name: 'Quick Settings' });
+
+    expect(title.closest('[data-panel-header]')).toBeNull();
   });
 });
 

--- a/packages/components/src/Panel/Panel.tsx
+++ b/packages/components/src/Panel/Panel.tsx
@@ -29,6 +29,13 @@ interface PanelBaseProps {
   /**
    * Content of the panel. Typically a combination of `Panel.Header`,
    * `Panel.Content`, `Panel.Collapsible`, and `Panel.Footer`.
+   *
+   * `Panel.Header` is the layout wrapper that arranges `Panel.Title`,
+   * `Panel.Description`, and `Panel.HeaderActions` in a grid. When a
+   * Panel has only a title (no description, no actions), `Panel.Title`
+   * may be used as a direct child of `Panel` and the wrapper can be
+   * omitted. `Panel.Description` and `Panel.HeaderActions` always
+   * require a `Panel.Header` wrapper.
    */
   children: ReactNode;
   /** Accessible label. Required when no `Panel.Title` is present. */

--- a/packages/components/src/Panel/PanelDescription.tsx
+++ b/packages/components/src/Panel/PanelDescription.tsx
@@ -3,7 +3,7 @@ import { cn } from '@marigold/system';
 import { usePanelContext } from './Context';
 
 export interface PanelDescriptionProps {
-  /** Supporting copy shown beneath the `Panel.Title`. */
+  /** Supporting copy shown beneath the `Panel.Title`. Must be used inside `Panel.Header`. */
   children: ReactNode;
 }
 

--- a/packages/components/src/Panel/PanelHeader.tsx
+++ b/packages/components/src/Panel/PanelHeader.tsx
@@ -15,6 +15,7 @@ export const PanelHeader = ({ children }: PanelHeaderProps) => {
 
   return (
     <div
+      data-panel-header
       className={cn(
         "grid grid-cols-[1fr_auto] [grid-template-areas:'title_actions'_'description_actions']",
         'px-(--panel-px)',

--- a/packages/components/src/Panel/PanelHeaderActions.tsx
+++ b/packages/components/src/Panel/PanelHeaderActions.tsx
@@ -3,7 +3,7 @@ import { cn } from '@marigold/system';
 import { usePanelContext } from './Context';
 
 export interface PanelHeaderActionsProps {
-  /** Actions rendered at the end of the header (e.g. buttons or menus). */
+  /** Actions rendered at the end of the header (e.g. buttons or menus). Must be used inside `Panel.Header`. */
   children: ReactNode;
 }
 

--- a/packages/components/src/Panel/PanelTitle.tsx
+++ b/packages/components/src/Panel/PanelTitle.tsx
@@ -20,7 +20,11 @@ export const PanelTitle = ({ children }: PanelTitleProps) => {
       ref={titleSlotRef}
       level={headingLevel}
       id={titleId}
-      className={cn('[grid-area:title]', classNames.title)}
+      className={cn(
+        '[grid-area:title]',
+        'not-in-data-panel-header:px-(--panel-px)',
+        classNames.title
+      )}
     >
       {children}
     </Heading>


### PR DESCRIPTION
## Summary

- Allow `Panel.Title` as a direct child of `Panel` when no description or actions are needed. The headerless authoring form was already accessibility-correct (the `aria-labelledby` slot/context plumbing lives on the `Panel` root, not on `Panel.Header`); this PR adds the matching horizontal panel padding via Tailwind v4's `not-in-data-panel-header:` variant and officially documents it.
- `Panel.Description` and `Panel.HeaderActions` continue to require a `Panel.Header` wrapper.
- Drops the now-redundant `Panel.Header` from 8 dashboard examples + 1 docs MDX snippet (all "Danger zone" panels and form/inventory headings that had only a title).

Implementation note: `PanelHeader` adds a `data-panel-header` attribute; `PanelTitle` carries `not-in-data-panel-header:px-(--panel-px)` so the padding only emits when no `[data-panel-header]` ancestor exists. No React context, no provider boundary — purely DOM-driven via Tailwind variant. Pattern mirrors `BooleanField` ↔ `Checkbox`/`Switch`.

Jira: [DST-1375](https://reservix.atlassian.net/browse/DST-1375)

Changeset: `.changeset/panel-header-optional.md` (patch).

## Test plan

- [ ] `pnpm typecheck:only` clean
- [ ] `pnpm test:unit -- Panel` — 34/34 Panel tests + new "Title-only Panel" describe block pass (1118/1118 overall)
- [ ] `pnpm test:sb -- Panel` — 11/11 Panel storybook tests including the new `TitleOnlyWithoutHeader` story
- [ ] Visual check (verified in 6007 Storybook): title `padding-inline: 12px` headerless, `0px` inside `Panel.Header` — same alignment in both forms, no double-padding
- [ ] `pnpm sb` and visit the new `TitleOnlyWithoutHeader` story
- [ ] `pnpm start` and review the updated dashboard examples (Security → Danger zone, General → Danger zone, Billing → Danger zone, etc.)
- [ ] Verify the new `panel-without-header` demo renders in `/components/layout/panel`

[DST-1375]: https://reservix.atlassian.net/browse/DST-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ