### PR TITLE
Revert "fix(docs): drop force-static on manifest route (#5365)"

### DIFF
--- a/docs/app/api/manifest.json/route.ts
+++ b/docs/app/api/manifest.json/route.ts
@@ -1,9 +1,7 @@
 import { source } from '@/lib/source';
+import { NextResponse } from 'next/server';
 
-// `force-static` triggers a Node 22+ undici bug during Next.js prerender:
-// `TypeError: Cannot read private member #state` (undici#4290, node#58814).
-// Skip build-time prerender; the response is cached by the CDN via headers.
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';
 
 const EXCLUDED_PREFIXES = ['releases'];
 const EXCLUDED_SEGMENTS = ['__internal__'];
@@ -32,15 +30,8 @@ export async function GET() {
     })
     .sort((a, b) => a.slug.localeCompare(b.slug));
 
-  const body = JSON.stringify({
+  return NextResponse.json({
     baseUrl: 'https://www.marigold-ui.io',
     pages: entries,
-  });
-
-  return new Response(body, {
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
-    },
   });
 }


### PR DESCRIPTION
## Summary

Reverts #5365.

The `force-dynamic` swap was treating a symptom: the original Vercel
`Preview – marigold-docs` build failure on beta-release was reported as a
prerender error on `/api/manifest.json`, but production main deploys with
the same code (`force-static` + `NextResponse.json()`) had been succeeding
the entire time. The latest beta-release preview deploy (`7389e83ff`,
which has the `force-dynamic` fix merged in via this PR) is **still
failing** — confirming the fix wasn't addressing the real cause.

Suspected real root cause: env-var difference between the Vercel Production
and Preview environments after the MCP server integration (#5233) merged
to main. See `docs-vercel-preview-regression.md` for the full
investigation.

## Test plan

- [ ] Confirm production main deploy continues to succeed with the route
      back on `force-static`
- [ ] Investigate the underlying env-var/build issue separately and open a
      proper fix once the cause is understood