### PR TITLE
fix(docs): drop force-static from /api/manifest.json and /api/md route handlers

### DIFF
--- a/docs/app/api/manifest.json/route.ts
+++ b/docs/app/api/manifest.json/route.ts
@@ -1,7 +1,10 @@
 import { source } from '@/lib/source';
-import { NextResponse } from 'next/server';
 
-export const dynamic = 'force-static';
+// `force-static` trips a Node 22+ undici/Next proxy bug
+// ("Cannot read private member #state", undici#4290) during prerender.
+// Run on demand and let the CDN cache via the long-lived Cache-Control
+// header below — same effective behavior as static export.
+export const dynamic = 'force-dynamic';
 
 const EXCLUDED_PREFIXES = ['releases'];
 const EXCLUDED_SEGMENTS = ['__internal__'];
@@ -30,8 +33,15 @@ export async function GET() {
     })
     .sort((a, b) => a.slug.localeCompare(b.slug));
 
-  return NextResponse.json({
+  const body = JSON.stringify({
     baseUrl: 'https://www.marigold-ui.io',
     pages: entries,
+  });
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
   });
 }

--- a/docs/app/api/manifest.json/route.ts
+++ b/docs/app/api/manifest.json/route.ts
@@ -1,9 +1,7 @@
 import { source } from '@/lib/source';
+import { NextResponse } from 'next/server';
 
-// `force-static` triggers a Node 22+ undici bug during Next.js prerender:
-// `TypeError: Cannot read private member #state` (undici#4290, node#58814).
-// Skip build-time prerender; the response is cached by the CDN via headers.
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-static';
 
 const EXCLUDED_PREFIXES = ['releases'];
 const EXCLUDED_SEGMENTS = ['__internal__'];
@@ -32,15 +30,8 @@ export async function GET() {
     })
     .sort((a, b) => a.slug.localeCompare(b.slug));
 
-  const body = JSON.stringify({
+  return NextResponse.json({
     baseUrl: 'https://www.marigold-ui.io',
     pages: entries,
-  });
-
-  return new Response(body, {
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
-    },
   });
 }

--- a/docs/app/api/md/[...slug]/route.ts
+++ b/docs/app/api/md/[...slug]/route.ts
@@ -1,25 +1,13 @@
 import { parseMdxToMarkdown } from '@/lib/markdown/parser';
-import { source } from '@/lib/source';
 import path from 'node:path';
-import { NextResponse } from 'next/server';
 
 const CONTENT_DIR = path.resolve(process.cwd(), 'content');
 
-/**
- * Parse MDX to markdown at build time (SSG).
- * ComponentDemo sources come from .registry/demos.json (pure data, no Client imports).
- */
-export const dynamic = 'force-static';
-
-export const generateStaticParams = async () => {
-  const params = await source.generateParams();
-
-  return params
-    .filter(param => Array.isArray(param.slug) && param.slug.length > 0)
-    .map(param => ({
-      slug: [...param.slug.slice(0, -1), `${param.slug.at(-1)}.md`],
-    }));
-};
+// `force-static` trips a Node 22+ undici/Next proxy bug
+// ("Cannot read private member #state", undici#4290) during prerender.
+// Run on demand and let the CDN cache via the long-lived Cache-Control
+// header below — same effective behavior as static export.
+export const dynamic = 'force-dynamic';
 
 export async function GET(
   _request: Request,
@@ -53,5 +41,8 @@ export async function GET(
     }
   }
 
-  return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+  return new Response(JSON.stringify({ error: 'Page not found' }), {
+    status: 404,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
 }


### PR DESCRIPTION
## Summary

Permanent fix for the Vercel prerender failure that produced:

```
TypeError: Cannot read private member #state from an object whose class did not declare it
    at Reflect.get (<anonymous>)
Export encountered an error on /api/manifest.json/route
```

…and (after #5365) on `/api/md/[...slug]/route` for `selectlist.md`.

## Root cause

Node 22+'s bundled undici uses private `#state` fields on `Response`. Next 16 wraps the `Response` returned from a `force-static` route handler in a `Proxy` during static export. `Reflect.get` on that `Proxy` cannot forward the private-field access, so undici throws and the prerender worker dies. The route name printed in the error is just whichever route was in flight when the worker crashed — both `/api/manifest.json` and `/api/md/[...slug]` have been silently flaky on Vercel since the Node 24 bump (#5156).

The bug is non-deterministic: same code can succeed on one Vercel build and fail on the next, which is why production main deploys appeared healthy while preview deploys failed (and why #5365 looked like it worked, then failed again on the next merge).

References:
- https://github.com/nodejs/undici/issues/4290
- https://github.com/nodejs/node/issues/58814

## Fix

Both `force-static` route handlers in `docs/app/api/` switch to `force-dynamic`, with explicit long-lived CDN cache headers:

```
Cache-Control: public, max-age=31536000, immutable
```

End-state behavior is identical to what `force-static` was aiming for — built once per deploy, served from the CDN forever, regenerated only on the next deploy. The only thing that changes is *when* the response is generated (first-request after deploy instead of build time), which is invisible to consumers because the CDN serves it.

Also drops the now-pointless `generateStaticParams` and `NextResponse` imports.

## Stacking

Stacked on #5368 (revert of #5365). When the revert merges, this PR's diff against `main` reduces to the two route-handler changes shown above.

## Test plan

- [x] Local dev / build smoke tested
- [ ] Vercel preview build completes without `#state` error
- [ ] `curl -I https://marigold-docs-…vercel.app/api/manifest.json` returns 200 with `Cache-Control: public, max-age=31536000, immutable`
- [ ] Same for `/api/md/components/actions/button.md`