### PR TITLE
fix(docs): drop force-static from /api/md route handler

### DIFF
--- a/docs/app/api/manifest.json/route.ts
+++ b/docs/app/api/manifest.json/route.ts
@@ -40,7 +40,7 @@ export async function GET() {
   return new Response(body, {
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=31536000, immutable',
     },
   });
 }

--- a/docs/app/api/md/[...slug]/route.ts
+++ b/docs/app/api/md/[...slug]/route.ts
@@ -1,25 +1,12 @@
 import { parseMdxToMarkdown } from '@/lib/markdown/parser';
-import { source } from '@/lib/source';
 import path from 'node:path';
-import { NextResponse } from 'next/server';
 
 const CONTENT_DIR = path.resolve(process.cwd(), 'content');
 
-/**
- * Parse MDX to markdown at build time (SSG).
- * ComponentDemo sources come from .registry/demos.json (pure data, no Client imports).
- */
-export const dynamic = 'force-static';
-
-export const generateStaticParams = async () => {
-  const params = await source.generateParams();
-
-  return params
-    .filter(param => Array.isArray(param.slug) && param.slug.length > 0)
-    .map(param => ({
-      slug: [...param.slug.slice(0, -1), `${param.slug.at(-1)}.md`],
-    }));
-};
+// `force-static` triggers a Node 22+ undici bug during Next.js prerender:
+// `TypeError: Cannot read private member #state` (undici#4290, node#58814).
+// Skip build-time prerender; the response is cached by the CDN via headers.
+export const dynamic = 'force-dynamic';
 
 export async function GET(
   _request: Request,
@@ -53,5 +40,8 @@ export async function GET(
     }
   }
 
-  return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+  return new Response(JSON.stringify({ error: 'Page not found' }), {
+    status: 404,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
 }


### PR DESCRIPTION
## Summary

Follow-up to #5365 — same root cause, different route.

The `Cannot read private member #state` Vercel build failure is the [Node 22+ undici/Next.js Proxy bug](https://github.com/nodejs/undici/issues/4290) ([node#58814](https://github.com/nodejs/node/issues/58814)). Node's bundled undici uses private `#state` fields on `Response`; Next 16 wraps any `Response` returned from a `force-static` handler in a `Proxy` during static export; `Reflect.get` on that `Proxy` can't forward the private-field access, so undici throws and the prerender worker dies. The route name in the error is just whichever route was in flight when the worker crashed — the bug is non-deterministic and lives in the `force-static` route-handler path itself, not in any specific route's code.

#5365 only flipped `/api/manifest.json` to `force-dynamic`. The very next beta-release preview build fired the same crash on `/api/md/components/collection/selectlist.md` instead — `/api/md/[...slug]` is the more dangerous of the two `force-static` route handlers because it prerenders ~130 pages.

## Changes

- `docs/app/api/md/[...slug]/route.ts` — `force-static` → `force-dynamic`. Drops the now-pointless `generateStaticParams` and the `NextResponse` import. Existing `Cache-Control: public, max-age=31536000, immutable` header keeps the response cached at the CDN edge for a year, so end-state behavior is unchanged from the static export.
- `docs/app/api/manifest.json/route.ts` — bumps the temporary `max-age=3600, s-maxage=86400` Cache-Control put in by #5365 to the same `max-age=31536000, immutable` for consistency with the md route.

After this, no docs route handler uses `force-static`, which fully eliminates the prerender flake.

## Test plan

- [ ] Vercel preview build completes without `#state` error
- [ ] `curl -I` on `/api/manifest.json` and a sample `/api/md/...md` returns 200 with `Cache-Control: public, max-age=31536000, immutable`
- [ ] `x-vercel-cache: HIT` on the second request to either endpoint