### PR TITLE
fix(docs): make MCP/embedding env vars optional for local builds

### DIFF
--- a/.changeset/docs-optional-env-vars.md
+++ b/.changeset/docs-optional-env-vars.md
@@ -1,0 +1,5 @@
+---
+'@marigold/docs': patch
+---
+
+fix(docs): make MCP and embedding env vars optional so `pnpm build:docs` works locally without `AWS_BEDROCK_*`, `OIDC_*`, or `BLOB_READ_WRITE_TOKEN` set. Also corrects the `claude mcp add marigold-docs` snippet to use the positional URL argument instead of `--url`.

--- a/docs/app/.well-known/oauth-protected-resource/route.ts
+++ b/docs/app/.well-known/oauth-protected-resource/route.ts
@@ -5,13 +5,7 @@ import {
 } from 'mcp-handler';
 import { NextResponse } from 'next/server';
 
-const OIDC_AUTHORITY = process.env.OIDC_AUTHORITY;
-
-if (!OIDC_AUTHORITY) {
-  throw new Error('Missing OIDC configuration. Set OIDC_AUTHORITY.');
-}
-
-const authority: string = OIDC_AUTHORITY;
+const authority = process.env.OIDC_AUTHORITY || '';
 
 export function GET(req: Request) {
   const resourceUrl = getPublicUrl(req).origin;

--- a/docs/app/mcp/route.ts
+++ b/docs/app/mcp/route.ts
@@ -27,15 +27,8 @@ const EMBEDDINGS_FILE = path.join(
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
-if (!process.env.OIDC_AUTHORITY || !process.env.OIDC_CLIENT_ID) {
-  throw new Error(
-    'Missing OIDC configuration. Set OIDC_AUTHORITY and OIDC_CLIENT_ID.'
-  );
-}
-
-const OIDC_AUTHORITY: string = process.env.OIDC_AUTHORITY;
-const OIDC_CLIENT_ID: string = process.env.OIDC_CLIENT_ID;
-const KEYCLOAK_JWKS_URI = `${OIDC_AUTHORITY.replace(/\/$/, '')}/protocol/openid-connect/certs`;
+const OIDC_AUTHORITY = process.env.OIDC_AUTHORITY || '';
+const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID || '';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -54,13 +47,8 @@ let bedrock: BedrockRuntimeClient | null = null;
 function getBedrock(): BedrockRuntimeClient {
   if (bedrock) return bedrock;
 
-  const accessKeyId = process.env.AWS_BEDROCK_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.AWS_BEDROCK_SECRET_ACCESS_KEY;
-  if (!accessKeyId || !secretAccessKey) {
-    throw new Error(
-      'Missing AWS Bedrock credentials. Set AWS_BEDROCK_ACCESS_KEY_ID and AWS_BEDROCK_SECRET_ACCESS_KEY.'
-    );
-  }
+  const accessKeyId = process.env.AWS_BEDROCK_ACCESS_KEY_ID || '';
+  const secretAccessKey = process.env.AWS_BEDROCK_SECRET_ACCESS_KEY || '';
 
   bedrock = new BedrockRuntimeClient({
     region: AWS_REGION,
@@ -109,8 +97,12 @@ function loadStore(): VectorStore {
   return { chunks: data, vectors };
 }
 
-// Load eagerly at module init; file is bundled via outputFileTracingIncludes.
-const store: VectorStore = loadStore();
+// Lazy so module init does not require embeddings.json (local builds skip it; production bundles it via outputFileTracingIncludes).
+let store: VectorStore | null = null;
+function getStore(): VectorStore {
+  if (!store) store = loadStore();
+  return store;
+}
 
 // ─── Search ──────────────────────────────────────────────────────────────────
 
@@ -144,7 +136,17 @@ function search(queryVec: Float32Array, vs: VectorStore, limit: number) {
 
 // ─── Auth (Keycloak JWT) ─────────────────────────────────────────────────────
 
-const jwks = createRemoteJWKSet(new URL(KEYCLOAK_JWKS_URI));
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJwks() {
+  if (jwks) return jwks;
+  jwks = createRemoteJWKSet(
+    new URL(
+      `${OIDC_AUTHORITY.replace(/\/$/, '')}/protocol/openid-connect/certs`
+    )
+  );
+  return jwks;
+}
 
 const verifyToken = async (
   _req: Request,
@@ -153,7 +155,7 @@ const verifyToken = async (
   if (!bearerToken) return undefined;
 
   try {
-    const { payload } = await jwtVerify(bearerToken, jwks, {
+    const { payload } = await jwtVerify(bearerToken, getJwks(), {
       issuer: OIDC_AUTHORITY,
       audience: OIDC_CLIENT_ID,
     });
@@ -205,7 +207,7 @@ const handler = createMcpHandler(
       async ({ query, limit }) => {
         try {
           const queryVec = await embedQuery(query.trim());
-          const results = search(queryVec, store, limit);
+          const results = search(queryVec, getStore(), limit);
 
           return {
             content: [

--- a/docs/app/mcp/route.ts
+++ b/docs/app/mcp/route.ts
@@ -29,6 +29,7 @@ const EMBEDDINGS_FILE = path.join(
 
 const OIDC_AUTHORITY = process.env.OIDC_AUTHORITY || '';
 const OIDC_CLIENT_ID = process.env.OIDC_CLIENT_ID || '';
+const KEYCLOAK_JWKS_URI = `${OIDC_AUTHORITY.replace(/\/$/, '')}/protocol/openid-connect/certs`;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -99,10 +100,10 @@ function loadStore(): VectorStore {
 
 // Lazy so module init does not require embeddings.json (local builds skip it; production bundles it via outputFileTracingIncludes).
 let store: VectorStore | null = null;
-function getStore(): VectorStore {
+const getStore = (): VectorStore => {
   if (!store) store = loadStore();
   return store;
-}
+};
 
 // ─── Search ──────────────────────────────────────────────────────────────────
 
@@ -138,15 +139,10 @@ function search(queryVec: Float32Array, vs: VectorStore, limit: number) {
 
 let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 
-function getJwks() {
-  if (jwks) return jwks;
-  jwks = createRemoteJWKSet(
-    new URL(
-      `${OIDC_AUTHORITY.replace(/\/$/, '')}/protocol/openid-connect/certs`
-    )
-  );
+const getJwks = () => {
+  if (!jwks) jwks = createRemoteJWKSet(new URL(KEYCLOAK_JWKS_URI));
   return jwks;
-}
+};
 
 const verifyToken = async (
   _req: Request,

--- a/docs/content/getting-started/usage-with-ai/index.mdx
+++ b/docs/content/getting-started/usage-with-ai/index.mdx
@@ -46,9 +46,9 @@ The **marigold-docs** MCP server provides semantic search over the full Marigold
     ```bash
     claude mcp add marigold-docs \
       --transport http \
-      --url https://www.marigold-ui.io/mcp \
       --client-id dst-marigold-docs-mcp \
-      --callback-port 6749
+      --callback-port 6749 \
+      https://www.marigold-ui.io/mcp
     ```
 
     On first use, the server will ask you to authenticate through your browser.

--- a/docs/lib/markdown/etl/embedder.ts
+++ b/docs/lib/markdown/etl/embedder.ts
@@ -44,20 +44,9 @@ class TokenRateLimiter {
 
 const rateLimiter = new TokenRateLimiter();
 
-const AWS_BEDROCK_ACCESS_KEY_ID = process.env.AWS_BEDROCK_ACCESS_KEY_ID;
-const AWS_BEDROCK_SECRET_ACCESS_KEY = process.env.AWS_BEDROCK_SECRET_ACCESS_KEY;
-
-if (!AWS_BEDROCK_ACCESS_KEY_ID || !AWS_BEDROCK_SECRET_ACCESS_KEY) {
-  throw new Error(
-    'Missing AWS credentials. Set AWS_BEDROCK_ACCESS_KEY_ID and AWS_BEDROCK_SECRET_ACCESS_KEY environment variables.'
-  );
-}
-
-if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  throw new Error(
-    'Missing BLOB_READ_WRITE_TOKEN. Embeddings can only be published to Vercel Blob.'
-  );
-}
+const AWS_BEDROCK_ACCESS_KEY_ID = process.env.AWS_BEDROCK_ACCESS_KEY_ID || '';
+const AWS_BEDROCK_SECRET_ACCESS_KEY =
+  process.env.AWS_BEDROCK_SECRET_ACCESS_KEY || '';
 
 const client = new BedrockRuntimeClient({
   region: AWS_REGION,

--- a/docs/scripts/build-embeddings.mjs
+++ b/docs/scripts/build-embeddings.mjs
@@ -1,27 +1,6 @@
 #!/usr/bin/env zx
 import { $, chalk } from 'zx';
 
-if (
-  !process.env.AWS_BEDROCK_ACCESS_KEY_ID ||
-  !process.env.AWS_BEDROCK_SECRET_ACCESS_KEY
-) {
-  console.error(
-    chalk.red(
-      'Missing AWS credentials: AWS_BEDROCK_ACCESS_KEY_ID and AWS_BEDROCK_SECRET_ACCESS_KEY must be set.'
-    )
-  );
-  process.exit(1);
-}
-
-if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  console.error(
-    chalk.red(
-      'Missing BLOB_READ_WRITE_TOKEN: embeddings must be uploadable to Vercel Blob.'
-    )
-  );
-  process.exit(1);
-}
-
 console.log(chalk.blue('Chunking docs...'));
 await $`pnpm tsx lib/markdown/etl/chunker.ts`;
 

--- a/docs/scripts/download-embeddings.mjs
+++ b/docs/scripts/download-embeddings.mjs
@@ -12,17 +12,10 @@ const outputPath = resolve(
   'embeddings.json'
 );
 
-if (!process.env.BLOB_READ_WRITE_TOKEN) {
-  console.error(
-    'BLOB_READ_WRITE_TOKEN is not set. Cannot download embeddings.'
-  );
-  process.exit(1);
-}
-
 try {
   const result = await get('embeddings.json', {
     access: 'private',
-    token: process.env.BLOB_READ_WRITE_TOKEN,
+    token: process.env.BLOB_READ_WRITE_TOKEN || '',
   });
 
   if (!result) {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                              
  Drop the module-init throws and early-exits guarding `AWS_BEDROCK_*`, `OIDC_*`, and `BLOB_READ_WRITE_TOKEN`, falling back to empty defaults. Makes `pnpm build:docs` succeed locally without
   secrets; Vercel still provides them at deploy time. Also fixes the `claude mcp add` snippet to use the positional URL form.                                                                
                                                                                                                                                                                              
  ## Description                                                                                                                                                                              
                                                                                                                                                                                              
  Until now, running `pnpm build:docs` locally required exporting `AWS_BEDROCK_ACCESS_KEY_ID`, `AWS_BEDROCK_SECRET_ACCESS_KEY`, `OIDC_AUTHORITY`, `OIDC_CLIENT_ID`, and                       
  `BLOB_READ_WRITE_TOKEN`. The MCP route handler and the OAuth metadata route both threw at module init when any of these were missing, which Next.js evaluates during the “Collecting page   
  data” phase and turns into a hard build failure.                                                                                                                                            
                                                                                 
  This PR removes those module-level guards and falls back to `''` everywhere these vars are read. On Vercel the values come from the project's environment, so production behaviour is       
  unchanged.                             
                                                                                                                                                                                              
  ### Changes                                                                    
                                  
  - `docs/app/mcp/route.ts` — drop the OIDC and Bedrock-credential throws; fall back to `''`. Lazy-init the Keycloak `JWKS` (so `new URL(...)` doesn't run at module load with an empty       
  authority) and lazy-load the `embeddings.json` vector store (so local builds don't fail when the file isn't downloaded).                                                                  
  - `docs/app/.well-known/oauth-protected-resource/route.ts` — drop the `OIDC_AUTHORITY` throw; default to `''`.                                                                              
  - `docs/lib/markdown/etl/embedder.ts` — drop the AWS / Blob throws; default to `''`.                                                                                                        
  - `docs/scripts/build-embeddings.mjs` / `docs/scripts/download-embeddings.mjs` — drop the early `process.exit(1)` checks.                                                                   
  - `docs/content/getting-started/usage-with-ai/index.mdx` — fix the `claude mcp add` snippet: the URL must be the positional argument, not a `--url` flag.                                   
                                                                                                                                                                                              
  ## Test Instructions                                                                                                                                                                        
                                                                                                                                                                                              
  - [ ] Unset all five env vars locally and run `pnpm build:docs` — build succeeds (no “Missing OIDC configuration” / “Missing AWS credentials” errors, no `ENOENT embeddings.json`).         
  - [ ] `pnpm --filter @marigold/docs types:check` is clean.
  - [ ] Vercel preview deploy succeeds and `/mcp` still responds (the env vars are set there, so behavior is unchanged).                                                                      
  - [ ] Copy the updated 
      ```
    claude mcp add marigold-docs \
      --transport http \
      --client-id dst-marigold-docs-mcp \
      --callback-port 6749 \
      https://www.marigold-ui.io/mcp
    ```
    snippet from the docs page and verify it registers the server in Claude Code without an "unknown option `--url`" error. 

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)
