### PR TITLE
ci([DST-1380]): add VRT_ENABLED toggle for visual-regression workflow

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -20,17 +20,22 @@ on:
 
 jobs:
   chromatic:
+    # To disable this workflow without code changes, set the repository variable
+    # VRT_ENABLED to 'false' (Settings → Secrets and variables → Actions → Variables).
+    # Unset or any other value keeps the workflow active (fail-open).
     if: >
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/run-chromatic')
+      vars.VRT_ENABLED != 'false' && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.merged == true
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          contains(github.event.comment.body, '/run-chromatic')
+        )
       )
 
     name: Visual Regression Tests


### PR DESCRIPTION
## Summary

- Gates the `chromatic` job in `.github/workflows/visual-regression-tests.yml` on a repository variable `vars.VRT_ENABLED`.
- Fail-open: workflow runs unless `VRT_ENABLED=false` is explicitly set in *Settings → Secrets and variables → Actions → Variables*.
- Lets us disable visual-regression runs via the GitHub UI (e.g. when Chromatic is down or during freezes) without editing and merging YAML.

Jira: [DST-1380](https://reservix.atlassian.net/browse/DST-1380)

## Test plan

- [ ] Workflow YAML lints cleanly (GitHub Actions parses the `if:` expression)
- [ ] With no `VRT_ENABLED` repo variable set: workflow runs as before on push / merged PR / `/run-chromatic` comment / manual dispatch
- [ ] With `VRT_ENABLED=false` set: chromatic job is skipped on all triggers
- [ ] With `VRT_ENABLED=true` set: workflow runs (any non-`'false'` value should be active)

[DST-1380]: https://reservix.atlassian.net/browse/DST-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ