### PR TITLE
docs([DST-1385])Document Switch settings variant and auto-save rule

### DIFF
--- a/.changeset/switch-settings-variant-docs.md
+++ b/.changeset/switch-settings-variant-docs.md
@@ -2,8 +2,7 @@
 '@marigold/docs': patch
 ---
 
-docs: document Switch `variant="settings"` and the auto-save rule
+docs(DST-1385): document Switch `variant="settings"` and the auto-save rule
 
 Adds a Button-style variant table under `## Appearance` summarising `default` and `settings`, rewrites `Settings and preference` with placement guidance and the reasoning for why switches must live on auto-save surfaces (light-switch metaphor + `role="switch"` ARIA contract + save-semantics conflict), and adds a warning Callout reserving `variant="settings"` for auto-save surfaces.
 
-[DST-1385](https://reservix.atlassian.net/browse/DST-1385)

--- a/.changeset/switch-settings-variant-docs.md
+++ b/.changeset/switch-settings-variant-docs.md
@@ -1,0 +1,9 @@
+---
+'@marigold/docs': patch
+---
+
+docs: document Switch `variant="settings"` and the auto-save rule
+
+Adds a Button-style variant table under `## Appearance` summarising `default` and `settings`, rewrites `Settings and preference` with placement guidance and the reasoning for why switches must live on auto-save surfaces (light-switch metaphor + `role="switch"` ARIA contract + save-semantics conflict), and adds a warning Callout reserving `variant="settings"` for auto-save surfaces.
+
+[DST-1385](https://reservix.atlassian.net/browse/DST-1385)

--- a/docs/content/components/form/switch/index.mdx
+++ b/docs/content/components/form/switch/index.mdx
@@ -27,13 +27,20 @@ The switch is composed of:
 
 <AppearanceTable component={'Switch'} />
 
+The Switch component provides two layout variants for different placement contexts.
+
+| Variant    | Description                             | When to use                                                                                                                                                                 |
+| ---------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`  | Toggle on the left, label on the right. | Inline contexts where the switch sits inside a larger element, such as a card row, list item, or menu. Compact placements where the switch is one of several visual pieces. |
+| `settings` | Label on the left, toggle on the right. | Dedicated settings or preference pages laid out as a vertical list, where users scan labels top-to-bottom and glance right to check or change state.                        |
+
 ## Usage
 
 Switches are for standalone settings where flipping the control applies the change right away. No save button, no form submission. The change is live the moment you toggle.
 
 You'll find them on settings pages, notification preferences, feature toggles, and privacy panels. Each switch should control one independent setting. Toggling one should never affect another.
 
-By default, the toggle sits on the left and the label on the right. This compact layout works well when a switch is embedded inside another element, like a card or a list item, where space is tight and the toggle needs to sit inline with other content. For standalone settings pages where the label is the primary scanning element, use `variant="settings"` instead (see below).
+Use the default variant when the switch is embedded inside another element, such as a card or list item. For standalone settings pages, use `variant="settings"`. See [Settings and preference](#settings-and-preference) below.
 
 <ComponentDemo name="switch-card" />
 
@@ -66,11 +73,23 @@ Add a description when the label alone doesn't explain what toggling actually do
 
 ### Settings and preference
 
-On dedicated settings or preference pages, switches typically appear as a vertical list where the label is the primary scanning element. Placing the label on the left and the toggle on the right works better here because users need to understand what a setting controls before they decide whether to change it. In a vertical list, this creates two stable columns: a readable label column on the left that users scan top to bottom, and a uniform action column on the right they glance at only to check or change state. On mobile, this also places the toggle near the right thumb for easier one-handed reach.
-
-Use `variant="settings"` for this layout. The default variant (toggle on the left) is better suited for compact, inline contexts like cards or list items where the switch is part of a larger element.
+On dedicated settings or preference pages, switches appear as a vertical list where the label is the primary scanning element. Use `variant="settings"` for this layout: the label sits on the left and the toggle on the right.
 
 <ComponentDemo name="switch-settings" />
+
+The label-left layout works because users need to understand what a setting controls before deciding whether to change it. The two-column rhythm gives a readable label column scanned top-to-bottom and a uniform action column glanced at only to check or change state. On mobile, the toggle also lands near the right thumb for easier one-handed reach.
+
+Group switches by topic with a section heading. Each row should control one independent setting; toggling one should never silently affect another.
+
+A switch is built around the light-switch metaphor: flipping it _is_ the change, not a request to make the change. The component renders with `role="switch"`, which screen readers announce as "on" or "off" the moment the user activates it. Both the visual and accessibility contract say the new state is true now.
+
+Putting a switch inside a `<Form>` with a Save button breaks both contracts. The toggle visually flips and the screen reader announces "on", but the underlying state is not actually saved until the user submits. This is why production auto-save settings (iOS Settings, GitHub repo Features, Linear, Vercel, Notion) use switches, while save-bound admin forms (WordPress, Jira, Salesforce) use checkboxes.
+
+<Callout title="Use only on auto-save surfaces" type="warning">
+  Reserve `variant="settings"` for pages that save changes the moment a user
+  toggles. If your settings page batches changes behind a Save button, use
+  [Checkbox](/components/form/checkbox) instead.
+</Callout>
 
 ### Choosing the right control
 


### PR DESCRIPTION
## Summary

- Adds a Button-style variant table under `## Appearance` that summarises `default` (toggle-left, label-right) and `settings` (label-left, toggle-right) with concrete "when to use" guidance for each.
- Tightens the variant intro paragraph in `## Usage` to remove duplication with the new table and link readers down to the detailed section.
- Rewrites `### Settings and preference` with placement rationale (vertical list, label-left scanning, mobile thumb reach), grouping rules, and the reasoning for why switches must live on auto-save surfaces.
- Adds a `<Callout type="warning">` reserving `variant="settings"` for auto-save surfaces and pointing readers to Checkbox for save-bound forms.

Jira: [DST-1385](https://reservix.atlassian.net/browse/DST-1385)

## Why this needs documenting

The Switch docs already assert that switches "take effect right away" with "no save button, no form submission", but they never explain the *reasoning*. Without that reasoning, the rule reads as stylistic preference and is easy to break.

The gap surfaced concretely while reviewing the `settings-form` example (DST-1313): six Switches sat inside a save-bound `<Form>` with a Save button, exactly the anti-pattern the docs should warn against. The example was fixed (Switch → Checkbox conversion in commit `239983447`), but the underlying rule was still under-documented. Without writing it down, anyone could reintroduce the same pattern in a future example or product surface and have no clear basis to push back.

The reasoning has three independent layers, and each one justifies the rule on its own:

1. **Mental model.** A switch is built around the light-switch metaphor. Flipping it *is* the change, not a request to make the change. The visual contract says the new state is true now.
2. **Accessibility.** The component renders with `role="switch"`, which screen readers announce as "on" or "off" the moment the user activates it. AT users hear the new state even more decisively than sighted users see it.
3. **Industry consensus.** Production auto-save settings (iOS Settings, GitHub repo Features, Linear, Vercel, Notion) use switches. Production save-bound admin forms (WordPress, Jira, Salesforce) use checkboxes. The two controls signal different save models.

Putting a switch inside a `<Form>` with a Save button breaks all three: the toggle visually flips and AT announces "on", but the underlying state is not actually saved until the user submits. Both contracts lie until Save is clicked.

The Callout makes this actionable for readers in a hurry; the surrounding prose explains *why* for readers who want to understand the rule before applying it.

## Test plan

- [ ] Run docs locally (`pnpm start`) and navigate to `/components/form/switch`.
- [ ] Variant table renders with two rows under `## Appearance`.
- [ ] `## Usage` intro paragraph points to `Settings and preference`.
- [ ] `### Settings and preference` reads in this order: layout intro → demo → label-left rationale → grouping → metaphor + ARIA + save-semantics paragraphs → warning Callout.
- [ ] Callout link to `[Checkbox](/components/form/checkbox)` resolves correctly.
- [ ] No regression in the existing `### Choosing the right control` section (unchanged but adjacent).
- [ ] `pnpm typecheck:only` and `pnpm lint` clean (no expected impact from .mdx changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1385]: https://reservix.atlassian.net/browse/DST-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ