### PR TITLE
feat([DST-901]): accept number + string scale values in styleProps

### DIFF
--- a/.changeset/dst-901-styleprops-numeric-strings.md
+++ b/.changeset/dst-901-styleprops-numeric-strings.md
@@ -4,10 +4,10 @@
 '@marigold/theme-rui': patch
 ---
 
-feat([DST-901]): styleProps for `width`, `maxWidth`, `height`, `space`, `spaceX`, `spaceY`, `pr`, `pl`, `pt`, `pb` now accept both numeric scale values (`4`) and their string equivalents (`"4"`). The public types are now declarative (`Scale | Fraction | WidthKeyword`, etc.) instead of being derived from internal lookup maps.
+feat([DST-901]): styleProps for `width`, `maxWidth`, `height`, `space`, `spaceX`, `spaceY`, `pr`, `pl`, `pt`, `pb` now accept both numeric scale values (`4`) and their string equivalents (`"4"`). The public types are now declarative (`Scale | Fraction | WidthKeyword`, etc.) instead of being derived from the internal class-name maps.
 
-Components that previously resolved `width`, `maxWidth`, and `height` via class-name lookup (Form, Calendar, legacy Table column header / select-all cell, Slider, Scrollable, Switch, Grid) now resolve them through CSS custom properties (`createWidthVar` / `createHeightVar`) targeting `--width`, `--max-width`, `--height`. These variables are registered as non-inheriting (`@property … inherits: false`) in the RUI theme so they cannot leak into descendants.
+Components that previously resolved `width`, `maxWidth`, and `height` via class-name lookup (Form, Calendar, legacy Table column header / select-all cell, Slider, Scrollable, Switch, Grid) now resolve them through CSS custom properties (`createWidthVar` / `createHeightVar`) targeting `--width`, `--max-width`, `--height`. Those variables — along with `--container-width` and `--field-width` already used by `FieldBase` — are registered as non-inheriting (`@property … inherits: false`) in the RUI theme so they cannot leak into descendants.
 
-`createWidthVar` gained support for the previously missing keywords (`svh`, `lvh`, `dvh`, `px`, `container`), and a new `createHeightVar` helper was added.
+`createWidthVar` gained support for the previously missing keywords (`svh`, `lvh`, `dvh`, `px`, `container`), and a new `createHeightVar` helper was added. Both share a common factory and a base keyword set, so they remain trivially in sync.
 
 **Breaking** (`@marigold/system`): The runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom` are no longer exported. Use the prop types (`WidthProp`, `HeightProp`, …) and the CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) instead. The corresponding TypeScript prop types are unchanged.

--- a/.changeset/dst-901-styleprops-numeric-strings.md
+++ b/.changeset/dst-901-styleprops-numeric-strings.md
@@ -1,0 +1,13 @@
+---
+'@marigold/system': major
+'@marigold/components': minor
+'@marigold/theme-rui': patch
+---
+
+feat([DST-901]): styleProps for `width`, `maxWidth`, `height`, `space`, `spaceX`, `spaceY`, `pr`, `pl`, `pt`, `pb` now accept both numeric scale values (`4`) and their string equivalents (`"4"`). The public types are now declarative (`Scale | Fraction | WidthKeyword`, etc.) instead of being derived from internal lookup maps.
+
+Components that previously resolved `width`, `maxWidth`, and `height` via class-name lookup (Form, Calendar, legacy Table column header / select-all cell, Slider, Scrollable, Switch, Grid) now resolve them through CSS custom properties (`createWidthVar` / `createHeightVar`) targeting `--width`, `--max-width`, `--height`. These variables are registered as non-inheriting (`@property … inherits: false`) in the RUI theme so they cannot leak into descendants.
+
+`createWidthVar` gained support for the previously missing keywords (`svh`, `lvh`, `dvh`, `px`, `container`), and a new `createHeightVar` helper was added.
+
+**Breaking** (`@marigold/system`): The runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom` are no longer exported. Use the prop types (`WidthProp`, `HeightProp`, …) and the CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) instead. The corresponding TypeScript prop types are unchanged.

--- a/docs/content/foundations/form-fields/index.mdx
+++ b/docs/content/foundations/form-fields/index.mdx
@@ -94,6 +94,8 @@ Help Text should be used to provide additional clarification or instructions whe
 
 The width of form fields can be adjusted based on the context and design requirements. Marigold's form components support a `width` prop that allows you to set the width of the field using keywords (`fit`, `full`, `auto`), scales (`32`, `64`, `96`), or fraction values (`1/2`, `2/3`, etc.).
 
+Scale values may be passed either as a number or as the equivalent string — both `width={32}` and `width="32"` are valid and produce the same result. The same applies to spacing-scale props on layout components (`space`, `spaceX`, `spaceY`, `pl`, `pr`, `pt`, `pb`).
+
 When using fixed/keywords widths the `label` and `description` won't be included in the width calculation and won't adapt to the width of the field. The text will not shrink if the field is too small to fit the text.
 
 For fraction values, the field will take up the specified fraction of the width of its parent container. This is particularly useful for creating responsive layouts where fields need to adjust based on the available space.

--- a/docs/ui/Token.tsx
+++ b/docs/ui/Token.tsx
@@ -1,10 +1,50 @@
 'use client';
 
-import { Inline, Stack, alignment, cn, paddingSpace } from '@/ui';
+import { Inline, Stack, alignment, cn } from '@/ui';
 import { Card } from 'fumadocs-ui/components/card';
 import type { ComponentProps } from 'react';
 import { useEffect, useState } from 'react';
 import { Rectangle } from './Rectangle';
+
+// Mirrors the spacing scale exposed by @marigold/system's `Scale` / `ScaleValue`
+// types. Kept as a runtime list here because the docs render a class string
+// per key (`pl-${key}`), which Tailwind needs as static literals.
+const SPACING_SCALE: readonly string[] = [
+  '0',
+  '0.5',
+  '1',
+  '1.5',
+  '2',
+  '2.5',
+  '3',
+  '3.5',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '14',
+  '16',
+  '20',
+  '24',
+  '28',
+  '32',
+  '36',
+  '40',
+  '44',
+  '48',
+  '52',
+  '56',
+  '60',
+  '64',
+  '72',
+  '80',
+  '96',
+];
 
 export const AlignmentsX = () => {
   return (
@@ -153,23 +193,21 @@ export const Spacing = () => {
         </tr>
       </thead>
       <tbody>
-        {Object.keys(paddingSpace)
-          .sort((a, b) => parseFloat(a) - parseFloat(b))
-          .map(key => (
-            <tr key={key}>
-              <td>
-                <code className="before:content-none after:content-none">
-                  {key}
-                </code>
-              </td>
-              <td>{Number(key) * 4}px</td>
-              <td>
-                <div className={cn(`pl-${key}`, 'bg-slate-300')}>
-                  <div className="h-3 bg-white"></div>
-                </div>
-              </td>
-            </tr>
-          ))}
+        {SPACING_SCALE.map(key => (
+          <tr key={key}>
+            <td>
+              <code className="before:content-none after:content-none">
+                {key}
+              </code>
+            </td>
+            <td>{Number(key) * 4}px</td>
+            <td>
+              <div className={cn(`pl-${key}`, 'bg-slate-300')}>
+                <div className="h-3 bg-white"></div>
+              </div>
+            </td>
+          </tr>
+        ))}
       </tbody>
     </table>
   );

--- a/docs/ui/Token.tsx
+++ b/docs/ui/Token.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import { Inline, Stack, alignment, cn } from '@/ui';
+import type { ScaleValue } from '@/ui';
 import { Card } from 'fumadocs-ui/components/card';
 import type { ComponentProps } from 'react';
 import { useEffect, useState } from 'react';
 import { Rectangle } from './Rectangle';
 
-// Mirrors the spacing scale exposed by @marigold/system's `Scale` / `ScaleValue`
-// types. Kept as a runtime list here because the docs render a class string
-// per key (`pl-${key}`), which Tailwind needs as static literals.
-const SPACING_SCALE: readonly string[] = [
+type ScaleString = `${ScaleValue}`;
+
+// Mirrors the spacing scale exposed by @marigold/system's `ScaleValue` type.
+// Kept as a runtime list because the docs render `pl-${key}` per row, which
+// Tailwind needs as a static literal. The `satisfies` clause makes any
+// invalid or mistyped entry a type error; unhandled entries surface as a
+// missing row in the rendered table.
+const SPACING_SCALE = [
   '0',
   '0.5',
   '1',
@@ -44,7 +49,7 @@ const SPACING_SCALE: readonly string[] = [
   '72',
   '80',
   '96',
-];
+] as const satisfies readonly ScaleString[];
 
 export const AlignmentsX = () => {
   return (

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 import type RAC from 'react-aria-components';
 import { Calendar, DateValue } from 'react-aria-components';
-import {
-  WidthProp,
-  cn,
-  width as twWidth,
-  useClassNames,
-} from '@marigold/system';
+import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
 import { CalendarGrid } from './CalendarGrid';
 import { CalendarHeader } from './CalendarHeader';
 import { CalendarListBox } from './CalendarListBox';
@@ -136,10 +131,10 @@ const _Calendar = ({
       >
         <Calendar
           className={cn(
-            'relative flex flex-col',
-            twWidth[width],
+            'relative flex w-(--width) flex-col',
             classNames.calendar
           )}
+          style={createWidthVar('width', `${width}`)}
           {...props}
         >
           <div className={classNames.calendarContainer}>
@@ -171,10 +166,10 @@ const _Calendar = ({
     >
       <Calendar
         className={cn(
-          'relative flex flex-col',
-          twWidth[width],
+          'relative flex w-(--width) flex-col',
           classNames.calendar
         )}
+        style={createWidthVar('width', `${width}`)}
         {...props}
       >
         <div

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -134,7 +134,7 @@ const _Calendar = ({
             'relative flex w-(--width) flex-col',
             classNames.calendar
           )}
-          style={createWidthVar('width', `${width}`)}
+          style={createWidthVar('width', width)}
           {...props}
         >
           <div className={classNames.calendarContainer}>
@@ -169,7 +169,7 @@ const _Calendar = ({
           'relative flex w-(--width) flex-col',
           classNames.calendar
         )}
-        style={createWidthVar('width', `${width}`)}
+        style={createWidthVar('width', width)}
         {...props}
       >
         <div

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -50,7 +50,10 @@ test('applies maxWidth styling', () => {
   );
 
   const form = screen.getByTestId('form');
-  expect(form).toHaveClass('max-w-48');
+  expect(form).toHaveClass('max-w-(--max-width)');
+  expect(form.style.getPropertyValue('--max-width')).toBe(
+    'calc(var(--spacing) * 48)'
+  );
 });
 
 test('applies unstyled prop', () => {

--- a/packages/components/src/Form/Form.test.tsx
+++ b/packages/components/src/Form/Form.test.tsx
@@ -50,7 +50,6 @@ test('applies maxWidth styling', () => {
   );
 
   const form = screen.getByTestId('form');
-  expect(form).toHaveClass('max-w-(--max-width)');
   expect(form.style.getPropertyValue('--max-width')).toBe(
     'calc(var(--spacing) * 48)'
   );

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { Form } from 'react-aria-components';
 import type RAC from 'react-aria-components';
-import { cn, maxWidth as twMaxWidth } from '@marigold/system';
+import { cn, createWidthVar } from '@marigold/system';
 import type { MaxWidthProp } from '@marigold/system';
 
 export interface FormProps extends Omit<RAC.FormProps, 'className' | 'style'> {
@@ -19,7 +19,8 @@ const _Form = forwardRef<HTMLFormElement, FormProps>(
     <Form
       {...props}
       ref={ref}
-      className={cn(twMaxWidth[maxWidth], unstyled && 'contents')}
+      className={cn('max-w-(--max-width)', unstyled && 'contents')}
+      style={createWidthVar('max-width', `${maxWidth}`)}
     />
   )
 );

--- a/packages/components/src/Form/Form.tsx
+++ b/packages/components/src/Form/Form.tsx
@@ -20,7 +20,7 @@ const _Form = forwardRef<HTMLFormElement, FormProps>(
       {...props}
       ref={ref}
       className={cn('max-w-(--max-width)', unstyled && 'contents')}
-      style={createWidthVar('max-width', `${maxWidth}`)}
+      style={createWidthVar('max-width', maxWidth)}
     />
   )
 );

--- a/packages/components/src/Grid/Grid.test.tsx
+++ b/packages/components/src/Grid/Grid.test.tsx
@@ -49,7 +49,6 @@ describe('Grid', () => {
 
       const grid = screen.getByTestId('grid');
 
-      expect(grid).toHaveClass('h-(--height)');
       expect(grid.style.getPropertyValue('--height')).toBe('auto');
     });
 
@@ -58,7 +57,6 @@ describe('Grid', () => {
 
       const grid = screen.getByTestId('grid');
 
-      expect(grid).toHaveClass('h-(--height)');
       expect(grid.style.getPropertyValue('--height')).toBe(
         'calc(var(--spacing) * 96)'
       );

--- a/packages/components/src/Grid/Grid.test.tsx
+++ b/packages/components/src/Grid/Grid.test.tsx
@@ -49,7 +49,8 @@ describe('Grid', () => {
 
       const grid = screen.getByTestId('grid');
 
-      expect(grid).toHaveClass('h-auto');
+      expect(grid).toHaveClass('h-(--height)');
+      expect(grid.style.getPropertyValue('--height')).toBe('auto');
     });
 
     test('applies custom height', () => {
@@ -57,7 +58,10 @@ describe('Grid', () => {
 
       const grid = screen.getByTestId('grid');
 
-      expect(grid).toHaveClass('h-96');
+      expect(grid).toHaveClass('h-(--height)');
+      expect(grid.style.getPropertyValue('--height')).toBe(
+        'calc(var(--spacing) * 96)'
+      );
     });
   });
 

--- a/packages/components/src/Grid/Grid.tsx
+++ b/packages/components/src/Grid/Grid.tsx
@@ -3,8 +3,8 @@ import type { HeightProp, SpaceProp, SpacingTokens } from '@marigold/system';
 import {
   alignment,
   cn,
+  createHeightVar,
   createSpacingVar,
-  height as twHeight,
 } from '@marigold/system';
 import type { AriaRegionProps } from '@marigold/types';
 import { GridArea } from './GridArea';
@@ -80,16 +80,16 @@ export const Grid = ({
   return (
     <div
       className={cn(
-        'grid gap-(--space)',
+        'grid h-(--height) gap-(--space)',
         alignX && alignment?.horizontal?.alignmentX[alignX],
-        alignY && alignment?.horizontal?.alignmentY[alignY],
-        twHeight[height]
+        alignY && alignment?.horizontal?.alignmentY[alignY]
       )}
       style={{
         gridTemplateAreas: parseGridAreas(areas),
         gridTemplateColumns: parseTemplateValue(columns),
         gridTemplateRows: parseTemplateValue(rows),
         ...createSpacingVar('space', `${space}`),
+        ...createHeightVar('height', `${height}`),
       }}
       {...props}
     >

--- a/packages/components/src/Grid/Grid.tsx
+++ b/packages/components/src/Grid/Grid.tsx
@@ -89,7 +89,7 @@ export const Grid = ({
         gridTemplateColumns: parseTemplateValue(columns),
         gridTemplateRows: parseTemplateValue(rows),
         ...createSpacingVar('space', `${space}`),
-        ...createHeightVar('height', `${height}`),
+        ...createHeightVar('height', height),
       }}
       {...props}
     >

--- a/packages/components/src/Scrollable/Scrollable.test.tsx
+++ b/packages/components/src/Scrollable/Scrollable.test.tsx
@@ -22,8 +22,9 @@ test('should have classNames', () => {
   const scroll = screen.getByTestId('scroll');
 
   expect(scroll.className).toMatchInlineSnapshot(
-    `"sticky h-(--height) overflow-auto overscroll-auto w-full"`
+    `"sticky h-(--height) w-(--width) overflow-auto overscroll-auto"`
   );
+  expect(scroll.style.getPropertyValue('--width')).toBe('100%');
   expect(scroll).toBeValid();
 });
 
@@ -35,6 +36,8 @@ test('support width and height prop', () => {
   );
   const scroll = screen.getByTestId('scroll');
   expect(scroll.className).toMatchInlineSnapshot(
-    `"sticky h-(--height) overflow-auto overscroll-auto w-1/2"`
+    `"sticky h-(--height) w-(--width) overflow-auto overscroll-auto"`
   );
+  expect(scroll.style.getPropertyValue('--width')).toBe('calc((1 / 2) * 100%)');
+  expect(scroll.style.getPropertyValue('--height')).toBe('200px');
 });

--- a/packages/components/src/Scrollable/Scrollable.tsx
+++ b/packages/components/src/Scrollable/Scrollable.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import type { WidthProp } from '@marigold/system';
-import { cn, createVar, width as twWidth } from '@marigold/system';
+import { cn, createVar, createWidthVar } from '@marigold/system';
 import type { AriaRegionProps } from '@marigold/types';
 
 export interface ScrollableProps extends AriaRegionProps {
@@ -26,11 +26,13 @@ export const Scrollable = ({
 }: ScrollableProps) => (
   <div
     {...props}
-    className={cn([
-      'sticky h-(--height) overflow-auto overscroll-auto',
-      twWidth[width],
-    ])}
-    style={createVar({ height })}
+    className={cn(
+      'sticky h-(--height) w-(--width) overflow-auto overscroll-auto'
+    )}
+    style={{
+      ...createVar({ height }),
+      ...createWidthVar('width', `${width}`),
+    }}
   >
     {children}
   </div>

--- a/packages/components/src/Scrollable/Scrollable.tsx
+++ b/packages/components/src/Scrollable/Scrollable.tsx
@@ -31,7 +31,7 @@ export const Scrollable = ({
     )}
     style={{
       ...createVar({ height }),
-      ...createWidthVar('width', `${width}`),
+      ...createWidthVar('width', width),
     }}
   >
     {children}

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -7,12 +7,7 @@ import {
   SliderThumb,
   SliderTrack,
 } from 'react-aria-components';
-import {
-  WidthProp,
-  cn,
-  width as twWidth,
-  useClassNames,
-} from '@marigold/system';
+import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
 import { FieldBase, FieldBaseProps } from '../FieldBase/FieldBase';
 import { Label } from '../Label/Label';
 
@@ -83,10 +78,10 @@ const _Slider = forwardRef(
       <FieldBase
         as={Slider}
         className={cn(
-          'grid grid-cols-[auto_1fr] gap-y-1',
-          classNames.container,
-          twWidth[width]
+          'grid w-(--width) grid-cols-[auto_1fr] gap-y-1',
+          classNames.container
         )}
+        style={createWidthVar('width', `${width}`)}
         ref={ref}
         {...props}
       >

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -13,7 +13,10 @@ import { Label } from '../Label/Label';
 
 export interface SliderProps<T>
   extends
-    Omit<RAC.SliderProps<T>, 'children' | 'isDisabled' | 'orientation'>,
+    Omit<
+      RAC.SliderProps<T>,
+      'children' | 'isDisabled' | 'orientation' | 'style'
+    >,
     Pick<FieldBaseProps<'label'>, 'description'> {
   variant?: string;
   size?: string;

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -84,7 +84,7 @@ const _Slider = forwardRef(
           'grid w-(--width) grid-cols-[auto_1fr] gap-y-1',
           classNames.container
         )}
-        style={createWidthVar('width', `${width}`)}
+        style={createWidthVar('width', width)}
         ref={ref}
         {...props}
       >

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -28,7 +28,7 @@ test('supports base styling', () => {
     `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
   expect(container.className).toMatchInlineSnapshot(
-    `"w-full group/switch flex items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
+    `"group/switch flex w-(--width) items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
   );
   expect(track.className).toMatchInlineSnapshot(`"relative"`);
   expect(thumb.className).toMatchInlineSnapshot(
@@ -41,7 +41,7 @@ test('takes full width by default', () => {
 
   const { container } = getSwitchParts();
   expect(container.className).toMatchInlineSnapshot(
-    `"w-full group/switch flex items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
+    `"group/switch flex w-(--width) items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
   );
 });
 

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -1,12 +1,7 @@
 import { ReactNode, forwardRef } from 'react';
 import type RAC from 'react-aria-components';
 import { Switch } from 'react-aria-components';
-import {
-  WidthProp,
-  cn,
-  width as twWidth,
-  useClassNames,
-} from '@marigold/system';
+import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
 import { Label } from '../Label/Label';
 
 type RemovedProps =
@@ -78,11 +73,10 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
         {...props}
         ref={ref}
         className={cn(
-          twWidth[width],
-          'group/switch',
-          'flex items-center gap-[1ch]',
+          'group/switch flex w-(--width) items-center gap-[1ch]',
           classNames.container
         )}
+        style={createWidthVar('width', `${width}`)}
       >
         {label && <Label elementType="span">{label}</Label>}
         <div className="relative">

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -76,7 +76,7 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
           'group/switch flex w-(--width) items-center gap-[1ch]',
           classNames.container
         )}
-        style={createWidthVar('width', `${width}`)}
+        style={createWidthVar('width', width)}
       >
         {label && <Label elementType="span">{label}</Label>}
         <div className="relative">

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -7,10 +7,10 @@ import { Label } from '../Label/Label';
 type RemovedProps =
   | 'children'
   | 'className'
+  | 'style'
   | 'isDisabled'
   | 'isReadOnly'
   | 'isSelected'
-  | 'children'
   | 'slot';
 
 export interface SwitchProps extends Omit<RAC.SwitchProps, RemovedProps> {

--- a/packages/components/src/legacy/Table/TableColumnHeader.tsx
+++ b/packages/components/src/legacy/Table/TableColumnHeader.tsx
@@ -4,7 +4,7 @@ import { useHover } from '@react-aria/interactions';
 import { useTableColumnHeader } from '@react-aria/table';
 import { mergeProps } from '@react-aria/utils';
 import { GridNode } from '@react-types/grid';
-import { cn, width as twWidth, useStateProps } from '@marigold/system';
+import { cn, createWidthVar, useStateProps } from '@marigold/system';
 import { SortDown } from '../../icons/SortDown';
 import { SortUp } from '../../icons/SortUp';
 import { useTableContext } from './Context';
@@ -44,10 +44,10 @@ export const TableColumnHeader = ({
       colSpan={column.colspan}
       ref={ref}
       className={cn(
-        'whitespace-nowrap data-[react-aria-pressable="true"]:cursor-pointer',
-        twWidth[width],
+        'w-(--width) whitespace-nowrap data-[react-aria-pressable="true"]:cursor-pointer',
         classNames?.header
       )}
+      style={createWidthVar('width', `${width}`)}
       {...mergeProps(columnHeaderProps, hoverProps, focusProps)}
       {...stateProps}
       align={align}

--- a/packages/components/src/legacy/Table/TableColumnHeader.tsx
+++ b/packages/components/src/legacy/Table/TableColumnHeader.tsx
@@ -47,7 +47,7 @@ export const TableColumnHeader = ({
         'w-(--width) whitespace-nowrap data-[react-aria-pressable="true"]:cursor-pointer',
         classNames?.header
       )}
-      style={createWidthVar('width', `${width}`)}
+      style={createWidthVar('width', width)}
       {...mergeProps(columnHeaderProps, hoverProps, focusProps)}
       {...stateProps}
       align={align}

--- a/packages/components/src/legacy/Table/TableSelectAllCell.tsx
+++ b/packages/components/src/legacy/Table/TableSelectAllCell.tsx
@@ -7,12 +7,7 @@ import {
 } from '@react-aria/table';
 import { mergeProps } from '@react-aria/utils';
 import { GridNode } from '@react-types/grid';
-import {
-  WidthProp,
-  cn,
-  width as twWidth,
-  useStateProps,
-} from '@marigold/system';
+import { WidthProp, cn, createWidthVar, useStateProps } from '@marigold/system';
 import { Checkbox } from '../../Checkbox/Checkbox';
 import { useTableContext } from './Context';
 import { mapCheckboxProps } from './utils';
@@ -53,7 +48,8 @@ export const TableSelectAllCell = ({
   return (
     <th
       ref={ref}
-      className={cn(twWidth[width], ['leading-none'], classNames?.header)}
+      className={cn('w-(--width) leading-none', classNames?.header)}
+      style={createWidthVar('width', `${width}`)}
       {...mergeProps(columnHeaderProps, hoverProps, focusProps)}
       {...stateProps}
       align={align}

--- a/packages/components/src/legacy/Table/TableSelectAllCell.tsx
+++ b/packages/components/src/legacy/Table/TableSelectAllCell.tsx
@@ -49,7 +49,7 @@ export const TableSelectAllCell = ({
     <th
       ref={ref}
       className={cn('w-(--width) leading-none', classNames?.header)}
-      style={createWidthVar('width', `${width}`)}
+      style={createWidthVar('width', width)}
       {...mergeProps(columnHeaderProps, hoverProps, focusProps)}
       {...stateProps}
       align={align}

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -47,23 +47,12 @@ export { defaultTheme } from './defaultTheme';
 
 // Style Props - only export what exists
 export {
-  width,
-  maxWidth,
-  height,
   fontWeight,
   textSize,
   textStyle,
   textWrap,
   whiteSpace,
   lineHeight,
-  gapSpace,
-  paddingSpace,
-  paddingSpaceX,
-  paddingSpaceY,
-  paddingRight,
-  paddingLeft,
-  paddingTop,
-  paddingBottom,
   alignment,
   placeItems,
   textAlign,
@@ -94,8 +83,11 @@ export type {
   VerticalAlignProp,
   SpaceProp,
   WidthProp,
+  WidthValue,
   MaxWidthProp,
+  MaxWidthValue,
   HeightProp,
+  HeightValue,
 } from './style-props';
 
 // Utils
@@ -106,6 +98,7 @@ export {
   createVar,
   createSpacingVar,
   createWidthVar,
+  createHeightVar,
   ensureCssVar,
   isFraction,
   isScale,

--- a/packages/system/src/style-props.tsx
+++ b/packages/system/src/style-props.tsx
@@ -1,8 +1,5 @@
 import type { Scale } from './utils/css-variables.utils';
 
-/**
- * Fraction-based dimension values supported by `width`, `maxWidth`, and `height`.
- */
 type Fraction =
   | '1/2'
   | '1/3'
@@ -30,9 +27,6 @@ type Fraction =
   | '10/12'
   | '11/12';
 
-/**
- * Keywords shared by `width`, `maxWidth`, and `height`.
- */
 type DimensionKeyword =
   | 'auto'
   | 'full'
@@ -46,27 +40,22 @@ type DimensionKeyword =
   | 'px';
 
 type WidthKeyword = DimensionKeyword | 'container';
-type MaxWidthKeyword = DimensionKeyword | 'container';
-type HeightKeyword = DimensionKeyword;
 
 /**
- * Allowed values for the `width` style prop.
- *
- * Accepts the spacing scale (both numeric `4` and string `"4"`), fractional
- * widths (`"1/2"`, `"3/4"`, ...), and keyword sizes (`"full"`, `"fit"`, ...).
+ * Allowed values for the `width` style prop. Accepts the spacing scale (as
+ * either `4` or `"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`,
+ * ...).
  */
 export type WidthValue = Scale | Fraction | WidthKeyword;
 
-/**
- * Allowed values for the `maxWidth` style prop. See {@link WidthValue}.
- */
-export type MaxWidthValue = Scale | Fraction | MaxWidthKeyword;
+/** Allowed values for the `maxWidth` style prop. See {@link WidthValue}. */
+export type MaxWidthValue = Scale | Fraction | WidthKeyword;
 
 /**
  * Allowed values for the `height` style prop. Like {@link WidthValue} but
  * without the `"container"` keyword.
  */
-export type HeightValue = Scale | Fraction | HeightKeyword;
+export type HeightValue = Scale | Fraction | DimensionKeyword;
 
 export const fontWeight = {
   thin: 'font-thin',

--- a/packages/system/src/style-props.tsx
+++ b/packages/system/src/style-props.tsx
@@ -1,222 +1,72 @@
 import type { Scale } from './utils/css-variables.utils';
 
-export const width = {
-  auto: 'w-auto',
-  full: 'w-full',
-  fit: 'w-fit',
-  min: 'w-min',
-  max: 'w-max',
-  screen: 'w-screen',
-  svh: 'w-svh',
-  lvh: 'w-lvh',
-  dvh: 'w-dvh',
-  px: 'w-px',
-  0: 'w-0',
-  '0.5': 'w-0.5',
-  1: 'w-1',
-  '1.5': 'w-1.5',
-  2: 'w-2',
-  '2.5': 'w-2.5',
-  3: 'w-3',
-  '3.5': 'w-3.5',
-  4: 'w-4',
-  5: 'w-5',
-  6: 'w-6',
-  7: 'w-7',
-  8: 'w-8',
-  9: 'w-9',
-  10: 'w-10',
-  11: 'w-11',
-  12: 'w-12',
-  14: 'w-14',
-  16: 'w-16',
-  20: 'w-20',
-  24: 'w-24',
-  28: 'w-28',
-  32: 'w-32',
-  36: 'w-36',
-  40: 'w-40',
-  44: 'w-44',
-  48: 'w-48',
-  52: 'w-52',
-  56: 'w-56',
-  60: 'w-60',
-  64: 'w-64',
-  72: 'w-72',
-  80: 'w-80',
-  96: 'w-96',
-  '1/2': 'w-1/2',
-  '1/3': 'w-1/3',
-  '2/3': 'w-2/3',
-  '1/4': 'w-1/4',
-  '2/4': 'w-2/4',
-  '3/4': 'w-3/4',
-  '1/5': 'w-1/5',
-  '2/5': 'w-2/5',
-  '3/5': 'w-3/5',
-  '1/6': 'w-1/6',
-  '2/6': 'w-2/6',
-  '3/6': 'w-3/6',
-  '4/6': 'w-4/6',
-  '5/6': 'w-5/6',
-  '1/12': 'w-1/12',
-  '2/12': 'w-2/12',
-  '3/12': 'w-3/12',
-  '4/12': 'w-4/12',
-  '5/12': 'w-5/12',
-  '6/12': 'w-6/12',
-  '7/12': 'w-7/12',
-  '8/12': 'w-8/12',
-  '9/12': 'w-9/12',
-  '10/12': 'w-10/12',
-  '11/12': 'w-11/12',
-  container: 'var(--spacing-container)',
-} as const;
+/**
+ * Fraction-based dimension values supported by `width`, `maxWidth`, and `height`.
+ */
+type Fraction =
+  | '1/2'
+  | '1/3'
+  | '2/3'
+  | '1/4'
+  | '2/4'
+  | '3/4'
+  | '1/5'
+  | '2/5'
+  | '3/5'
+  | '1/6'
+  | '2/6'
+  | '3/6'
+  | '4/6'
+  | '5/6'
+  | '1/12'
+  | '2/12'
+  | '3/12'
+  | '4/12'
+  | '5/12'
+  | '6/12'
+  | '7/12'
+  | '8/12'
+  | '9/12'
+  | '10/12'
+  | '11/12';
 
-export const maxWidth = {
-  auto: 'max-w-auto',
-  full: 'max-w-full',
-  fit: 'max-w-fit',
-  min: 'max-w-min',
-  max: 'max-w-max',
-  screen: 'max-w-screen',
-  svh: 'max-w-svh',
-  lvh: 'max-w-lvh',
-  dvh: 'max-w-dvh',
-  px: 'max-w-px',
-  0: 'max-w-0',
-  '0.5': 'max-w-0.5',
-  1: 'max-w-1',
-  '1.5': 'max-w-1.5',
-  2: 'max-w-2',
-  '2.5': 'max-w-2.5',
-  3: 'max-w-3',
-  '3.5': 'max-w-3.5',
-  4: 'max-w-4',
-  5: 'max-w-5',
-  6: 'max-w-6',
-  7: 'max-w-7',
-  8: 'max-w-8',
-  9: 'max-w-9',
-  10: 'max-w-10',
-  11: 'max-w-11',
-  12: 'max-w-12',
-  14: 'max-w-14',
-  16: 'max-w-16',
-  20: 'max-w-20',
-  24: 'max-w-24',
-  28: 'max-w-28',
-  32: 'max-w-32',
-  36: 'max-w-36',
-  40: 'max-w-40',
-  44: 'max-w-44',
-  48: 'max-w-48',
-  52: 'max-w-52',
-  56: 'max-w-56',
-  60: 'max-w-60',
-  64: 'max-w-64',
-  72: 'max-w-72',
-  80: 'max-w-80',
-  96: 'max-w-96',
-  '1/2': 'max-w-1/2',
-  '1/3': 'max-w-1/3',
-  '2/3': 'max-w-2/3',
-  '1/4': 'max-w-1/4',
-  '2/4': 'max-w-2/4',
-  '3/4': 'max-w-3/4',
-  '1/5': 'max-w-1/5',
-  '2/5': 'max-w-2/5',
-  '3/5': 'max-w-3/5',
-  '1/6': 'max-w-1/6',
-  '2/6': 'max-w-2/6',
-  '3/6': 'max-w-3/6',
-  '4/6': 'max-w-4/6',
-  '5/6': 'max-w-5/6',
-  '1/12': 'max-w-1/12',
-  '2/12': 'max-w-2/12',
-  '3/12': 'max-w-3/12',
-  '4/12': 'max-w-4/12',
-  '5/12': 'max-w-5/12',
-  '6/12': 'max-w-6/12',
-  '7/12': 'max-w-7/12',
-  '8/12': 'max-w-8/12',
-  '9/12': 'max-w-9/12',
-  '10/12': 'max-w-10/12',
-  '11/12': 'max-w-11/12',
-  container: 'max-w-[var(--spacing-container)]',
-} as const;
+/**
+ * Keywords shared by `width`, `maxWidth`, and `height`.
+ */
+type DimensionKeyword =
+  | 'auto'
+  | 'full'
+  | 'fit'
+  | 'min'
+  | 'max'
+  | 'screen'
+  | 'svh'
+  | 'lvh'
+  | 'dvh'
+  | 'px';
 
-export const height = {
-  auto: 'h-auto',
-  full: 'h-full',
-  fit: 'h-fit',
-  min: 'h-min',
-  max: 'h-max',
-  screen: 'h-screen',
-  svh: 'h-svh',
-  lvh: 'h-lvh',
-  dvh: 'h-dvh',
-  px: 'h-px',
-  0: 'h-0',
-  '0.5': 'h-0.5',
-  1: 'h-1',
-  '1.5': 'h-1.5',
-  2: 'h-2',
-  '2.5': 'h-2.5',
-  3: 'h-3',
-  '3.5': 'h-3.5',
-  4: 'h-4',
-  5: 'h-5',
-  6: 'h-6',
-  7: 'h-7',
-  8: 'h-8',
-  9: 'h-9',
-  10: 'h-10',
-  11: 'h-11',
-  12: 'h-12',
-  14: 'h-14',
-  16: 'h-16',
-  20: 'h-20',
-  24: 'h-24',
-  28: 'h-28',
-  32: 'h-32',
-  36: 'h-36',
-  40: 'h-40',
-  44: 'h-44',
-  48: 'h-48',
-  52: 'h-52',
-  56: 'h-56',
-  60: 'h-60',
-  64: 'h-64',
-  72: 'h-72',
-  80: 'h-80',
-  96: 'h-96',
-  '1/2': 'h-1/2',
-  '1/3': 'h-1/3',
-  '2/3': 'h-2/3',
-  '1/4': 'h-1/4',
-  '2/4': 'h-2/4',
-  '3/4': 'h-3/4',
-  '1/5': 'h-1/5',
-  '2/5': 'h-2/5',
-  '3/5': 'h-3/5',
-  '1/6': 'h-1/6',
-  '2/6': 'h-2/6',
-  '3/6': 'h-3/6',
-  '4/6': 'h-4/6',
-  '5/6': 'h-5/6',
-  '1/12': 'h-1/12',
-  '2/12': 'h-2/12',
-  '3/12': 'h-3/12',
-  '4/12': 'h-4/12',
-  '5/12': 'h-5/12',
-  '6/12': 'h-6/12',
-  '7/12': 'h-7/12',
-  '8/12': 'h-8/12',
-  '9/12': 'h-9/12',
-  '10/12': 'h-10/12',
-  '11/12': 'h-11/12',
-} as const;
+type WidthKeyword = DimensionKeyword | 'container';
+type MaxWidthKeyword = DimensionKeyword | 'container';
+type HeightKeyword = DimensionKeyword;
+
+/**
+ * Allowed values for the `width` style prop.
+ *
+ * Accepts the spacing scale (both numeric `4` and string `"4"`), fractional
+ * widths (`"1/2"`, `"3/4"`, ...), and keyword sizes (`"full"`, `"fit"`, ...).
+ */
+export type WidthValue = Scale | Fraction | WidthKeyword;
+
+/**
+ * Allowed values for the `maxWidth` style prop. See {@link WidthValue}.
+ */
+export type MaxWidthValue = Scale | Fraction | MaxWidthKeyword;
+
+/**
+ * Allowed values for the `height` style prop. Like {@link WidthValue} but
+ * without the `"container"` keyword.
+ */
+export type HeightValue = Scale | Fraction | HeightKeyword;
 
 export const fontWeight = {
   thin: 'font-thin',
@@ -274,302 +124,6 @@ export const lineHeight = {
   normal: 'leading-normal',
   relaxed: 'leading-relaxed',
   loose: 'leading-loose',
-} as const;
-
-export const gapSpace = {
-  0: 'gap-0',
-  '0.5': 'gap-0.5',
-  1: 'gap-1',
-  '1.5': 'gap-1.5',
-  2: 'gap-2',
-  '2.5': 'gap-2.5',
-  3: 'gap-3',
-  '3.5': 'gap-3.5',
-  4: 'gap-4',
-  5: 'gap-5',
-  6: 'gap-6',
-  7: 'gap-7',
-  8: 'gap-8',
-  9: 'gap-9',
-  10: 'gap-10',
-  11: 'gap-11',
-  12: 'gap-12',
-  14: 'gap-14',
-  16: 'gap-16',
-  20: 'gap-20',
-  24: 'gap-24',
-  28: 'gap-28',
-  32: 'gap-32',
-  36: 'gap-36',
-  40: 'gap-40',
-  44: 'gap-44',
-  48: 'gap-48',
-  52: 'gap-52',
-  56: 'gap-56',
-  60: 'gap-60',
-  64: 'gap-64',
-  72: 'gap-72',
-  80: 'gap-80',
-  96: 'gap-96',
-} as const;
-
-export const paddingSpace = {
-  0: 'p-0',
-  '0.5': 'p-0.5',
-  1: 'p-1',
-  '1.5': 'p-1.5',
-  2: 'p-2',
-  '2.5': 'p-2.5',
-  3: 'p-3',
-  '3.5': 'p-3.5',
-  4: 'p-4',
-  5: 'p-5',
-  6: 'p-6',
-  7: 'p-7',
-  8: 'p-8',
-  9: 'p-9',
-  10: 'p-10',
-  11: 'p-11',
-  12: 'p-12',
-  14: 'p-14',
-  16: 'p-16',
-  20: 'p-20',
-  24: 'p-24',
-  28: 'p-28',
-  32: 'p-32',
-  36: 'p-36',
-  40: 'p-40',
-  44: 'p-44',
-  48: 'p-48',
-  52: 'p-52',
-  56: 'p-56',
-  60: 'p-60',
-  64: 'p-64',
-  72: 'p-72',
-  80: 'p-80',
-  96: 'p-96',
-} as const;
-
-export const paddingSpaceX = {
-  0: 'px-0',
-  '0.5': 'px-0.5',
-  1: 'px-1',
-  '1.5': 'px-1.5',
-  2: 'px-2',
-  '2.5': 'px-2.5',
-  3: 'px-3',
-  '3.5': 'px-3.5',
-  4: 'px-4',
-  5: 'px-5',
-  6: 'px-6',
-  7: 'px-7',
-  8: 'px-8',
-  9: 'px-9',
-  10: 'px-10',
-  11: 'px-11',
-  12: 'px-12',
-  14: 'px-14',
-  16: 'px-16',
-  20: 'px-20',
-  24: 'px-24',
-  28: 'px-28',
-  32: 'px-32',
-  36: 'px-36',
-  40: 'px-40',
-  44: 'px-44',
-  48: 'px-48',
-  52: 'px-52',
-  56: 'px-56',
-  60: 'px-60',
-  64: 'px-64',
-  72: 'px-72',
-  80: 'px-80',
-  96: 'px-96',
-} as const;
-
-export const paddingSpaceY = {
-  0: 'py-0',
-  '0.5': 'py-0.5',
-  1: 'py-1',
-  '1.5': 'py-1.5',
-  2: 'py-2',
-  '2.5': 'py-2.5',
-  3: 'py-3',
-  '3.5': 'py-3.5',
-  4: 'py-4',
-  5: 'py-5',
-  6: 'py-6',
-  7: 'py-7',
-  8: 'py-8',
-  9: 'py-9',
-  10: 'py-10',
-  11: 'py-11',
-  12: 'py-12',
-  14: 'py-14',
-  16: 'py-16',
-  20: 'py-20',
-  24: 'py-24',
-  28: 'py-28',
-  32: 'py-32',
-  36: 'py-36',
-  40: 'py-40',
-  44: 'py-44',
-  48: 'py-48',
-  52: 'py-52',
-  56: 'py-56',
-  60: 'py-60',
-  64: 'py-64',
-  72: 'py-72',
-  80: 'py-80',
-  96: 'py-96',
-} as const;
-
-export const paddingRight = {
-  0: 'pr-0',
-  '0.5': 'pr-0.5',
-  1: 'pr-1',
-  '1.5': 'pr-1.5',
-  2: 'pr-2',
-  '2.5': 'pr-2.5',
-  3: 'pr-3',
-  '3.5': 'pr-3.5',
-  4: 'pr-4',
-  5: 'pr-5',
-  6: 'pr-6',
-  7: 'pr-7',
-  8: 'pr-8',
-  9: 'pr-9',
-  10: 'pr-10',
-  11: 'pr-11',
-  12: 'pr-12',
-  14: 'pr-14',
-  16: 'pr-16',
-  20: 'pr-20',
-  24: 'pr-24',
-  28: 'pr-28',
-  32: 'pr-32',
-  36: 'pr-36',
-  40: 'pr-40',
-  44: 'pr-44',
-  48: 'pr-48',
-  52: 'pr-52',
-  56: 'pr-56',
-  60: 'pr-60',
-  64: 'pr-64',
-  72: 'pr-72',
-  80: 'pr-80',
-  96: 'pr-96',
-} as const;
-
-export const paddingLeft = {
-  0: 'pl-0',
-  '0.5': 'pl-0.5',
-  1: 'pl-1',
-  '1.5': 'pl-1.5',
-  2: 'pl-2',
-  '2.5': 'pl-2.5',
-  3: 'pl-3',
-  '3.5': 'pl-3.5',
-  4: 'pl-4',
-  5: 'pl-5',
-  6: 'pl-6',
-  7: 'pl-7',
-  8: 'pl-8',
-  9: 'pl-9',
-  10: 'pl-10',
-  11: 'pl-11',
-  12: 'pl-12',
-  14: 'pl-14',
-  16: 'pl-16',
-  20: 'pl-20',
-  24: 'pl-24',
-  28: 'pl-28',
-  32: 'pl-32',
-  36: 'pl-36',
-  40: 'pl-40',
-  44: 'pl-44',
-  48: 'pl-48',
-  52: 'pl-52',
-  56: 'pl-56',
-  60: 'pl-60',
-  64: 'pl-64',
-  72: 'pl-72',
-  80: 'pl-80',
-  96: 'pl-96',
-} as const;
-
-export const paddingTop = {
-  0: 'pt-0',
-  '0.5': 'pt-0.5',
-  1: 'pt-1',
-  '1.5': 'pt-1.5',
-  2: 'pt-2',
-  '2.5': 'pt-2.5',
-  3: 'pt-3',
-  '3.5': 'pt-3.5',
-  4: 'pt-4',
-  5: 'pt-5',
-  6: 'pt-6',
-  7: 'pt-7',
-  8: 'pt-8',
-  9: 'pt-9',
-  10: 'pt-10',
-  11: 'pt-11',
-  12: 'pt-12',
-  14: 'pt-14',
-  16: 'pt-16',
-  20: 'pt-20',
-  24: 'pt-24',
-  28: 'pt-28',
-  32: 'pt-32',
-  36: 'pt-36',
-  40: 'pt-40',
-  44: 'pt-44',
-  48: 'pt-48',
-  52: 'pt-52',
-  56: 'pt-56',
-  60: 'pt-60',
-  64: 'pt-64',
-  72: 'pt-72',
-  80: 'pt-80',
-  96: 'pt-96',
-} as const;
-
-export const paddingBottom = {
-  0: 'pb-0',
-  '0.5': 'pb-0.5',
-  1: 'pb-1',
-  '1.5': 'pb-1.5',
-  2: 'pb-2',
-  '2.5': 'pb-2.5',
-  3: 'pb-3',
-  '3.5': 'pb-3.5',
-  4: 'pb-4',
-  5: 'pb-5',
-  6: 'pb-6',
-  7: 'pb-7',
-  8: 'pb-8',
-  9: 'pb-9',
-  10: 'pb-10',
-  11: 'pb-11',
-  12: 'pb-12',
-  14: 'pb-14',
-  16: 'pb-16',
-  20: 'pb-20',
-  24: 'pb-24',
-  28: 'pb-28',
-  32: 'pb-32',
-  36: 'pb-36',
-  40: 'pb-40',
-  44: 'pb-44',
-  48: 'pb-48',
-  52: 'pb-52',
-  56: 'pb-56',
-  60: 'pb-60',
-  64: 'pb-64',
-  72: 'pb-72',
-  80: 'pb-80',
-  96: 'pb-96',
 } as const;
 
 export const alignment = {
@@ -728,57 +282,81 @@ export type FontSizeProp = {
 export type GapSpaceProp = {
   /**
    * The space between the children. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  space?: keyof typeof gapSpace;
+  space?: Scale;
 };
 
 export type PaddingSpaceProp = {
   /**
    * Set the padding space for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  space?: keyof typeof paddingSpace;
+  space?: Scale;
 };
 
 export type PaddingSpacePropX = {
   /**
    * Set the horizontal padding space for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  spaceX?: keyof typeof paddingSpaceX;
+  spaceX?: Scale;
 };
 
 export type PaddingSpacePropY = {
   /**
    * Set the vertical padding space for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  spaceY?: keyof typeof paddingSpaceY;
+  spaceY?: Scale;
 };
 
 export type PaddingRightProp = {
   /**
    * Set the right padding for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  pr?: keyof typeof paddingRight;
+  pr?: Scale;
 };
 
 export type PaddingLeftProp = {
   /**
    * Set the left padding for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  pl?: keyof typeof paddingLeft;
+  pl?: Scale;
 };
 
 export type PaddingTopProp = {
   /**
    * Set the top padding for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  pt?: keyof typeof paddingTop;
+  pt?: Scale;
 };
 
 export type PaddingBottomProp = {
   /**
    * Set the bottom padding for the element. You can see allowed tokens [here](../../foundations/design-tokens?theme=core#spacing).
+   *
+   * Accepts a value from the spacing scale either as a number (`4`) or as its
+   * string equivalent (`"4"`).
    */
-  pb?: keyof typeof paddingBottom;
+  pb?: Scale;
 };
 
 export type PlaceItemsProp = {
@@ -805,22 +383,31 @@ export type VerticalAlignProp = {
 export type WidthProp = {
   /**
    * Sets the width of the element. You can see allowed tokens [here](https://tailwindcss.com/docs/width).
+   *
+   * Accepts spacing-scale values as either numbers (`4`) or their string
+   * equivalents (`"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`, ...).
    */
-  width?: keyof typeof width;
+  width?: WidthValue;
 };
 
 export type MaxWidthProp = {
   /**
    * Sets the max-width of the element. You can see allowed tokens [here](https://tailwindcss.com/docs/max-width).
+   *
+   * Accepts spacing-scale values as either numbers (`4`) or their string
+   * equivalents (`"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`, ...).
    */
-  maxWidth?: keyof typeof maxWidth;
+  maxWidth?: MaxWidthValue;
 };
 
 export type HeightProp = {
   /**
    * Set the height of the element. You can see allowed tokens [here](https://tailwindcss.com/docs/height).
+   *
+   * Accepts spacing-scale values as either numbers (`4`) or their string
+   * equivalents (`"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`, ...).
    */
-  height?: keyof typeof height;
+  height?: HeightValue;
 };
 
 /**

--- a/packages/system/src/style-props.tsx
+++ b/packages/system/src/style-props.tsx
@@ -42,14 +42,14 @@ type DimensionKeyword =
 type WidthKeyword = DimensionKeyword | 'container';
 
 /**
- * Allowed values for the `width` style prop. Accepts the spacing scale (as
- * either `4` or `"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`,
- * ...).
+ * Allowed values for the `width` and `maxWidth` style props. Accepts the
+ * spacing scale (as either `4` or `"4"`), fractions (`"1/2"`), and keywords
+ * (`"full"`, `"fit"`, ...).
  */
 export type WidthValue = Scale | Fraction | WidthKeyword;
 
-/** Allowed values for the `maxWidth` style prop. See {@link WidthValue}. */
-export type MaxWidthValue = Scale | Fraction | WidthKeyword;
+/** Alias of {@link WidthValue}. */
+export type MaxWidthValue = WidthValue;
 
 /**
  * Allowed values for the `height` style prop. Like {@link WidthValue} but

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -193,7 +193,7 @@ describe('createWidthVar', () => {
     'should throw an error for unsupported value "%s"',
     value => {
       expect(() => createWidthVar('width', value)).toThrowError(
-        `Unsupported width value: "${value}". Expected a keyword (fit, min, max, full, screen, auto, svh, lvh, dvh, px, container), a scale number, or a fraction (e.g., "1/2").`
+        `Unsupported width value: "${value}". Expected a keyword (fit, min, max, full, auto, svh, lvh, dvh, px, screen, container), a scale number, or a fraction (e.g., "1/2").`
       );
     }
   );
@@ -228,7 +228,7 @@ describe('createHeightVar', () => {
     'should throw an error for unsupported value "%s"',
     value => {
       expect(() => createHeightVar('height', value)).toThrowError(
-        `Unsupported height value: "${value}". Expected a keyword (fit, min, max, full, screen, auto, svh, lvh, dvh, px), a scale number, or a fraction (e.g., "1/2").`
+        `Unsupported height value: "${value}". Expected a keyword (fit, min, max, full, auto, svh, lvh, dvh, px, screen), a scale number, or a fraction (e.g., "1/2").`
       );
     }
   );

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createHeightVar,
   createSpacingVar,
   createVar,
   createWidthVar,
@@ -173,6 +174,11 @@ describe('createWidthVar', () => {
     ['full', { '--width': '100%' }],
     ['screen', { '--width': '100vw' }],
     ['auto', { '--width': 'auto' }],
+    ['svh', { '--width': '100svh' }],
+    ['lvh', { '--width': '100lvh' }],
+    ['dvh', { '--width': '100dvh' }],
+    ['px', { '--width': '1px' }],
+    ['container', { '--width': 'var(--spacing-container)' }],
   ])('should resolve width value "%s"', (value, expected) => {
     expect(createWidthVar('width', value)).toEqual(expected);
   });
@@ -183,11 +189,46 @@ describe('createWidthVar', () => {
     });
   });
 
-  it.each(['invalid', 'px', '10px'])(
+  it.each(['invalid', '10px', '1/2/3'])(
     'should throw an error for unsupported value "%s"',
     value => {
       expect(() => createWidthVar('width', value)).toThrowError(
-        `Unsupported width value: "${value}". Expected a keyword (fit, min, max, full, screen, auto), a scale number, or a fraction (e.g., "1/2").`
+        `Unsupported width value: "${value}". Expected a keyword (fit, min, max, full, screen, auto, svh, lvh, dvh, px, container), a scale number, or a fraction (e.g., "1/2").`
+      );
+    }
+  );
+});
+
+describe('createHeightVar', () => {
+  it.each([
+    ['4', { '--height': 'calc(var(--spacing) * 4)' }],
+    ['2.5', { '--height': 'calc(var(--spacing) * 2.5)' }],
+    ['1/2', { '--height': 'calc((1 / 2) * 100%)' }],
+    ['fit', { '--height': 'fit-content' }],
+    ['min', { '--height': 'min-content' }],
+    ['max', { '--height': 'max-content' }],
+    ['full', { '--height': '100%' }],
+    ['screen', { '--height': '100vh' }],
+    ['auto', { '--height': 'auto' }],
+    ['svh', { '--height': '100svh' }],
+    ['lvh', { '--height': '100lvh' }],
+    ['dvh', { '--height': '100dvh' }],
+    ['px', { '--height': '1px' }],
+  ])('should resolve height value "%s"', (value, expected) => {
+    expect(createHeightVar('height', value)).toEqual(expected);
+  });
+
+  it('should not support the "container" keyword', () => {
+    expect(() => createHeightVar('height', 'container')).toThrowError(
+      /Unsupported height value: "container"/
+    );
+  });
+
+  it.each(['invalid', '10px', '1/2/3'])(
+    'should throw an error for unsupported value "%s"',
+    value => {
+      expect(() => createHeightVar('height', value)).toThrowError(
+        `Unsupported height value: "${value}". Expected a keyword (fit, min, max, full, screen, auto, svh, lvh, dvh, px), a scale number, or a fraction (e.g., "1/2").`
       );
     }
   );

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -197,6 +197,15 @@ describe('createWidthVar', () => {
       );
     }
   );
+
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'should not resolve inherited Object property "%s" as a keyword',
+    value => {
+      expect(() => createWidthVar('width', value)).toThrowError(
+        /Unsupported width value/
+      );
+    }
+  );
 });
 
 describe('createHeightVar', () => {
@@ -229,6 +238,15 @@ describe('createHeightVar', () => {
     value => {
       expect(() => createHeightVar('height', value)).toThrowError(
         `Unsupported height value: "${value}". Expected a keyword (fit, min, max, full, auto, svh, lvh, dvh, px, screen), a scale number, or a fraction (e.g., "1/2").`
+      );
+    }
+  );
+
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'should not resolve inherited Object property "%s" as a keyword',
+    value => {
+      expect(() => createHeightVar('height', value)).toThrowError(
+        /Unsupported height value/
       );
     }
   );

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -99,83 +99,57 @@ export const createSpacingVar = (name: string, value: string) => {
   } as CSSProperties;
 };
 
-const widthKeywords: Record<string, string> = {
+const baseDimensionKeywords = {
   fit: 'fit-content',
   min: 'min-content',
   max: 'max-content',
   full: '100%',
-  screen: '100vw',
   auto: 'auto',
   svh: '100svh',
   lvh: '100lvh',
   dvh: '100dvh',
   px: '1px',
+} as const;
+
+const widthKeywords: Record<string, string> = {
+  ...baseDimensionKeywords,
+  screen: '100vw',
   container: 'var(--spacing-container)',
 };
 
 const heightKeywords: Record<string, string> = {
-  fit: 'fit-content',
-  min: 'min-content',
-  max: 'max-content',
-  full: '100%',
+  ...baseDimensionKeywords,
   screen: '100vh',
-  auto: 'auto',
-  svh: '100svh',
-  lvh: '100lvh',
-  dvh: '100dvh',
-  px: '1px',
 };
 
-const resolveDimensionValue = (
-  value: string,
-  keywords: Record<string, string>
-) =>
-  keywords[value] ||
-  (isScale(value) && `calc(var(--spacing) * ${value})`) ||
-  (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+const makeDimensionVar =
+  (axis: 'width' | 'height', keywords: Record<string, string>) =>
+  (name: string, value: string) => {
+    const resolved =
+      keywords[value] ||
+      (isScale(value) && `calc(var(--spacing) * ${value})`) ||
+      (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+
+    if (!resolved) {
+      throw new Error(
+        `Unsupported ${axis} value: "${value}". Expected a keyword (${Object.keys(keywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
+      );
+    }
+
+    return { [`--${name}`]: resolved } as CSSProperties;
+  };
 
 /**
- * Generates a CSS custom property for width that uses either a calc expression or a
- * fraction percentage.
+ * Generates a CSS custom property for width.
  *
- * Supports:
- * - Numeric scale (e.g., "4", "2.5"): Uses `--spacing` scale with calc()
- * - Fractions (e.g., "1/2", "2/3"): Converts to percentage
- * - CSS keywords (e.g., "fit", "min", "max", "screen", "svh", "container", ...)
- *
- * @param name - The custom property name for width.
- * @param value - Width value as a string (number, fraction, or keyword).
- * @returns Object with the CSS custom property for width.
+ * Supports the spacing scale (e.g. `"4"`, `"2.5"`), fractions (e.g. `"1/2"`),
+ * and keywords (`fit`, `min`, `max`, `full`, `screen`, `auto`, `svh`, `lvh`,
+ * `dvh`, `px`, `container`).
  */
-export const createWidthVar = (name: string, value: string) => {
-  const resolvedValue = resolveDimensionValue(value, widthKeywords);
-
-  if (!resolvedValue) {
-    throw new Error(
-      `Unsupported width value: "${value}". Expected a keyword (${Object.keys(widthKeywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
-    );
-  }
-
-  return { [`--${name}`]: resolvedValue } as CSSProperties;
-};
+export const createWidthVar = makeDimensionVar('width', widthKeywords);
 
 /**
- * Generates a CSS custom property for height. Mirrors {@link createWidthVar}
- * but resolves the `screen` keyword to `100vh` and does not support
- * `container` (no equivalent height token in the design system).
- *
- * @param name - The custom property name for height.
- * @param value - Height value as a string (number, fraction, or keyword).
- * @returns Object with the CSS custom property for height.
+ * Generates a CSS custom property for height. Like {@link createWidthVar} but
+ * resolves `screen` to `100vh` and does not support the `container` keyword.
  */
-export const createHeightVar = (name: string, value: string) => {
-  const resolvedValue = resolveDimensionValue(value, heightKeywords);
-
-  if (!resolvedValue) {
-    throw new Error(
-      `Unsupported height value: "${value}". Expected a keyword (${Object.keys(heightKeywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
-    );
-  }
-
-  return { [`--${name}`]: resolvedValue } as CSSProperties;
-};
+export const createHeightVar = makeDimensionVar('height', heightKeywords);

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -99,38 +99,81 @@ export const createSpacingVar = (name: string, value: string) => {
   } as CSSProperties;
 };
 
+const widthKeywords: Record<string, string> = {
+  fit: 'fit-content',
+  min: 'min-content',
+  max: 'max-content',
+  full: '100%',
+  screen: '100vw',
+  auto: 'auto',
+  svh: '100svh',
+  lvh: '100lvh',
+  dvh: '100dvh',
+  px: '1px',
+  container: 'var(--spacing-container)',
+};
+
+const heightKeywords: Record<string, string> = {
+  fit: 'fit-content',
+  min: 'min-content',
+  max: 'max-content',
+  full: '100%',
+  screen: '100vh',
+  auto: 'auto',
+  svh: '100svh',
+  lvh: '100lvh',
+  dvh: '100dvh',
+  px: '1px',
+};
+
+const resolveDimensionValue = (
+  value: string,
+  keywords: Record<string, string>
+) =>
+  keywords[value] ||
+  (isScale(value) && `calc(var(--spacing) * ${value})`) ||
+  (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+
 /**
  * Generates a CSS custom property for width that uses either a calc expression or a
  * fraction percentage.
  *
  * Supports:
- * - Numeric scale (e.g., "4", "2.5"): Uses `--spacing` scale with calc() → `w-4`, `w-2.5`
- * - Fractions (e.g., "1/2", "2/3"): Converts to percentage → `w-1/2`, `w-2/3`
- * - CSS keywords (e.g., "fit", "min", "max"): Uses corresponding CSS values → `w-fit`, `w-min`, `w-max`
+ * - Numeric scale (e.g., "4", "2.5"): Uses `--spacing` scale with calc()
+ * - Fractions (e.g., "1/2", "2/3"): Converts to percentage
+ * - CSS keywords (e.g., "fit", "min", "max", "screen", "svh", "container", ...)
  *
  * @param name - The custom property name for width.
  * @param value - Width value as a string (number, fraction, or keyword).
  * @returns Object with the CSS custom property for width.
- *
  */
 export const createWidthVar = (name: string, value: string) => {
-  const widthKeywords: Record<string, string> = {
-    fit: 'fit-content',
-    min: 'min-content',
-    max: 'max-content',
-    full: '100%',
-    screen: '100vw',
-    auto: 'auto',
-  };
-
-  const resolvedValue =
-    widthKeywords[value] ||
-    (isScale(value) && `calc(var(--spacing) * ${value})`) ||
-    (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+  const resolvedValue = resolveDimensionValue(value, widthKeywords);
 
   if (!resolvedValue) {
     throw new Error(
       `Unsupported width value: "${value}". Expected a keyword (${Object.keys(widthKeywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
+    );
+  }
+
+  return { [`--${name}`]: resolvedValue } as CSSProperties;
+};
+
+/**
+ * Generates a CSS custom property for height. Mirrors {@link createWidthVar}
+ * but resolves the `screen` keyword to `100vh` and does not support
+ * `container` (no equivalent height token in the design system).
+ *
+ * @param name - The custom property name for height.
+ * @param value - Height value as a string (number, fraction, or keyword).
+ * @returns Object with the CSS custom property for height.
+ */
+export const createHeightVar = (name: string, value: string) => {
+  const resolvedValue = resolveDimensionValue(value, heightKeywords);
+
+  if (!resolvedValue) {
+    throw new Error(
+      `Unsupported height value: "${value}". Expected a keyword (${Object.keys(heightKeywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
     );
   }
 

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -124,15 +124,16 @@ const heightKeywords: Record<string, string> = {
 
 const makeDimensionVar =
   (axis: 'width' | 'height', keywords: Record<string, string>) =>
-  (name: string, value: string) => {
-    const resolved = Object.hasOwn(keywords, value)
-      ? keywords[value]
-      : (isScale(value) && `calc(var(--spacing) * ${value})`) ||
-        (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+  (name: string, value: string | number) => {
+    const v = `${value}`;
+    const resolved = Object.hasOwn(keywords, v)
+      ? keywords[v]
+      : (isScale(v) && `calc(var(--spacing) * ${v})`) ||
+        (isFraction(v) && `calc((${v.split('/').join(' / ')}) * 100%)`);
 
     if (!resolved) {
       throw new Error(
-        `Unsupported ${axis} value: "${value}". Expected a keyword (${Object.keys(keywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
+        `Unsupported ${axis} value: "${v}". Expected a keyword (${Object.keys(keywords).join(', ')}), a scale number, or a fraction (e.g., "1/2").`
       );
     }
 

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -125,10 +125,10 @@ const heightKeywords: Record<string, string> = {
 const makeDimensionVar =
   (axis: 'width' | 'height', keywords: Record<string, string>) =>
   (name: string, value: string) => {
-    const resolved =
-      keywords[value] ||
-      (isScale(value) && `calc(var(--spacing) * ${value})`) ||
-      (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
+    const resolved = Object.hasOwn(keywords, value)
+      ? keywords[value]
+      : (isScale(value) && `calc(var(--spacing) * ${value})`) ||
+        (isFraction(value) && `calc((${value.split('/').join(' / ')}) * 100%)`);
 
     if (!resolved) {
       throw new Error(

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -462,16 +462,7 @@
   }
 }
 
-/* ============================ */
-/*    Layout Custom Properties  */
-/* ============================ */
-
-/*
- * Register dimension custom properties as non-inheriting so that a parent
- * setting `--width`, `--max-width`, or `--height` (via `createWidthVar` /
- * `createHeightVar`) does not leak into descendant components that consume
- * the same variable name. Each component resolves its own value locally.
- */
+/* Prevent layout custom properties from inheriting into descendants. */
 @property --width {
   syntax: '*';
   inherits: false;
@@ -481,6 +472,14 @@
   inherits: false;
 }
 @property --height {
+  syntax: '*';
+  inherits: false;
+}
+@property --container-width {
+  syntax: '*';
+  inherits: false;
+}
+@property --field-width {
   syntax: '*';
   inherits: false;
 }

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -461,3 +461,26 @@
     }
   }
 }
+
+/* ============================ */
+/*    Layout Custom Properties  */
+/* ============================ */
+
+/*
+ * Register dimension custom properties as non-inheriting so that a parent
+ * setting `--width`, `--max-width`, or `--height` (via `createWidthVar` /
+ * `createHeightVar`) does not leak into descendant components that consume
+ * the same variable name. Each component resolves its own value locally.
+ */
+@property --width {
+  syntax: '*';
+  inherits: false;
+}
+@property --max-width {
+  syntax: '*';
+  inherits: false;
+}
+@property --height {
+  syntax: '*';
+  inherits: false;
+}


### PR DESCRIPTION
## Summary

Closes [DST-901](https://reservix.atlassian.net/browse/DST-901). Co-lands the dimensional / spacing portion of [DST-1309](https://reservix.atlassian.net/browse/DST-1309) (CSS-var resolution for scale-based style props).

- StyleProps for `width`, `maxWidth`, `height`, `space`, `spaceX`, `spaceY`, `pr`, `pl`, `pt`, `pb` now accept both a numeric scale value (`4`) and its string equivalent (`"4"`). Public types are declarative (`Scale | Fraction | WidthKeyword`, etc.) instead of derived from internal class-name maps, so the type surface is independent of how the value is resolved at runtime.
- Components that previously resolved `width` / `maxWidth` / `height` through map lookups (`Form`, `Calendar`, legacy `Table` column-header / select-all-cell, `Slider`, `Scrollable`, `Switch`, `Grid`) now resolve them through CSS custom properties via `createWidthVar` / new `createHeightVar`, targeting `--width` / `--max-width` / `--height`. These vars — plus the existing `--container-width` and `--field-width` used by `FieldBase` — are registered as non-inheriting (`@property … inherits: false`) in the RUI theme so they cannot leak into descendants.
- `createWidthVar` gained the previously-missing keywords (`svh`, `lvh`, `dvh`, `px`, `container`); both helpers share a common factory and a base keyword set.
- **Breaking** (`@marigold/system`): the runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom` are no longer exported. Consume the prop types (`WidthProp`, `HeightProp`, …) and the CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) instead. Prop type names and shapes are unchanged.
- Docs: short note in `foundations/form-fields` that scale values accept both forms; `docs/ui/Token.tsx`'s spacing-table renderer (the only consumer of the deleted maps outside the system package) now uses a local scale array.

## Test plan

- [x] `pnpm typecheck:only` clean
- [x] `pnpm lint` 0 errors
- [x] `pnpm test:unit` — 1104/1104
- [x] `pnpm test:sb` — passing on touched components
- [x] Build of `@marigold/system` and `@marigold/theme-rui` succeeds
- [ ] CI green
- [ ] Visual regression (Chromatic) — verify Form / Calendar / Slider / Scrollable / Switch / Grid / legacy Table render identically; `--container-width` / `--field-width` non-inheritance shouldn't change visuals but is worth a sanity check
- [ ] Smoke test docs site (`pnpm start`) — Token spacing table renders, all `pl-*` cells visible

## Notes for the reviewer

- The 9 lookup sites moved from `twMap[value]` (static class) to `cn('w-(--width)', …)` + `style={createWidthVar('width', \`${value}\`)}` (dynamic CSS var). All of them have a default value at destructure time (`width = 'full'` / `'auto'` / `'fit'`), so `\`${value}\`` never coerces `undefined`.
- The non-inheriting `@property` rules for `--container-width` and `--field-width` were a finding from the simplify pass on this PR, not a behaviour fix — `FieldBase` already worked correctly because no descendant currently re-uses those names. Registering them keeps the layout-var protection complete.
- DST-1309's other categories (alignment, textAlign, placeItems, aspect, cursorStyle, font*, etc.) are deliberately untouched here. Those need a different per-prop strategy (inline `style` / move-into-component-file) and are best done in their own PR.

[DST-901]: https://reservix.atlassian.net/browse/DST-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DST-1309]: https://reservix.atlassian.net/browse/DST-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ