### PR TITLE
fix(scripts): show npm 2FA OTP prompt during beta release

### DIFF
--- a/scripts/beta-release.mjs
+++ b/scripts/beta-release.mjs
@@ -73,7 +73,10 @@ await $`git add -A`;
 await $`git commit -m ${'release: version packages (beta)'}`;
 
 console.log(chalk.cyan('\n▸ Publishing to npm (tag: beta)…'));
-await $`pnpm changeset publish`;
+// `stdio: 'inherit'` so changesets' interactive 2FA OTP prompt
+// (`Enter one-time password:`) reaches the terminal — without it, zx pipes
+// stdin and the prompt never appears, making the script look hung.
+await $({ stdio: 'inherit' })`pnpm changeset publish`;
 
 console.log(chalk.cyan('\n▸ Pushing commit + tags to origin…'));
 await $`git push --follow-tags`;


### PR DESCRIPTION
## Summary

- `pnpm release:beta` appeared to hang during the `changeset publish` step when npm 2FA was required — the \"Enter one-time password:\" prompt never reached the terminal because zx pipes stdin by default.
- Switch the publish step to \`\$({ stdio: 'inherit' })\` so changesets' interactive OTP prompt is visible and accepts input.
- Added a brief comment explaining the rationale next to the call.

## Test plan

- [ ] Run \`pnpm release:beta\` on the \`beta-release\` branch with at least one pending changeset and an npm account that requires 2FA.
- [ ] Confirm the script prints \`▸ Publishing to npm (tag: beta)…\` and then changesets' \`Enter one-time password:\` prompt appears.
- [ ] Type the OTP, confirm publish completes for all packages and the script proceeds to push commit + tags.