### PR TITLE
feat([DST-1134]): add `<RangeCalendar>` component

### DIFF
--- a/.changeset/add-range-calendar-component.md
+++ b/.changeset/add-range-calendar-component.md
@@ -1,0 +1,9 @@
+---
+"@marigold/components": minor
+"@marigold/theme-rui": minor
+"@marigold/system": minor
+---
+
+feat([DST-1134]): add `<RangeCalendar>` component
+
+Adds a new `<RangeCalendar>` for selecting a contiguous (or non-contiguous) date range, built on react-aria's `<RangeCalendar>` and Marigold conventions (`disabled`/`readOnly`/`error`, `dateUnavailable`, themed via `useClassNames`). Supports up to three side-by-side months via `visibleDuration`, with months stacking vertically below the `sm` breakpoint for mobile layouts. Shares context, header, grid, and listbox primitives with `<Calendar>`. Description and error rendering go through `<FieldBase>` for visual parity with the rest of the form-component family.

--- a/.changeset/add-range-calendar-component.md
+++ b/.changeset/add-range-calendar-component.md
@@ -1,9 +1,12 @@
 ---
-"@marigold/components": minor
-"@marigold/theme-rui": minor
-"@marigold/system": minor
+'@marigold/components': minor
+'@marigold/theme-rui': minor
+'@marigold/system': minor
+'@marigold/docs': patch
 ---
 
-feat([DST-1134]): add `<RangeCalendar>` component
+feat([DST-1134]): add `<RangeCalendar>` component (alpha)
 
-Adds a new `<RangeCalendar>` for selecting a contiguous (or non-contiguous) date range, built on react-aria's `<RangeCalendar>` and Marigold conventions (`disabled`/`readOnly`/`error`, `dateUnavailable`, themed via `useClassNames`). Supports up to three side-by-side months via `visibleDuration`, with months stacking vertically below the `sm` breakpoint for mobile layouts. Shares context, header, grid, and listbox primitives with `<Calendar>`. Description and error rendering go through `<FieldBase>` for visual parity with the rest of the form-component family.
+Adds a new `<RangeCalendar>` for selecting a contiguous or non-contiguous date range, built on react-aria's `<RangeCalendar>` with Marigold conventions (`disabled`, `readOnly`, `error`, `dateUnavailable`, `allowsNonContiguousRanges`). Supports up to three side-by-side months via `visibleDuration`, stacking vertically below the `sm` breakpoint; the same responsive stacking now applies to multi-month `<Calendar>` for parity. `description` and `errorMessage` route through `<FieldBase>` so the help/error UI matches the rest of the form-component family (TriangleAlert icon + HelpText container). Ships as an alpha component with a stub docs page under the form section.
+
+[DST-1134](https://reservix.atlassian.net/browse/DST-1134)

--- a/docs/content/components/form/meta.json
+++ b/docs/content/components/form/meta.json
@@ -11,6 +11,7 @@
     "multiselect",
     "number-field",
     "radio",
+    "rangecalendar",
     "search-field",
     "select",
     "selectlist",

--- a/docs/content/components/form/rangecalendar/index.mdx
+++ b/docs/content/components/form/rangecalendar/index.mdx
@@ -1,0 +1,27 @@
+---
+title: RangeCalendar
+description: Used to select a contiguous date range
+badge: alpha
+---
+
+The `<RangeCalendar>` component...
+
+## Anatomy
+
+## Appearance
+
+<AppearanceDemo component={'RangeCalendar'} />
+
+<AppearanceTable component={'RangeCalendar'} />
+
+## Usage
+
+## Props
+
+<StorybookHintMessage component={'RangeCalendar'} />
+
+### RangeCalendar
+
+<AutoTypeTable path="RangeCalendar" name="RangeCalendarProps" />
+
+## Related

--- a/docs/content/components/form/rangecalendar/rangecalendar-appearance.demo.tsx
+++ b/docs/content/components/form/rangecalendar/rangecalendar-appearance.demo.tsx
@@ -1,0 +1,12 @@
+import { CalendarDate } from '@internationalized/date';
+import { RangeCalendar, RangeCalendarProps } from '@marigold/components';
+
+export default (props: RangeCalendarProps) => (
+  <RangeCalendar
+    {...props}
+    defaultValue={{
+      start: new CalendarDate(2025, 8, 7),
+      end: new CalendarDate(2025, 8, 14),
+    }}
+  />
+);

--- a/packages/components/src/Calendar/Calendar.test.tsx
+++ b/packages/components/src/Calendar/Calendar.test.tsx
@@ -5,7 +5,7 @@ import { renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { Basic, ThreeMonths, TwoMonths } from './Calendar.stories';
-import { useCalendarContext } from './Context';
+import { useCalendarContext, useCalendarOrRangeState } from './Context';
 
 describe('Calendar', () => {
   const user = userEvent.setup();
@@ -336,5 +336,11 @@ describe('Calendar - Multi-month', () => {
 test('useCalendarContext throws when used outside Calendar', () => {
   expect(() => renderHook(() => useCalendarContext())).toThrow(
     'Calendar components must be used within <Calendar>'
+  );
+});
+
+test('useCalendarOrRangeState throws when used outside Calendar or RangeCalendar', () => {
+  expect(() => renderHook(() => useCalendarOrRangeState())).toThrow(
+    'Calendar subcomponents must be rendered inside <Calendar> or <RangeCalendar>'
   );
 });

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -59,14 +59,14 @@ export interface CalendarProps extends Omit<
    * The number of months to display at once. Up to 3 months are supported.
    * @default { months: 1 }
    */
-  visibleDuration?: { months: number };
+  visibleDuration?: { months: 1 | 2 | 3 };
   /**
    * Controls how the calendar pages when navigating.
    * - 'single': Page by one month at a time
    * - 'visible': Page by the number of visible months
    * @default 'visible'
    */
-  pageBehavior?: 'single' | 'visible';
+  pageBehavior?: RAC.CalendarProps<DateValue>['pageBehavior'];
 }
 
 type ViewMapKeys = 'month' | 'year';

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -192,7 +192,7 @@ const _Calendar = ({
             selectedDropdown && 'pointer-events-none opacity-0'
           )}
         >
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-6 flex items-center justify-between gap-4">
             <div className="flex w-fit gap-4">
               <CalendarListBox
                 key="month"

--- a/packages/components/src/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/Calendar/CalendarGrid.tsx
@@ -4,8 +4,8 @@ import {
   CalendarGrid,
   CalendarGridBody,
 } from 'react-aria-components';
-import { useClassNames } from '@marigold/system';
 import { CalendarGridHeader } from './CalendarGridHeader';
+import { useCalendarContext } from './Context';
 
 export interface CalendarGridProps {
   /**
@@ -16,7 +16,7 @@ export interface CalendarGridProps {
 }
 
 const _CalendarGrid = ({ offset }: CalendarGridProps) => {
-  const classNames = useClassNames({ component: 'Calendar' });
+  const { classNames } = useCalendarContext();
 
   return (
     <CalendarGrid offset={offset} className={classNames.calendarGrid}>

--- a/packages/components/src/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/Calendar/CalendarGrid.tsx
@@ -1,8 +1,10 @@
 import type { DateDuration } from '@internationalized/date';
+import { useContext } from 'react';
 import {
   CalendarCell,
   CalendarGrid,
   CalendarGridBody,
+  RangeCalendarStateContext,
 } from 'react-aria-components';
 import { CalendarGridHeader } from './CalendarGridHeader';
 import { useCalendarContext } from './Context';
@@ -17,14 +19,32 @@ export interface CalendarGridProps {
 
 const _CalendarGrid = ({ offset }: CalendarGridProps) => {
   const { classNames } = useCalendarContext();
+  // RAC strips `data-selected` from every cell when the calendar is disabled,
+  // so the in-range fill disappears in disabled <RangeCalendar>. We mark
+  // cells in the selected range ourselves so the theme can style them
+  // independently of RAC's interactive selection state. Use
+  // `highlightedRange` so the fill follows the in-progress selection
+  // instead of the previously committed value.
+  const rangeState = useContext(RangeCalendarStateContext);
+  const range = rangeState?.highlightedRange ?? null;
 
   return (
     <CalendarGrid offset={offset} className={classNames.calendarGrid}>
       <CalendarGridHeader />
       <CalendarGridBody>
-        {date => (
-          <CalendarCell date={date} className={classNames.calendarCell} />
-        )}
+        {date => {
+          const isInRange =
+            !!range &&
+            date.compare(range.start) >= 0 &&
+            date.compare(range.end) <= 0;
+          return (
+            <CalendarCell
+              date={date}
+              className={classNames.calendarCell}
+              data-in-range={isInRange ? '' : undefined}
+            />
+          );
+        }}
       </CalendarGridBody>
     </CalendarGrid>
   );

--- a/packages/components/src/Calendar/CalendarGridHeader.tsx
+++ b/packages/components/src/Calendar/CalendarGridHeader.tsx
@@ -1,12 +1,12 @@
 import { startOfWeek, today } from '@internationalized/date';
-import { useContext, useMemo } from 'react';
-import { CalendarGridProps, CalendarStateContext } from 'react-aria-components';
+import { useMemo } from 'react';
+import { CalendarGridProps } from 'react-aria-components';
 import { useCalendarGrid } from '@react-aria/calendar';
 import { useDateFormatter, useLocale } from '@react-aria/i18n';
-import { useClassNames } from '@marigold/system';
+import { useCalendarContext, useCalendarOrRangeState } from './Context';
 
 export function CalendarGridHeader(props: CalendarGridProps) {
-  const state = useContext(CalendarStateContext)!;
+  const state = useCalendarOrRangeState();
   const { headerProps } = useCalendarGrid(props, state);
 
   const { locale } = useLocale();
@@ -24,7 +24,7 @@ export function CalendarGridHeader(props: CalendarGridProps) {
     });
   }, [locale, state.timeZone, dayFormatter]);
 
-  const classNames = useClassNames({ component: 'Calendar' });
+  const { classNames } = useCalendarContext();
 
   return (
     <thead {...headerProps}>

--- a/packages/components/src/Calendar/CalendarHeader.tsx
+++ b/packages/components/src/Calendar/CalendarHeader.tsx
@@ -1,10 +1,9 @@
-import { useContext } from 'react';
-import { CalendarStateContext, Heading } from 'react-aria-components';
+import { Heading } from 'react-aria-components';
 import { useDateFormatter } from '@react-aria/i18n';
 import { IconButton } from '../IconButton/IconButton';
 import { ChevronLeft } from '../icons/ChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
-import { useCalendarContext } from './Context';
+import { useCalendarContext, useCalendarOrRangeState } from './Context';
 
 export interface CalendarHeaderProps {
   /**
@@ -26,7 +25,7 @@ export const CalendarHeader = ({
   showPrevious,
   showNext,
 }: CalendarHeaderProps) => {
-  const state = useContext(CalendarStateContext)!;
+  const state = useCalendarOrRangeState();
   const { classNames } = useCalendarContext();
 
   const monthFormatter = useDateFormatter({

--- a/packages/components/src/Calendar/CalendarListBox.tsx
+++ b/packages/components/src/Calendar/CalendarListBox.tsx
@@ -1,8 +1,7 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
-import { CalendarStateContext } from 'react-aria-components';
+import { Dispatch, SetStateAction } from 'react';
 import { cn } from '@marigold/system';
 import { ChevronsVertical } from '../icons/ChevronsVertical';
-import { useCalendarContext } from './Context';
+import { useCalendarContext, useCalendarOrRangeState } from './Context';
 import { useFormattedMonths } from './useFormattedMonths';
 
 interface CalendarButtonListBoxProps {
@@ -16,7 +15,7 @@ export const CalendarListBox = ({
   isDisabled,
   setSelectedDropdown,
 }: CalendarButtonListBoxProps) => {
-  const state = useContext(CalendarStateContext)!;
+  const state = useCalendarOrRangeState();
   const months = useFormattedMonths(state.timeZone, state.focusedDate);
 
   const buttonStyles =

--- a/packages/components/src/Calendar/Context.tsx
+++ b/packages/components/src/Calendar/Context.tsx
@@ -1,9 +1,17 @@
-import { createContext, useContext } from 'react';
-import type { DateValue } from 'react-aria-components';
+import { createContext, use } from 'react';
+import {
+  CalendarStateContext,
+  type DateValue,
+  RangeCalendarStateContext,
+} from 'react-aria-components';
 import type { ComponentClassNames } from '@marigold/system';
 
+export type CalendarSharedClassNames =
+  | ComponentClassNames<'Calendar'>
+  | ComponentClassNames<'RangeCalendar'>;
+
 export interface CalendarContextValue {
-  classNames: ComponentClassNames<'Calendar'>;
+  classNames: CalendarSharedClassNames;
   visibleMonths: number;
   minValue?: DateValue | null;
   maxValue?: DateValue | null;
@@ -13,9 +21,21 @@ export interface CalendarContextValue {
 export const CalendarContext = createContext<CalendarContextValue | null>(null);
 
 export const useCalendarContext = () => {
-  const ctx = useContext(CalendarContext);
+  const ctx = use(CalendarContext);
   if (!ctx) {
     throw new Error('Calendar components must be used within <Calendar>');
   }
   return ctx;
+};
+
+export const useCalendarOrRangeState = () => {
+  const calendarState = use(CalendarStateContext);
+  const rangeState = use(RangeCalendarStateContext);
+  const state = calendarState ?? rangeState;
+  if (!state) {
+    throw new Error(
+      'Calendar subcomponents must be rendered inside <Calendar> or <RangeCalendar>'
+    );
+  }
+  return state;
 };

--- a/packages/components/src/Calendar/ListBox.tsx
+++ b/packages/components/src/Calendar/ListBox.tsx
@@ -31,7 +31,7 @@ export function ListBox<T>({
   return (
     <RACAriaListBox
       className={cn(
-        'grid h-full max-h-[300px] min-w-[300px] grid-cols-3 gap-y-10 overflow-y-auto p-2'
+        'grid h-full max-h-[300px] w-full grid-cols-3 gap-y-10 overflow-y-auto p-2'
       )}
       data-testid={dataTestid}
       selectionMode="single"

--- a/packages/components/src/Calendar/MonthControls.tsx
+++ b/packages/components/src/Calendar/MonthControls.tsx
@@ -1,10 +1,10 @@
-import { useClassNames } from '@marigold/system';
 import { IconButton } from '../IconButton/IconButton';
 import { ChevronLeft } from '../icons/ChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
+import { useCalendarContext } from './Context';
 
 function MonthControls() {
-  const classNames = useClassNames({ component: 'Calendar' });
+  const { classNames } = useCalendarContext();
 
   return (
     <div className="flex w-full flex-nowrap justify-end gap-2.5">

--- a/packages/components/src/Calendar/MonthListBox.tsx
+++ b/packages/components/src/Calendar/MonthListBox.tsx
@@ -1,5 +1,6 @@
-import { Dispatch, SetStateAction, useContext } from 'react';
-import { CalendarStateContext, DateValue } from 'react-aria-components';
+import { Dispatch, SetStateAction } from 'react';
+import { DateValue } from 'react-aria-components';
+import { useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 import { useFormattedMonths } from './useFormattedMonths';
 
@@ -14,7 +15,7 @@ const MonthListBox = ({
   minValue,
   maxValue,
 }: MonthDropdownProps) => {
-  const state = useContext(CalendarStateContext)!;
+  const state = useCalendarOrRangeState();
   const months = useFormattedMonths(state.timeZone, state.focusedDate);
   const currentYear = state.focusedDate.year;
 

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -1,7 +1,8 @@
 import { CalendarDate } from '@internationalized/date';
-import { Dispatch, SetStateAction, useContext } from 'react';
-import { CalendarStateContext, DateValue } from 'react-aria-components';
+import { Dispatch, SetStateAction } from 'react';
+import { DateValue } from 'react-aria-components';
 import { useDateFormatter } from '@react-aria/i18n';
+import { useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 
 interface YearDropdownProps {
@@ -15,7 +16,7 @@ const YearListBox = ({
   minValue,
   maxValue,
 }: YearDropdownProps) => {
-  const state = useContext(CalendarStateContext)!;
+  const state = useCalendarOrRangeState();
   const years: CalendarDate[] = [];
   for (let i = -20; i <= 20; i++) {
     years.push(state.focusedDate.add({ years: i }));

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -133,19 +133,47 @@ export const Unavailable = meta.story({
 
 export const NonContiguous = meta.story({
   args: {
-    defaultValue: {
-      start: new CalendarDate(2025, 8, 4),
-      end: new CalendarDate(2025, 8, 8),
-    },
     allowsNonContiguousRanges: true,
   },
   render: args => {
     const { locale } = useLocale();
+    const [value, setValue] = useState<RangeValue<DateValue> | null>({
+      start: new CalendarDate(2025, 8, 4),
+      end: new CalendarDate(2025, 8, 8),
+    });
+
+    const isUnavailable = (date: DateValue) => isWeekend(date, locale);
+
+    const selectedDates: DateValue[] = [];
+    if (value) {
+      let cursor = value.start;
+      while (cursor.compare(value.end) <= 0) {
+        if (!isUnavailable(cursor)) selectedDates.push(cursor);
+        cursor = cursor.add({ days: 1 });
+      }
+    }
+
     return (
-      <RangeCalendar
-        {...args}
-        dateUnavailable={date => isWeekend(date, locale)}
-      />
+      <>
+        <RangeCalendar
+          {...args}
+          value={value}
+          onChange={setValue}
+          dateUnavailable={isUnavailable}
+        />
+        <pre style={{ marginTop: '1rem' }} data-testid="selectedRange">
+          <strong>RangeCalendar Value:</strong>
+          {value
+            ? ` ${value.start.toString()} → ${value.end.toString()}`
+            : ' (none)'}
+        </pre>
+        <pre style={{ marginTop: '0.5rem' }} data-testid="selectedDates">
+          <strong>Selected dates (excluding unavailable):</strong>
+          {selectedDates.length
+            ? ` ${selectedDates.map(d => d.toString()).join(', ')}`
+            : ' (none)'}
+        </pre>
+      </>
     );
   },
 });
@@ -183,19 +211,27 @@ export const MultiMonthNavigation = meta.story({
     onChange: fn(),
   },
   render: args => <RangeCalendar {...args} />,
-  play: async ({ canvasElement, userEvent }) => {
+  play: async ({ canvasElement, userEvent, step }) => {
     const canvas = within(canvasElement);
 
-    const nextButtons = canvas.getAllByRole('button', { name: /next/i });
-    await userEvent.click(nextButtons[0]);
+    await step('navigates forward two months', async () => {
+      const nextButtons = canvas.getAllByRole('button', { name: /next/i });
+      await userEvent.click(nextButtons[0]);
+    });
 
-    await expect(canvas.getByText('March 2025')).toBeInTheDocument();
-    await expect(canvas.getByText('April 2025')).toBeInTheDocument();
+    await step('shows March and April after navigating forward', async () => {
+      await expect(canvas.getByText('March 2025')).toBeInTheDocument();
+      await expect(canvas.getByText('April 2025')).toBeInTheDocument();
+    });
 
-    const prevButtons = canvas.getAllByRole('button', { name: /previous/i });
-    await userEvent.click(prevButtons[0]);
+    await step('navigates back two months', async () => {
+      const prevButtons = canvas.getAllByRole('button', { name: /previous/i });
+      await userEvent.click(prevButtons[0]);
+    });
 
-    await expect(canvas.getByText('January 2025')).toBeInTheDocument();
-    await expect(canvas.getByText('February 2025')).toBeInTheDocument();
+    await step('shows January and February after navigating back', async () => {
+      await expect(canvas.getByText('January 2025')).toBeInTheDocument();
+      await expect(canvas.getByText('February 2025')).toBeInTheDocument();
+    });
   },
 });

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -207,7 +207,7 @@ export const ThreeMonths = meta.story({
   render: args => <RangeCalendar {...args} />,
 });
 
-export const TwoMonthsMobile: any = meta.story({
+export const TwoMonthsMobile = meta.story({
   globals: {
     viewport: { value: 'smallScreen' },
   },
@@ -221,7 +221,7 @@ export const TwoMonthsMobile: any = meta.story({
   render: args => <RangeCalendar {...args} />,
 });
 
-export const ThreeMonthsMobile: any = meta.story({
+export const ThreeMonthsMobile = meta.story({
   globals: {
     viewport: { value: 'smallScreen' },
   },

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -200,6 +200,34 @@ export const ThreeMonths = meta.story({
   render: args => <RangeCalendar {...args} />,
 });
 
+export const TwoMonthsMobile: any = meta.story({
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  args: {
+    visibleDuration: { months: 2 },
+    defaultValue: {
+      start: new CalendarDate(2025, 2, 15),
+      end: new CalendarDate(2025, 3, 5),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+});
+
+export const ThreeMonthsMobile: any = meta.story({
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  args: {
+    visibleDuration: { months: 3 },
+    defaultValue: {
+      start: new CalendarDate(2025, 5, 20),
+      end: new CalendarDate(2025, 7, 10),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+});
+
 export const MultiMonthNavigation = meta.story({
   tags: ['component-test'],
   args: {

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -33,7 +33,7 @@ const meta = preview.meta({
         defaultValue: { summary: 'false' },
       },
     },
-    invalid: {
+    error: {
       control: { type: 'boolean' },
       description: 'Mark the value as invalid',
       table: {
@@ -108,8 +108,15 @@ export const ReadOnly = meta.story({
 export const WithError = meta.story({
   ...Basic.input,
   args: {
-    invalid: true,
+    error: true,
     errorMessage: 'Please select a valid date range.',
+  },
+});
+
+export const WithDescription = meta.story({
+  ...Basic.input,
+  args: {
+    description: 'Pick a start and end date for your reservation.',
   },
 });
 

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -1,0 +1,201 @@
+import { CalendarDate, isWeekend } from '@internationalized/date';
+import { useState } from 'react';
+import { DateValue, RangeValue } from 'react-aria-components';
+import { expect, fn, within } from 'storybook/test';
+import preview from '.storybook/preview';
+import { useLocale } from '@react-aria/i18n';
+import { RangeCalendar } from './RangeCalendar';
+
+const meta = preview.meta({
+  title: 'Components/RangeCalendar',
+  component: RangeCalendar,
+  decorators: [
+    Story => (
+      <div id="storybook-root">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disable the RangeCalendar',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    readOnly: {
+      control: { type: 'boolean' },
+      description: 'Make the RangeCalendar not editable',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    invalid: {
+      control: { type: 'boolean' },
+      description: 'Mark the value as invalid',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    allowsNonContiguousRanges: {
+      control: { type: 'boolean' },
+      description:
+        'Allow ranges that span unavailable dates by treating them as gaps',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    width: {
+      control: { type: 'text' },
+      description: 'Width of the RangeCalendar',
+      table: {
+        type: { summary: 'text' },
+        defaultValue: { summary: 'fit' },
+      },
+    },
+  },
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 7),
+      end: new CalendarDate(2025, 8, 14),
+    },
+  },
+});
+
+export const Basic = meta.story({
+  render: args => <RangeCalendar {...args} />,
+});
+
+export const Controlled = meta.story({
+  render: args => {
+    const [value, setValue] = useState<RangeValue<DateValue> | null>({
+      start: new CalendarDate(2019, 6, 5),
+      end: new CalendarDate(2019, 6, 12),
+    });
+    return (
+      <>
+        <RangeCalendar {...args} value={value} onChange={setValue} autoFocus />
+        <pre style={{ marginTop: '1rem' }} data-testid="selectedRange">
+          <strong>RangeCalendar Value:</strong>
+          {value
+            ? ` ${value.start.toString()} → ${value.end.toString()}`
+            : ' (none)'}
+        </pre>
+      </>
+    );
+  },
+});
+
+export const Disabled = meta.story({
+  ...Basic.input,
+  args: {
+    disabled: true,
+  },
+});
+
+export const ReadOnly = meta.story({
+  ...Basic.input,
+  args: {
+    readOnly: true,
+  },
+});
+
+export const WithError = meta.story({
+  ...Basic.input,
+  args: {
+    invalid: true,
+    errorMessage: 'Please select a valid date range.',
+  },
+});
+
+export const Unavailable = meta.story({
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 4),
+      end: new CalendarDate(2025, 8, 6),
+    },
+  },
+  render: args => {
+    const { locale } = useLocale();
+    return (
+      <RangeCalendar
+        {...args}
+        dateUnavailable={date => isWeekend(date, locale)}
+      />
+    );
+  },
+});
+
+export const NonContiguous = meta.story({
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 4),
+      end: new CalendarDate(2025, 8, 8),
+    },
+    allowsNonContiguousRanges: true,
+  },
+  render: args => {
+    const { locale } = useLocale();
+    return (
+      <RangeCalendar
+        {...args}
+        dateUnavailable={date => isWeekend(date, locale)}
+      />
+    );
+  },
+});
+
+export const TwoMonths = meta.story({
+  args: {
+    visibleDuration: { months: 2 },
+    defaultValue: {
+      start: new CalendarDate(2025, 2, 15),
+      end: new CalendarDate(2025, 3, 5),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+});
+
+export const ThreeMonths = meta.story({
+  args: {
+    visibleDuration: { months: 3 },
+    defaultValue: {
+      start: new CalendarDate(2025, 5, 20),
+      end: new CalendarDate(2025, 7, 10),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+});
+
+export const MultiMonthNavigation = meta.story({
+  tags: ['component-test'],
+  args: {
+    visibleDuration: { months: 2 },
+    defaultValue: {
+      start: new CalendarDate(2025, 1, 15),
+      end: new CalendarDate(2025, 1, 20),
+    },
+    onChange: fn(),
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    const nextButtons = canvas.getAllByRole('button', { name: /next/i });
+    await userEvent.click(nextButtons[0]);
+
+    await expect(canvas.getByText('March 2025')).toBeInTheDocument();
+    await expect(canvas.getByText('April 2025')).toBeInTheDocument();
+
+    const prevButtons = canvas.getAllByRole('button', { name: /previous/i });
+    await userEvent.click(prevButtons[0]);
+
+    await expect(canvas.getByText('January 2025')).toBeInTheDocument();
+    await expect(canvas.getByText('February 2025')).toBeInTheDocument();
+  },
+});

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -270,3 +270,175 @@ export const MultiMonthNavigation = meta.story({
     });
   },
 });
+
+export const RangeSelection = meta.story({
+  tags: ['component-test'],
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2019, 6, 5),
+      end: new CalendarDate(2019, 6, 5),
+    },
+    onChange: fn(),
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByLabelText(/Monday, June 10, 2019/i));
+    await userEvent.click(canvas.getByLabelText(/Saturday, June 15, 2019/i));
+
+    await expect(args.onChange).toHaveBeenCalled();
+    const lastCall = (args.onChange as ReturnType<typeof fn>).mock.calls.at(
+      -1
+    )?.[0];
+    await expect(lastCall.start).toEqual(new CalendarDate(2019, 6, 10));
+    await expect(lastCall.end).toEqual(new CalendarDate(2019, 6, 15));
+  },
+});
+
+export const ReadOnlyDoesNotCommit = meta.story({
+  tags: ['component-test'],
+  args: {
+    readOnly: true,
+    defaultValue: {
+      start: new CalendarDate(2019, 6, 5),
+      end: new CalendarDate(2019, 6, 10),
+    },
+    onChange: fn(),
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByLabelText(/Saturday, June 15, 2019/i));
+
+    await expect(args.onChange).not.toHaveBeenCalled();
+  },
+});
+
+export const UnavailableBlocks = meta.story({
+  tags: ['component-test'],
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 4),
+      end: new CalendarDate(2025, 8, 6),
+    },
+  },
+  render: args => {
+    const { locale } = useLocale();
+    return (
+      <RangeCalendar
+        {...args}
+        dateUnavailable={date => isWeekend(date, locale)}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const cells = canvas.getAllByRole('gridcell');
+    const unavailable = cells.find(
+      cell => cell.getAttribute('aria-disabled') === 'true'
+    );
+
+    await expect(unavailable).toBeDefined();
+  },
+});
+
+export const MonthDropdown = meta.story({
+  tags: ['component-test'],
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 7),
+      end: new CalendarDate(2025, 8, 14),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ canvasElement, userEvent, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('month dropdown is closed initially', async () => {
+      await expect(
+        canvas.queryByRole('listbox', { name: 'monthOptions' })
+      ).not.toBeInTheDocument();
+    });
+
+    await step('opens when the month button is clicked', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Aug' }));
+      await expect(
+        canvas.getByRole('listbox', { name: 'monthOptions' })
+      ).toBeInTheDocument();
+    });
+
+    await step('closes after selecting an option', async () => {
+      const monthOptions = canvas.getByRole('listbox', {
+        name: 'monthOptions',
+      });
+      const options = within(monthOptions).getAllByRole('option');
+      await userEvent.click(options[2]);
+
+      await expect(
+        canvas.queryByRole('listbox', { name: 'monthOptions' })
+      ).not.toBeInTheDocument();
+    });
+  },
+});
+
+export const YearDropdown = meta.story({
+  tags: ['component-test'],
+  args: {
+    defaultValue: {
+      start: new CalendarDate(2025, 8, 7),
+      end: new CalendarDate(2025, 8, 14),
+    },
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ canvasElement, userEvent, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('year dropdown is closed initially', async () => {
+      await expect(
+        canvas.queryByRole('listbox', { name: 'yearOptions' })
+      ).not.toBeInTheDocument();
+    });
+
+    await step('opens when the year button is clicked', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: '2025' }));
+      await expect(
+        canvas.getByRole('listbox', { name: 'yearOptions' })
+      ).toBeInTheDocument();
+    });
+  },
+});
+
+export const TwoMonthsRangeSelection = meta.story({
+  tags: ['component-test'],
+  args: {
+    visibleDuration: { months: 2 },
+    defaultValue: {
+      start: new CalendarDate(2025, 2, 15),
+      end: new CalendarDate(2025, 2, 15),
+    },
+    onChange: fn(),
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    const grids = canvas.getAllByRole('grid');
+    const startCell = within(grids[0]).getByLabelText(
+      /Thursday, February 20, 2025/i
+    );
+    const endCell = within(grids[1]).getByLabelText(/Monday, March 10, 2025/i);
+
+    await userEvent.click(startCell);
+    await userEvent.click(endCell);
+
+    await expect(args.onChange).toHaveBeenCalled();
+    const lastCall = (args.onChange as ReturnType<typeof fn>).mock.calls.at(
+      -1
+    )?.[0];
+    await expect(lastCall.start).toEqual(new CalendarDate(2025, 2, 20));
+    await expect(lastCall.end).toEqual(new CalendarDate(2025, 3, 10));
+  },
+});

--- a/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
@@ -108,6 +108,38 @@ describe('RangeCalendar', () => {
 
     expect(unavailable).toBeDefined();
   });
+
+  test('opens the month dropdown when the month button is clicked', async () => {
+    render(<Basic.Component />);
+
+    expect(screen.queryByTestId('monthOptions')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('month'));
+
+    expect(screen.getByTestId('monthOptions')).toBeInTheDocument();
+  });
+
+  test('opens the year dropdown when the year button is clicked', async () => {
+    render(<Basic.Component />);
+
+    expect(screen.queryByTestId('yearOptions')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('year'));
+
+    expect(screen.getByTestId('yearOptions')).toBeInTheDocument();
+  });
+
+  test('selecting an option from the month dropdown closes it', async () => {
+    render(<Basic.Component />);
+
+    await user.click(screen.getByTestId('month'));
+    const monthOptions = screen.getByTestId('monthOptions');
+    const options = within(monthOptions).getAllByRole('option');
+
+    await user.click(options[2]);
+
+    expect(screen.queryByTestId('monthOptions')).not.toBeInTheDocument();
+  });
 });
 
 describe('RangeCalendar - Multi-month', () => {

--- a/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
@@ -1,0 +1,224 @@
+/* eslint-disable testing-library/no-node-access */
+import { CalendarDate } from '@internationalized/date';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import {
+  Basic,
+  ThreeMonths,
+  TwoMonths,
+  Unavailable,
+  WithError,
+} from './RangeCalendar.stories';
+
+describe('RangeCalendar', () => {
+  const user = userEvent.setup();
+
+  test('renders with default range value', () => {
+    render(
+      <Basic.Component
+        defaultValue={{
+          start: new CalendarDate(2019, 6, 5),
+          end: new CalendarDate(2019, 6, 10),
+        }}
+      />
+    );
+
+    const selected = screen
+      .getAllByRole('gridcell')
+      .filter(cell => cell.getAttribute('aria-selected') === 'true');
+
+    expect(selected.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('selects a range with two clicks (uncontrolled)', async () => {
+    const onChange = vi.fn();
+    render(
+      <Basic.Component
+        defaultValue={{
+          start: new CalendarDate(2019, 6, 5),
+          end: new CalendarDate(2019, 6, 5),
+        }}
+        onChange={onChange}
+      />
+    );
+
+    const startCell = screen.getByText('10');
+    await user.click(startCell);
+
+    const endCell = screen.getByText('15');
+    await user.click(endCell);
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls.at(-1)?.[0];
+    expect(lastCall.start).toEqual(new CalendarDate(2019, 6, 10));
+    expect(lastCall.end).toEqual(new CalendarDate(2019, 6, 15));
+  });
+
+  test('marks all cells aria-disabled when disabled', () => {
+    render(
+      <Basic.Component
+        defaultValue={{
+          start: new CalendarDate(2019, 6, 5),
+          end: new CalendarDate(2019, 6, 10),
+        }}
+        disabled
+      />
+    );
+
+    const cells = screen.getAllByRole('gridcell');
+    expect(cells.every(c => c.getAttribute('aria-disabled') === 'true')).toBe(
+      true
+    );
+  });
+
+  test('does not call onChange when readOnly', async () => {
+    const onChange = vi.fn();
+    render(
+      <Basic.Component
+        defaultValue={{
+          start: new CalendarDate(2019, 6, 5),
+          end: new CalendarDate(2019, 6, 10),
+        }}
+        onChange={onChange}
+        readOnly
+      />
+    );
+
+    const cell = screen.getByText('15');
+    await user.click(cell);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('renders error message when provided', () => {
+    render(<WithError.Component />);
+
+    expect(screen.getByText(/please select/i)).toBeInTheDocument();
+  });
+
+  test('blocks dates marked unavailable', async () => {
+    const onChange = vi.fn();
+    render(<Unavailable.Component onChange={onChange} />);
+
+    const cells = screen.getAllByRole('gridcell');
+    const unavailable = cells.find(
+      cell => cell.getAttribute('aria-disabled') === 'true'
+    );
+
+    expect(unavailable).toBeDefined();
+  });
+});
+
+describe('RangeCalendar - Multi-month', () => {
+  const user = userEvent.setup();
+
+  test('renders two months with visibleDuration', () => {
+    render(<TwoMonths.Component />);
+
+    const grids = screen.getAllByRole('grid');
+    expect(grids).toHaveLength(2);
+
+    const calendar = screen.getByRole('application');
+    expect(calendar).toHaveTextContent(/February 2025/i);
+    expect(calendar).toHaveTextContent(/March 2025/i);
+  });
+
+  test('renders three months with visibleDuration', () => {
+    render(<ThreeMonths.Component />);
+
+    const grids = screen.getAllByRole('grid');
+    expect(grids).toHaveLength(3);
+
+    const calendar = screen.getByRole('application');
+    expect(calendar).toHaveTextContent(/May 2025/i);
+    expect(calendar).toHaveTextContent(/June 2025/i);
+    expect(calendar).toHaveTextContent(/July 2025/i);
+  });
+
+  test('navigates forward with next button', async () => {
+    render(
+      <TwoMonths.Component
+        defaultValue={{
+          start: new CalendarDate(2025, 1, 15),
+          end: new CalendarDate(2025, 1, 20),
+        }}
+      />
+    );
+
+    const calendar = screen.getByRole('application');
+    expect(calendar).toHaveTextContent(/January 2025/i);
+    expect(calendar).toHaveTextContent(/February 2025/i);
+
+    const buttons = screen.getAllByRole('button');
+    const nextButton = buttons.find(b => b.getAttribute('slot') === 'next');
+    expect(nextButton).toBeDefined();
+    await user.click(nextButton!);
+
+    expect(calendar).toHaveTextContent(/March 2025/i);
+    expect(calendar).toHaveTextContent(/April 2025/i);
+  });
+
+  test('navigates backward with previous button', async () => {
+    render(
+      <TwoMonths.Component
+        defaultValue={{
+          start: new CalendarDate(2025, 3, 15),
+          end: new CalendarDate(2025, 3, 20),
+        }}
+      />
+    );
+
+    const calendar = screen.getByRole('application');
+    expect(calendar).toHaveTextContent(/March 2025/i);
+    expect(calendar).toHaveTextContent(/April 2025/i);
+
+    const buttons = screen.getAllByRole('button');
+    const prevButton = buttons.find(b => b.getAttribute('slot') === 'previous');
+    expect(prevButton).toBeDefined();
+    await user.click(prevButton!);
+
+    expect(calendar).toHaveTextContent(/January 2025/i);
+    expect(calendar).toHaveTextContent(/February 2025/i);
+  });
+
+  test('selects a range across the second month with two clicks', async () => {
+    const onChange = vi.fn();
+    render(
+      <TwoMonths.Component
+        defaultValue={{
+          start: new CalendarDate(2025, 2, 15),
+          end: new CalendarDate(2025, 2, 15),
+        }}
+        onChange={onChange}
+      />
+    );
+
+    const grids = screen.getAllByRole('grid');
+    const firstGrid = grids[0];
+    const secondGrid = grids[1];
+
+    const startCell = within(firstGrid)
+      .getAllByRole('gridcell')
+      .find(
+        cell =>
+          cell.textContent === '20' &&
+          cell.getAttribute('aria-disabled') !== 'true'
+      )!;
+    const endCell = within(secondGrid)
+      .getAllByRole('gridcell')
+      .find(
+        cell =>
+          cell.textContent === '10' &&
+          cell.getAttribute('aria-disabled') !== 'true'
+      )!;
+
+    await user.click(startCell.firstChild as Element);
+    await user.click(endCell.firstChild as Element);
+
+    expect(onChange).toHaveBeenCalled();
+    const lastCall = onChange.mock.calls.at(-1)?.[0];
+    expect(lastCall.start).toEqual(new CalendarDate(2025, 2, 20));
+    expect(lastCall.end).toEqual(new CalendarDate(2025, 3, 10));
+  });
+});

--- a/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
@@ -1,7 +1,8 @@
-/* eslint-disable testing-library/no-node-access */
 import { CalendarDate } from '@internationalized/date';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+import { I18nProvider } from 'react-aria-components';
 import { vi } from 'vitest';
 import {
   Basic,
@@ -11,11 +12,14 @@ import {
   WithError,
 } from './RangeCalendar.stories';
 
+const renderWithLocale = (ui: ReactNode) =>
+  render(<I18nProvider locale="en-US">{ui}</I18nProvider>);
+
 describe('RangeCalendar', () => {
   const user = userEvent.setup();
 
   test('renders with default range value', () => {
-    render(
+    renderWithLocale(
       <Basic.Component
         defaultValue={{
           start: new CalendarDate(2019, 6, 5),
@@ -33,7 +37,7 @@ describe('RangeCalendar', () => {
 
   test('selects a range with two clicks (uncontrolled)', async () => {
     const onChange = vi.fn();
-    render(
+    renderWithLocale(
       <Basic.Component
         defaultValue={{
           start: new CalendarDate(2019, 6, 5),
@@ -43,11 +47,8 @@ describe('RangeCalendar', () => {
       />
     );
 
-    const startCell = screen.getByText('10');
-    await user.click(startCell);
-
-    const endCell = screen.getByText('15');
-    await user.click(endCell);
+    await user.click(screen.getByLabelText(/Monday, June 10, 2019/i));
+    await user.click(screen.getByLabelText(/Saturday, June 15, 2019/i));
 
     expect(onChange).toHaveBeenCalled();
     const lastCall = onChange.mock.calls.at(-1)?.[0];
@@ -56,7 +57,7 @@ describe('RangeCalendar', () => {
   });
 
   test('marks all cells aria-disabled when disabled', () => {
-    render(
+    renderWithLocale(
       <Basic.Component
         defaultValue={{
           start: new CalendarDate(2019, 6, 5),
@@ -74,7 +75,7 @@ describe('RangeCalendar', () => {
 
   test('does not call onChange when readOnly', async () => {
     const onChange = vi.fn();
-    render(
+    renderWithLocale(
       <Basic.Component
         defaultValue={{
           start: new CalendarDate(2019, 6, 5),
@@ -85,21 +86,20 @@ describe('RangeCalendar', () => {
       />
     );
 
-    const cell = screen.getByText('15');
-    await user.click(cell);
+    await user.click(screen.getByLabelText(/Saturday, June 15, 2019/i));
 
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('renders error message when provided', () => {
-    render(<WithError.Component />);
+    renderWithLocale(<WithError.Component />);
 
     expect(screen.getByText(/please select/i)).toBeInTheDocument();
   });
 
   test('blocks dates marked unavailable', async () => {
     const onChange = vi.fn();
-    render(<Unavailable.Component onChange={onChange} />);
+    renderWithLocale(<Unavailable.Component onChange={onChange} />);
 
     const cells = screen.getAllByRole('gridcell');
     const unavailable = cells.find(
@@ -110,35 +110,45 @@ describe('RangeCalendar', () => {
   });
 
   test('opens the month dropdown when the month button is clicked', async () => {
-    render(<Basic.Component />);
+    renderWithLocale(<Basic.Component />);
 
-    expect(screen.queryByTestId('monthOptions')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('listbox', { name: 'monthOptions' })
+    ).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId('month'));
+    await user.click(screen.getByRole('button', { name: 'Aug' }));
 
-    expect(screen.getByTestId('monthOptions')).toBeInTheDocument();
+    expect(
+      screen.getByRole('listbox', { name: 'monthOptions' })
+    ).toBeInTheDocument();
   });
 
   test('opens the year dropdown when the year button is clicked', async () => {
-    render(<Basic.Component />);
+    renderWithLocale(<Basic.Component />);
 
-    expect(screen.queryByTestId('yearOptions')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('listbox', { name: 'yearOptions' })
+    ).not.toBeInTheDocument();
 
-    await user.click(screen.getByTestId('year'));
+    await user.click(screen.getByRole('button', { name: '2025' }));
 
-    expect(screen.getByTestId('yearOptions')).toBeInTheDocument();
+    expect(
+      screen.getByRole('listbox', { name: 'yearOptions' })
+    ).toBeInTheDocument();
   });
 
   test('selecting an option from the month dropdown closes it', async () => {
-    render(<Basic.Component />);
+    renderWithLocale(<Basic.Component />);
 
-    await user.click(screen.getByTestId('month'));
-    const monthOptions = screen.getByTestId('monthOptions');
+    await user.click(screen.getByRole('button', { name: 'Aug' }));
+    const monthOptions = screen.getByRole('listbox', { name: 'monthOptions' });
     const options = within(monthOptions).getAllByRole('option');
 
     await user.click(options[2]);
 
-    expect(screen.queryByTestId('monthOptions')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('listbox', { name: 'monthOptions' })
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -146,7 +156,7 @@ describe('RangeCalendar - Multi-month', () => {
   const user = userEvent.setup();
 
   test('renders two months with visibleDuration', () => {
-    render(<TwoMonths.Component />);
+    renderWithLocale(<TwoMonths.Component />);
 
     const grids = screen.getAllByRole('grid');
     expect(grids).toHaveLength(2);
@@ -157,7 +167,7 @@ describe('RangeCalendar - Multi-month', () => {
   });
 
   test('renders three months with visibleDuration', () => {
-    render(<ThreeMonths.Component />);
+    renderWithLocale(<ThreeMonths.Component />);
 
     const grids = screen.getAllByRole('grid');
     expect(grids).toHaveLength(3);
@@ -169,7 +179,7 @@ describe('RangeCalendar - Multi-month', () => {
   });
 
   test('navigates forward with next button', async () => {
-    render(
+    renderWithLocale(
       <TwoMonths.Component
         defaultValue={{
           start: new CalendarDate(2025, 1, 15),
@@ -182,17 +192,14 @@ describe('RangeCalendar - Multi-month', () => {
     expect(calendar).toHaveTextContent(/January 2025/i);
     expect(calendar).toHaveTextContent(/February 2025/i);
 
-    const buttons = screen.getAllByRole('button');
-    const nextButton = buttons.find(b => b.getAttribute('slot') === 'next');
-    expect(nextButton).toBeDefined();
-    await user.click(nextButton!);
+    await user.click(screen.getAllByRole('button', { name: /next/i })[0]);
 
     expect(calendar).toHaveTextContent(/March 2025/i);
     expect(calendar).toHaveTextContent(/April 2025/i);
   });
 
   test('navigates backward with previous button', async () => {
-    render(
+    renderWithLocale(
       <TwoMonths.Component
         defaultValue={{
           start: new CalendarDate(2025, 3, 15),
@@ -205,10 +212,7 @@ describe('RangeCalendar - Multi-month', () => {
     expect(calendar).toHaveTextContent(/March 2025/i);
     expect(calendar).toHaveTextContent(/April 2025/i);
 
-    const buttons = screen.getAllByRole('button');
-    const prevButton = buttons.find(b => b.getAttribute('slot') === 'previous');
-    expect(prevButton).toBeDefined();
-    await user.click(prevButton!);
+    await user.click(screen.getAllByRole('button', { name: /previous/i })[0]);
 
     expect(calendar).toHaveTextContent(/January 2025/i);
     expect(calendar).toHaveTextContent(/February 2025/i);
@@ -216,7 +220,7 @@ describe('RangeCalendar - Multi-month', () => {
 
   test('selects a range across the second month with two clicks', async () => {
     const onChange = vi.fn();
-    render(
+    renderWithLocale(
       <TwoMonths.Component
         defaultValue={{
           start: new CalendarDate(2025, 2, 15),
@@ -227,26 +231,13 @@ describe('RangeCalendar - Multi-month', () => {
     );
 
     const grids = screen.getAllByRole('grid');
-    const firstGrid = grids[0];
-    const secondGrid = grids[1];
+    const startCell = within(grids[0]).getByLabelText(
+      /Thursday, February 20, 2025/i
+    );
+    const endCell = within(grids[1]).getByLabelText(/Monday, March 10, 2025/i);
 
-    const startCell = within(firstGrid)
-      .getAllByRole('gridcell')
-      .find(
-        cell =>
-          cell.textContent === '20' &&
-          cell.getAttribute('aria-disabled') !== 'true'
-      )!;
-    const endCell = within(secondGrid)
-      .getAllByRole('gridcell')
-      .find(
-        cell =>
-          cell.textContent === '10' &&
-          cell.getAttribute('aria-disabled') !== 'true'
-      )!;
-
-    await user.click(startCell.firstChild as Element);
-    await user.click(endCell.firstChild as Element);
+    await user.click(startCell);
+    await user.click(endCell);
 
     expect(onChange).toHaveBeenCalled();
     const lastCall = onChange.mock.calls.at(-1)?.[0];

--- a/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.test.tsx
@@ -1,14 +1,11 @@
 import { CalendarDate } from '@internationalized/date';
-import { render, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { I18nProvider } from 'react-aria-components';
-import { vi } from 'vitest';
 import {
   Basic,
   ThreeMonths,
   TwoMonths,
-  Unavailable,
   WithError,
 } from './RangeCalendar.stories';
 
@@ -16,8 +13,6 @@ const renderWithLocale = (ui: ReactNode) =>
   render(<I18nProvider locale="en-US">{ui}</I18nProvider>);
 
 describe('RangeCalendar', () => {
-  const user = userEvent.setup();
-
   test('renders with default range value', () => {
     renderWithLocale(
       <Basic.Component
@@ -33,27 +28,6 @@ describe('RangeCalendar', () => {
       .filter(cell => cell.getAttribute('aria-selected') === 'true');
 
     expect(selected.length).toBeGreaterThanOrEqual(2);
-  });
-
-  test('selects a range with two clicks (uncontrolled)', async () => {
-    const onChange = vi.fn();
-    renderWithLocale(
-      <Basic.Component
-        defaultValue={{
-          start: new CalendarDate(2019, 6, 5),
-          end: new CalendarDate(2019, 6, 5),
-        }}
-        onChange={onChange}
-      />
-    );
-
-    await user.click(screen.getByLabelText(/Monday, June 10, 2019/i));
-    await user.click(screen.getByLabelText(/Saturday, June 15, 2019/i));
-
-    expect(onChange).toHaveBeenCalled();
-    const lastCall = onChange.mock.calls.at(-1)?.[0];
-    expect(lastCall.start).toEqual(new CalendarDate(2019, 6, 10));
-    expect(lastCall.end).toEqual(new CalendarDate(2019, 6, 15));
   });
 
   test('marks all cells aria-disabled when disabled', () => {
@@ -73,88 +47,14 @@ describe('RangeCalendar', () => {
     );
   });
 
-  test('does not call onChange when readOnly', async () => {
-    const onChange = vi.fn();
-    renderWithLocale(
-      <Basic.Component
-        defaultValue={{
-          start: new CalendarDate(2019, 6, 5),
-          end: new CalendarDate(2019, 6, 10),
-        }}
-        onChange={onChange}
-        readOnly
-      />
-    );
-
-    await user.click(screen.getByLabelText(/Saturday, June 15, 2019/i));
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
   test('renders error message when provided', () => {
     renderWithLocale(<WithError.Component />);
 
     expect(screen.getByText(/please select/i)).toBeInTheDocument();
   });
-
-  test('blocks dates marked unavailable', async () => {
-    const onChange = vi.fn();
-    renderWithLocale(<Unavailable.Component onChange={onChange} />);
-
-    const cells = screen.getAllByRole('gridcell');
-    const unavailable = cells.find(
-      cell => cell.getAttribute('aria-disabled') === 'true'
-    );
-
-    expect(unavailable).toBeDefined();
-  });
-
-  test('opens the month dropdown when the month button is clicked', async () => {
-    renderWithLocale(<Basic.Component />);
-
-    expect(
-      screen.queryByRole('listbox', { name: 'monthOptions' })
-    ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Aug' }));
-
-    expect(
-      screen.getByRole('listbox', { name: 'monthOptions' })
-    ).toBeInTheDocument();
-  });
-
-  test('opens the year dropdown when the year button is clicked', async () => {
-    renderWithLocale(<Basic.Component />);
-
-    expect(
-      screen.queryByRole('listbox', { name: 'yearOptions' })
-    ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: '2025' }));
-
-    expect(
-      screen.getByRole('listbox', { name: 'yearOptions' })
-    ).toBeInTheDocument();
-  });
-
-  test('selecting an option from the month dropdown closes it', async () => {
-    renderWithLocale(<Basic.Component />);
-
-    await user.click(screen.getByRole('button', { name: 'Aug' }));
-    const monthOptions = screen.getByRole('listbox', { name: 'monthOptions' });
-    const options = within(monthOptions).getAllByRole('option');
-
-    await user.click(options[2]);
-
-    expect(
-      screen.queryByRole('listbox', { name: 'monthOptions' })
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe('RangeCalendar - Multi-month', () => {
-  const user = userEvent.setup();
-
   test('renders two months with visibleDuration', () => {
     renderWithLocale(<TwoMonths.Component />);
 
@@ -176,72 +76,5 @@ describe('RangeCalendar - Multi-month', () => {
     expect(calendar).toHaveTextContent(/May 2025/i);
     expect(calendar).toHaveTextContent(/June 2025/i);
     expect(calendar).toHaveTextContent(/July 2025/i);
-  });
-
-  test('navigates forward with next button', async () => {
-    renderWithLocale(
-      <TwoMonths.Component
-        defaultValue={{
-          start: new CalendarDate(2025, 1, 15),
-          end: new CalendarDate(2025, 1, 20),
-        }}
-      />
-    );
-
-    const calendar = screen.getByRole('application');
-    expect(calendar).toHaveTextContent(/January 2025/i);
-    expect(calendar).toHaveTextContent(/February 2025/i);
-
-    await user.click(screen.getAllByRole('button', { name: /next/i })[0]);
-
-    expect(calendar).toHaveTextContent(/March 2025/i);
-    expect(calendar).toHaveTextContent(/April 2025/i);
-  });
-
-  test('navigates backward with previous button', async () => {
-    renderWithLocale(
-      <TwoMonths.Component
-        defaultValue={{
-          start: new CalendarDate(2025, 3, 15),
-          end: new CalendarDate(2025, 3, 20),
-        }}
-      />
-    );
-
-    const calendar = screen.getByRole('application');
-    expect(calendar).toHaveTextContent(/March 2025/i);
-    expect(calendar).toHaveTextContent(/April 2025/i);
-
-    await user.click(screen.getAllByRole('button', { name: /previous/i })[0]);
-
-    expect(calendar).toHaveTextContent(/January 2025/i);
-    expect(calendar).toHaveTextContent(/February 2025/i);
-  });
-
-  test('selects a range across the second month with two clicks', async () => {
-    const onChange = vi.fn();
-    renderWithLocale(
-      <TwoMonths.Component
-        defaultValue={{
-          start: new CalendarDate(2025, 2, 15),
-          end: new CalendarDate(2025, 2, 15),
-        }}
-        onChange={onChange}
-      />
-    );
-
-    const grids = screen.getAllByRole('grid');
-    const startCell = within(grids[0]).getByLabelText(
-      /Thursday, February 20, 2025/i
-    );
-    const endCell = within(grids[1]).getByLabelText(/Monday, March 10, 2025/i);
-
-    await user.click(startCell);
-    await user.click(endCell);
-
-    expect(onChange).toHaveBeenCalled();
-    const lastCall = onChange.mock.calls.at(-1)?.[0];
-    expect(lastCall.start).toEqual(new CalendarDate(2025, 2, 20));
-    expect(lastCall.end).toEqual(new CalendarDate(2025, 3, 10));
   });
 });

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import {
   RangeCalendar as AriaRangeCalendar,
@@ -132,6 +132,22 @@ const _RangeCalendar = <T extends DateValue>({
     ViewMapKeys | undefined
   >();
 
+  // react-aria's `useRangeCalendar` registers a window-level `pointerup`
+  // listener that commits the in-progress range when the click target is not
+  // a button. RAC's <ListBoxItem> renders with role="option", so picking a
+  // month or year would otherwise trip that commit and drop the user's first
+  // click. Stopping native pointerup propagation on the dropdown overlay
+  // keeps the event from reaching `window` while still letting the option's
+  // own press handler run at the target phase.
+  const dropdownOverlayRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const node = dropdownOverlayRef.current;
+    if (!node) return;
+    const stop = (event: PointerEvent) => event.stopPropagation();
+    node.addEventListener('pointerup', stop);
+    return () => node.removeEventListener('pointerup', stop);
+  }, []);
+
   const ViewMap = {
     month: (
       <MonthListBox
@@ -209,6 +225,7 @@ const _RangeCalendar = <T extends DateValue>({
         {...props}
       >
         <div
+          ref={dropdownOverlayRef}
           className={cn(
             'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
             selectedDropdown && 'pointer-events-auto opacity-100'

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -105,7 +105,7 @@ const _RangeCalendar = <T extends DateValue>({
   pageBehavior = 'visible',
   ...rest
 }: RangeCalendarProps<T>) => {
-  const visibleMonths = visibleDuration?.months ?? 1;
+  const visibleMonths = visibleDuration.months;
   const isMultiMonth = visibleMonths > 1;
 
   const props: RAC.RangeCalendarProps<T> = {

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -1,9 +1,9 @@
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import {
   RangeCalendar as AriaRangeCalendar,
   DateValue,
-  Text,
+  FieldErrorContext,
 } from 'react-aria-components';
 import {
   WidthProp,
@@ -22,6 +22,7 @@ import {
   hasOnlyOneSelectableMonth,
   hasOnlyOneSelectableYear,
 } from '../Calendar/calendarListBoxSelectableCheck';
+import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 
 // Props
 // ---------------
@@ -34,9 +35,10 @@ type RemovedProps =
   | 'className'
   | 'style';
 
-export interface RangeCalendarProps<
-  T extends DateValue = DateValue,
-> extends Omit<RAC.RangeCalendarProps<T>, RemovedProps> {
+export interface RangeCalendarProps<T extends DateValue = DateValue>
+  extends
+    Omit<RAC.RangeCalendarProps<T>, RemovedProps>,
+    Pick<FieldBaseProps<'div'>, 'description' | 'errorMessage'> {
   /**
    * Disables the RangeCalendar.
    * @default false
@@ -51,16 +53,12 @@ export interface RangeCalendarProps<
    * Whether the value is invalid.
    * @default false
    */
-  invalid?: boolean;
+  error?: boolean;
   /**
    * Whether non-contiguous ranges are allowed.
    * @default false
    */
   allowsNonContiguousRanges?: boolean;
-  /**
-   * Error message rendered below the calendar.
-   */
-  errorMessage?: ReactNode;
   variant?: string;
   size?: string;
   /**
@@ -93,9 +91,10 @@ type ViewMapKeys = 'month' | 'year';
 const _RangeCalendar = <T extends DateValue>({
   disabled,
   readOnly,
-  invalid,
+  error,
   allowsNonContiguousRanges,
   errorMessage,
+  description,
   size,
   variant,
   width = 'fit',
@@ -112,7 +111,7 @@ const _RangeCalendar = <T extends DateValue>({
   const props: RAC.RangeCalendarProps<T> = {
     isDisabled: disabled,
     isReadOnly: readOnly,
-    isInvalid: invalid,
+    isInvalid: error,
     isDateUnavailable: dateUnavailable,
     allowsNonContiguousRanges,
     minValue,
@@ -165,46 +164,17 @@ const _RangeCalendar = <T extends DateValue>({
     ),
   } satisfies { [key in ViewMapKeys]: React.JSX.Element };
 
-  if (isMultiMonth) {
-    return (
-      <CalendarContext.Provider
-        value={{
-          classNames,
-          visibleMonths,
-          minValue,
-          maxValue,
-          disabled,
-        }}
-      >
-        <AriaRangeCalendar
-          className={cn(
-            'relative flex flex-col',
-            twWidth[width],
-            classNames.calendar
-          )}
-          {...props}
-        >
-          <div className={classNames.calendarContainer}>
-            {[...Array(visibleMonths).keys()].map(i => (
-              <div key={i} className={classNames.calendarMonth}>
-                <CalendarHeader
-                  monthOffset={i}
-                  showPrevious={i === 0}
-                  showNext={i === visibleMonths - 1}
-                />
-                <CalendarGrid offset={{ months: i }} />
-              </div>
-            ))}
-          </div>
-          {errorMessage ? (
-            <Text slot="errorMessage" className={classNames.errorMessage}>
-              {errorMessage}
-            </Text>
-          ) : null}
-        </AriaRangeCalendar>
-      </CalendarContext.Provider>
-    );
-  }
+  const fieldErrorValue = useMemo(
+    () =>
+      error
+        ? {
+            isInvalid: true,
+            validationErrors: [],
+            validationDetails: {} as ValidityState,
+          }
+        : null,
+    [error]
+  );
 
   return (
     <CalendarContext.Provider
@@ -216,61 +186,78 @@ const _RangeCalendar = <T extends DateValue>({
         disabled,
       }}
     >
-      <AriaRangeCalendar
-        className={cn(
-          'relative flex flex-col',
-          twWidth[width],
-          classNames.calendar
-        )}
-        {...props}
-      >
-        <div
-          ref={dropdownOverlayRef}
-          className={cn(
-            'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
-            selectedDropdown && 'pointer-events-auto opacity-100'
-          )}
+      <FieldErrorContext.Provider value={fieldErrorValue}>
+        <FieldBase
+          as={AriaRangeCalendar}
+          variant={variant}
+          size={size}
+          description={description}
+          errorMessage={errorMessage}
+          isInvalid={error}
+          isDisabled={disabled}
+          className={cn(twWidth[width], classNames.calendar)}
+          {...props}
         >
-          {ViewMap[selectedDropdown as ViewMapKeys]}
-        </div>
-
-        <div
-          className={cn(
-            'flex flex-col',
-            selectedDropdown && 'pointer-events-none opacity-0'
-          )}
-        >
-          <div className="mb-4 flex items-center justify-between">
-            <div className="flex w-fit gap-4">
-              <CalendarListBox
-                key="month"
-                type="month"
-                isDisabled={
-                  hasOnlyOneSelectableMonth(minValue, maxValue) ||
-                  props.isDisabled
-                }
-                setSelectedDropdown={setSelectedDropdown}
-              />
-              <CalendarListBox
-                key="year"
-                type="year"
-                isDisabled={
-                  hasOnlyOneSelectableYear(minValue, maxValue) ||
-                  props.isDisabled
-                }
-                setSelectedDropdown={setSelectedDropdown}
-              />
+          {isMultiMonth ? (
+            <div className={classNames.calendarContainer}>
+              {[...Array(visibleMonths).keys()].map(i => (
+                <div key={i} className={classNames.calendarMonth}>
+                  <CalendarHeader
+                    monthOffset={i}
+                    showPrevious={i === 0}
+                    showNext={i === visibleMonths - 1}
+                  />
+                  <CalendarGrid offset={{ months: i }} />
+                </div>
+              ))}
             </div>
-            <MonthControls />
-          </div>
-          <CalendarGrid />
-        </div>
-        {errorMessage ? (
-          <Text slot="errorMessage" className={classNames.errorMessage}>
-            {errorMessage}
-          </Text>
-        ) : null}
-      </AriaRangeCalendar>
+          ) : (
+            <div className="relative">
+              <div
+                ref={dropdownOverlayRef}
+                className={cn(
+                  'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
+                  selectedDropdown && 'pointer-events-auto opacity-100'
+                )}
+              >
+                {ViewMap[selectedDropdown as ViewMapKeys]}
+              </div>
+
+              <div
+                className={cn(
+                  'flex flex-col',
+                  selectedDropdown && 'pointer-events-none opacity-0'
+                )}
+              >
+                <div className="mb-4 flex items-center justify-between">
+                  <div className="flex w-fit gap-4">
+                    <CalendarListBox
+                      key="month"
+                      type="month"
+                      isDisabled={
+                        hasOnlyOneSelectableMonth(minValue, maxValue) ||
+                        props.isDisabled
+                      }
+                      setSelectedDropdown={setSelectedDropdown}
+                    />
+                    <CalendarListBox
+                      key="year"
+                      type="year"
+                      isDisabled={
+                        hasOnlyOneSelectableYear(minValue, maxValue) ||
+                        props.isDisabled
+                      }
+                      setSelectedDropdown={setSelectedDropdown}
+                    />
+                  </div>
+                  <MonthControls />
+                </div>
+                <CalendarGrid />
+              </div>
+            </div>
+          )}
+        </FieldBase>
+      </FieldErrorContext.Provider>
     </CalendarContext.Provider>
   );
 };

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -1,0 +1,261 @@
+import { type ReactNode, useState } from 'react';
+import type RAC from 'react-aria-components';
+import {
+  RangeCalendar as AriaRangeCalendar,
+  DateValue,
+  Text,
+} from 'react-aria-components';
+import {
+  WidthProp,
+  cn,
+  width as twWidth,
+  useClassNames,
+} from '@marigold/system';
+import { CalendarGrid } from '../Calendar/CalendarGrid';
+import { CalendarHeader } from '../Calendar/CalendarHeader';
+import { CalendarListBox } from '../Calendar/CalendarListBox';
+import { CalendarContext } from '../Calendar/Context';
+import MonthControls from '../Calendar/MonthControls';
+import MonthListBox from '../Calendar/MonthListBox';
+import YearListBox from '../Calendar/YearListBox';
+import {
+  hasOnlyOneSelectableMonth,
+  hasOnlyOneSelectableYear,
+} from '../Calendar/calendarListBoxSelectableCheck';
+
+// Props
+// ---------------
+type RemovedProps =
+  | 'isDateUnavailable'
+  | 'isDisabled'
+  | 'isReadOnly'
+  | 'isInvalid'
+  | 'errorMessage'
+  | 'className'
+  | 'style';
+
+export interface RangeCalendarProps<
+  T extends DateValue = DateValue,
+> extends Omit<RAC.RangeCalendarProps<T>, RemovedProps> {
+  /**
+   * Disables the RangeCalendar.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Whether the calendar value is immutable.
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
+   * Whether the value is invalid.
+   * @default false
+   */
+  invalid?: boolean;
+  /**
+   * Whether non-contiguous ranges are allowed.
+   * @default false
+   */
+  allowsNonContiguousRanges?: boolean;
+  /**
+   * Error message rendered below the calendar.
+   */
+  errorMessage?: ReactNode;
+  variant?: string;
+  size?: string;
+  /**
+   * Sets the width of the calendar. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   * @default fit
+   */
+  width?: WidthProp['width'];
+  /**
+   * Callback that is called for each date of the calendar. If it returns true, then the date is unavailable.
+   */
+  dateUnavailable?: RAC.RangeCalendarProps<T>['isDateUnavailable'];
+  /**
+   * The number of months to display at once. Up to 3 months are supported.
+   * @default { months: 1 }
+   */
+  visibleDuration?: { months: number };
+  /**
+   * Controls how the calendar pages when navigating.
+   * - 'single': Page by one month at a time
+   * - 'visible': Page by the number of visible months
+   * @default 'visible'
+   */
+  pageBehavior?: 'single' | 'visible';
+}
+
+type ViewMapKeys = 'month' | 'year';
+
+// Component
+// ---------------
+const _RangeCalendar = <T extends DateValue>({
+  disabled,
+  readOnly,
+  invalid,
+  allowsNonContiguousRanges,
+  errorMessage,
+  size,
+  variant,
+  width = 'fit',
+  dateUnavailable,
+  minValue,
+  maxValue,
+  visibleDuration = { months: 1 },
+  pageBehavior = 'visible',
+  ...rest
+}: RangeCalendarProps<T>) => {
+  const visibleMonths = visibleDuration?.months ?? 1;
+  const isMultiMonth = visibleMonths > 1;
+
+  const props: RAC.RangeCalendarProps<T> = {
+    isDisabled: disabled,
+    isReadOnly: readOnly,
+    isInvalid: invalid,
+    isDateUnavailable: dateUnavailable,
+    allowsNonContiguousRanges,
+    minValue,
+    maxValue,
+    visibleDuration,
+    pageBehavior,
+    ...rest,
+  };
+
+  const classNames = useClassNames({
+    component: 'RangeCalendar',
+    size,
+    variant,
+  });
+
+  const [selectedDropdown, setSelectedDropdown] = useState<
+    ViewMapKeys | undefined
+  >();
+
+  const ViewMap = {
+    month: (
+      <MonthListBox
+        setSelectedDropdown={setSelectedDropdown}
+        minValue={minValue}
+        maxValue={maxValue}
+      />
+    ),
+    year: (
+      <YearListBox
+        setSelectedDropdown={setSelectedDropdown}
+        minValue={minValue}
+        maxValue={maxValue}
+      />
+    ),
+  } satisfies { [key in ViewMapKeys]: React.JSX.Element };
+
+  if (isMultiMonth) {
+    return (
+      <CalendarContext.Provider
+        value={{
+          classNames,
+          visibleMonths,
+          minValue,
+          maxValue,
+          disabled,
+        }}
+      >
+        <AriaRangeCalendar
+          className={cn(
+            'relative flex flex-col',
+            twWidth[width],
+            classNames.calendar
+          )}
+          {...props}
+        >
+          <div className={classNames.calendarContainer}>
+            {[...Array(visibleMonths).keys()].map(i => (
+              <div key={i} className={classNames.calendarMonth}>
+                <CalendarHeader
+                  monthOffset={i}
+                  showPrevious={i === 0}
+                  showNext={i === visibleMonths - 1}
+                />
+                <CalendarGrid offset={{ months: i }} />
+              </div>
+            ))}
+          </div>
+          {errorMessage ? (
+            <Text slot="errorMessage" className={classNames.errorMessage}>
+              {errorMessage}
+            </Text>
+          ) : null}
+        </AriaRangeCalendar>
+      </CalendarContext.Provider>
+    );
+  }
+
+  return (
+    <CalendarContext.Provider
+      value={{
+        classNames,
+        visibleMonths,
+        minValue,
+        maxValue,
+        disabled,
+      }}
+    >
+      <AriaRangeCalendar
+        className={cn(
+          'relative flex flex-col',
+          twWidth[width],
+          classNames.calendar
+        )}
+        {...props}
+      >
+        <div
+          className={cn(
+            'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
+            selectedDropdown && 'pointer-events-auto opacity-100'
+          )}
+        >
+          {ViewMap[selectedDropdown as ViewMapKeys]}
+        </div>
+
+        <div
+          className={cn(
+            'flex flex-col',
+            selectedDropdown && 'pointer-events-none opacity-0'
+          )}
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex w-fit gap-4">
+              <CalendarListBox
+                key="month"
+                type="month"
+                isDisabled={
+                  hasOnlyOneSelectableMonth(minValue, maxValue) ||
+                  props.isDisabled
+                }
+                setSelectedDropdown={setSelectedDropdown}
+              />
+              <CalendarListBox
+                key="year"
+                type="year"
+                isDisabled={
+                  hasOnlyOneSelectableYear(minValue, maxValue) ||
+                  props.isDisabled
+                }
+                setSelectedDropdown={setSelectedDropdown}
+              />
+            </div>
+            <MonthControls />
+          </div>
+          <CalendarGrid />
+        </div>
+        {errorMessage ? (
+          <Text slot="errorMessage" className={classNames.errorMessage}>
+            {errorMessage}
+          </Text>
+        ) : null}
+      </AriaRangeCalendar>
+    </CalendarContext.Provider>
+  );
+};
+
+export { _RangeCalendar as RangeCalendar };

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -188,74 +188,84 @@ const _RangeCalendar = <T extends DateValue>({
     >
       <FieldErrorContext.Provider value={fieldErrorValue}>
         <FieldBase
-          as={AriaRangeCalendar}
           variant={variant}
           size={size}
+          width={width}
           description={description}
           errorMessage={errorMessage}
           isInvalid={error}
           isDisabled={disabled}
-          className={cn(twWidth[width], classNames.calendar)}
-          {...props}
         >
-          {isMultiMonth ? (
-            <div className={classNames.calendarContainer}>
-              {[...Array(visibleMonths).keys()].map(i => (
-                <div key={i} className={classNames.calendarMonth}>
-                  <CalendarHeader
-                    monthOffset={i}
-                    showPrevious={i === 0}
-                    showNext={i === visibleMonths - 1}
-                  />
-                  <CalendarGrid offset={{ months: i }} />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="relative">
-              <div
-                ref={dropdownOverlayRef}
-                className={cn(
-                  'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
-                  selectedDropdown && 'pointer-events-auto opacity-100'
-                )}
-              >
-                {ViewMap[selectedDropdown as ViewMapKeys]}
-              </div>
-
-              <div
-                className={cn(
-                  'flex flex-col',
-                  selectedDropdown && 'pointer-events-none opacity-0'
-                )}
-              >
-                <div className="mb-4 flex items-center justify-between">
-                  <div className="flex w-fit gap-4">
-                    <CalendarListBox
-                      key="month"
-                      type="month"
-                      isDisabled={
-                        hasOnlyOneSelectableMonth(minValue, maxValue) ||
-                        props.isDisabled
-                      }
-                      setSelectedDropdown={setSelectedDropdown}
+          {/*
+           * RAC's <RangeCalendar> only registers an `errorMessage` slot, so
+           * rendering <FieldBase> as the calendar element would make
+           * <Text slot="description"> from <HelpText> throw "Invalid slot".
+           * Wrapping AriaRangeCalendar as a child keeps the description
+           * outside the calendar's slot context.
+           */}
+          <AriaRangeCalendar
+            {...props}
+            className={cn(twWidth[width], classNames.calendar)}
+          >
+            {isMultiMonth ? (
+              <div className={classNames.calendarContainer}>
+                {[...Array(visibleMonths).keys()].map(i => (
+                  <div key={i} className={classNames.calendarMonth}>
+                    <CalendarHeader
+                      monthOffset={i}
+                      showPrevious={i === 0}
+                      showNext={i === visibleMonths - 1}
                     />
-                    <CalendarListBox
-                      key="year"
-                      type="year"
-                      isDisabled={
-                        hasOnlyOneSelectableYear(minValue, maxValue) ||
-                        props.isDisabled
-                      }
-                      setSelectedDropdown={setSelectedDropdown}
-                    />
+                    <CalendarGrid offset={{ months: i }} />
                   </div>
-                  <MonthControls />
-                </div>
-                <CalendarGrid />
+                ))}
               </div>
-            </div>
-          )}
+            ) : (
+              <div className="relative">
+                <div
+                  ref={dropdownOverlayRef}
+                  className={cn(
+                    'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
+                    selectedDropdown && 'pointer-events-auto opacity-100'
+                  )}
+                >
+                  {ViewMap[selectedDropdown as ViewMapKeys]}
+                </div>
+
+                <div
+                  className={cn(
+                    'flex flex-col',
+                    selectedDropdown && 'pointer-events-none opacity-0'
+                  )}
+                >
+                  <div className="mb-4 flex items-center justify-between">
+                    <div className="flex w-fit gap-4">
+                      <CalendarListBox
+                        key="month"
+                        type="month"
+                        isDisabled={
+                          hasOnlyOneSelectableMonth(minValue, maxValue) ||
+                          props.isDisabled
+                        }
+                        setSelectedDropdown={setSelectedDropdown}
+                      />
+                      <CalendarListBox
+                        key="year"
+                        type="year"
+                        isDisabled={
+                          hasOnlyOneSelectableYear(minValue, maxValue) ||
+                          props.isDisabled
+                        }
+                        setSelectedDropdown={setSelectedDropdown}
+                      />
+                    </div>
+                    <MonthControls />
+                  </div>
+                  <CalendarGrid />
+                </div>
+              </div>
+            )}
+          </AriaRangeCalendar>
         </FieldBase>
       </FieldErrorContext.Provider>
     </CalendarContext.Provider>

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -205,7 +205,11 @@ const _RangeCalendar = <T extends DateValue>({
            */}
           <AriaRangeCalendar
             {...props}
-            className={cn(twWidth[width], classNames.calendar)}
+            className={cn(
+              'relative flex flex-col',
+              twWidth[width],
+              classNames.calendar
+            )}
           >
             {isMultiMonth ? (
               <div className={classNames.calendarContainer}>
@@ -221,7 +225,7 @@ const _RangeCalendar = <T extends DateValue>({
                 ))}
               </div>
             ) : (
-              <div className="relative">
+              <>
                 <div
                   ref={dropdownOverlayRef}
                   className={cn(
@@ -238,7 +242,7 @@ const _RangeCalendar = <T extends DateValue>({
                     selectedDropdown && 'pointer-events-none opacity-0'
                   )}
                 >
-                  <div className="mb-4 flex items-center justify-between">
+                  <div className="mb-6 flex items-center justify-between gap-4">
                     <div className="flex w-fit gap-4">
                       <CalendarListBox
                         key="month"
@@ -263,7 +267,7 @@ const _RangeCalendar = <T extends DateValue>({
                   </div>
                   <CalendarGrid />
                 </div>
-              </div>
+              </>
             )}
           </AriaRangeCalendar>
         </FieldBase>

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ContextType, useCallback, useMemo, useState } from 'react';
 import type RAC from 'react-aria-components';
 import {
   RangeCalendar as AriaRangeCalendar,
@@ -74,17 +74,31 @@ export interface RangeCalendarProps<T extends DateValue = DateValue>
    * The number of months to display at once. Up to 3 months are supported.
    * @default { months: 1 }
    */
-  visibleDuration?: { months: number };
+  visibleDuration?: { months: 1 | 2 | 3 };
   /**
    * Controls how the calendar pages when navigating.
    * - 'single': Page by one month at a time
    * - 'visible': Page by the number of visible months
    * @default 'visible'
    */
-  pageBehavior?: 'single' | 'visible';
+  pageBehavior?: RAC.RangeCalendarProps<T>['pageBehavior'];
 }
 
 type ViewMapKeys = 'month' | 'year';
+
+const EMPTY_VALIDITY_STATE: ValidityState = {
+  badInput: false,
+  customError: false,
+  patternMismatch: false,
+  rangeOverflow: false,
+  rangeUnderflow: false,
+  stepMismatch: false,
+  tooLong: false,
+  tooShort: false,
+  typeMismatch: false,
+  valid: false,
+  valueMissing: false,
+};
 
 // Component
 // ---------------
@@ -135,12 +149,12 @@ const _RangeCalendar = <T extends DateValue>({
   // listener that commits the in-progress range when the click target is not
   // a button. RAC's <ListBoxItem> renders with role="option", so picking a
   // month or year would otherwise trip that commit and drop the user's first
-  // click. Stopping native pointerup propagation on the dropdown overlay
-  // keeps the event from reaching `window` while still letting the option's
-  // own press handler run at the target phase.
-  const dropdownOverlayRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const node = dropdownOverlayRef.current;
+  // click. A native listener is required (not React's `onPointerUpCapture`)
+  // because react-aria's listener also runs on the native event, before any
+  // synthetic event would reach a React capture handler. Using a callback
+  // ref ensures the listener (re)attaches whenever the overlay node mounts,
+  // including when `visibleDuration` toggles single↔multi at runtime.
+  const dropdownOverlayRef = useCallback((node: HTMLDivElement | null) => {
     if (!node) return;
     const stop = (event: PointerEvent) => event.stopPropagation();
     node.addEventListener('pointerup', stop);
@@ -164,13 +178,13 @@ const _RangeCalendar = <T extends DateValue>({
     ),
   } satisfies { [key in ViewMapKeys]: React.JSX.Element };
 
-  const fieldErrorValue = useMemo(
+  const fieldErrorValue = useMemo<ContextType<typeof FieldErrorContext>>(
     () =>
       error
         ? {
             isInvalid: true,
             validationErrors: [],
-            validationDetails: {} as ValidityState,
+            validationDetails: EMPTY_VALIDITY_STATE,
           }
         : null,
     [error]

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -195,6 +195,9 @@ export type { RadioGroupProps } from './Radio/RadioGroup';
 export { Radio } from './Radio/Radio';
 export type { RadioProps } from './Radio/Radio';
 
+export { RangeCalendar } from './RangeCalendar/RangeCalendar';
+export type { RangeCalendarProps } from './RangeCalendar/RangeCalendar';
+
 export { RouterProvider } from './RouterProvider/RouterProvider';
 
 export { Scrollable } from './Scrollable/Scrollable';

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -246,8 +246,7 @@ export type Theme = {
       | 'calendarHeader'
       | 'calendarGrid'
       | 'calendarHeading'
-      | 'select'
-      | 'errorMessage',
+      | 'select',
       ComponentStyleFunction<string, string>
     >;
     DatePicker?: ComponentStyleFunction<string, string>;

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -236,6 +236,20 @@ export type Theme = {
       | 'select',
       ComponentStyleFunction<string, string>
     >;
+    RangeCalendar?: Record<
+      | 'calendar'
+      | 'calendarContainer'
+      | 'calendarMonth'
+      | 'calendarListboxButton'
+      | 'calendarCell'
+      | 'calendarControllers'
+      | 'calendarHeader'
+      | 'calendarGrid'
+      | 'calendarHeading'
+      | 'select'
+      | 'errorMessage',
+      ComponentStyleFunction<string, string>
+    >;
     DatePicker?: ComponentStyleFunction<string, string>;
     ComboBox?: Record<
       'icon' | 'mobileTrigger',

--- a/themes/theme-rui/src/components/Calendar.styles.ts
+++ b/themes/theme-rui/src/components/Calendar.styles.ts
@@ -10,8 +10,8 @@ export const Calendar: ThemeComponent<'Calendar'> = {
       'group-[[role=dialog]]/tray:shadow-none group-[[role=dialog]]/tray:border-0 group-[[role=dialog]]/tray:p-0 group-[[role=dialog]]/tray:place-self-center',
     ],
   }),
-  calendarContainer: cva({ base: 'flex gap-4' }),
-  calendarMonth: cva({ base: 'min-w-[250px] flex-1' }),
+  calendarContainer: cva({ base: 'flex flex-col gap-4 sm:flex-row' }),
+  calendarMonth: cva({ base: 'min-w-[250px] sm:flex-1' }),
   calendarCell: cva({
     base: [
       'relative flex size-9 items-center justify-center whitespace-nowrap rounded-lg justify-self-center',

--- a/themes/theme-rui/src/components/Calendar.styles.ts
+++ b/themes/theme-rui/src/components/Calendar.styles.ts
@@ -1,5 +1,20 @@
 import { ThemeComponent, cva } from '@marigold/system';
 
+// Shared cell classes used by both Calendar and RangeCalendar. Only the
+// cell shape (size/rounding) and the selected-state styling differ between
+// them, so each consumer composes those on top.
+export const calendarCellBase = [
+  'relative flex items-center justify-center whitespace-nowrap justify-self-center',
+  'my-0.5',
+  'border border-transparent p-0 text-sm font-normal text-foreground',
+  'outline-offset-2 duration-150 transition-[color,background-color]',
+  'data-hovered:bg-hover data-hovered:text-foreground',
+  'data-focus-visible:z-10 focus-visible:ui-state-focus outline-none',
+  'disabled:pointer-events-none disabled:opacity-30',
+  'unavailable:pointer-events-none unavailable:opacity-30 unavailable:line-through',
+  'outside-month:hidden',
+];
+
 export const Calendar: ThemeComponent<'Calendar'> = {
   calendar: cva({
     base: [
@@ -14,15 +29,9 @@ export const Calendar: ThemeComponent<'Calendar'> = {
   calendarMonth: cva({ base: 'min-w-[250px] sm:flex-1' }),
   calendarCell: cva({
     base: [
-      'relative flex size-9 items-center justify-center whitespace-nowrap rounded-lg justify-self-center',
-      'border border-transparent p-0 text-sm font-normal text-foreground',
-      'outline-offset-2 duration-150 transition-[color,background-color]',
+      'size-9 rounded-lg',
       'selected:bg-brand selected:text-brand-foreground',
-      'data-hovered:bg-hover data-hovered:text-foreground',
-      'data-focus-visible:z-10 focus-visible:ui-state-focus outline-none',
-      'disabled:pointer-events-none disabled:opacity-30',
-      'unavailable:pointer-events-none unavailable:opacity-30 unavailable:line-through',
-      'outside-month:hidden',
+      ...calendarCellBase,
     ],
   }),
   calendarControllers: cva({
@@ -39,7 +48,7 @@ export const Calendar: ThemeComponent<'Calendar'> = {
     ],
   }),
   calendarGrid: cva({
-    base: '[&_td]:p-1 [&_td]:group-[[role=dialog]]/tray:p-0.75',
+    base: 'border-collapse border-spacing-0 [&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
   }),
   calendarHeading: cva({
     base: 'text-sm font-medium',

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -1,0 +1,71 @@
+import { type ThemeComponent, cva } from '@marigold/system';
+
+export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
+  calendar: cva({
+    base: [
+      'min-h-[350px] ui-surface shadow-elevation-border p-2',
+      'group-data-trigger/popover:shadow-elevation-overlay',
+      'group-[[role=dialog]]/tray:shadow-none group-[[role=dialog]]/tray:border-0 group-[[role=dialog]]/tray:p-0 group-[[role=dialog]]/tray:place-self-center',
+    ],
+  }),
+  calendarContainer: cva({ base: 'flex gap-4' }),
+  calendarMonth: cva({ base: 'min-w-[250px] flex-1' }),
+  calendarCell: cva({
+    base: [
+      'relative flex size-9 items-center justify-center whitespace-nowrap rounded-none justify-self-center',
+      'my-0.5',
+      'border border-transparent p-0 text-sm font-normal text-foreground',
+      'outline-offset-2 duration-150 transition-[color,background-color]',
+      'selected:bg-brand/15 selected:text-foreground',
+      'selection-start:bg-brand selection-start:text-brand-foreground selection-start:rounded-l-lg',
+      'selection-end:bg-brand selection-end:text-brand-foreground selection-end:rounded-r-lg',
+      'data-hovered:bg-hover data-hovered:text-foreground',
+      'data-focus-visible:z-10 focus-visible:ui-state-focus outline-none',
+      'disabled:pointer-events-none disabled:opacity-30',
+      'unavailable:pointer-events-none unavailable:opacity-30 unavailable:line-through',
+      'outside-month:hidden',
+    ],
+  }),
+  calendarControllers: cva({
+    base: [
+      'inline-flex items-center justify-center gap-[0.5ch]',
+      'size-9 rounded-lg',
+      'text-muted-foreground',
+      'focus-visible:ui-state-focus outline-none',
+    ],
+  }),
+  calendarHeader: cva({
+    base: [
+      'size-9 rounded-lg p-0 text-xs font-medium text-muted-foreground text-center',
+    ],
+  }),
+  calendarGrid: cva({
+    base: '[&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
+  }),
+  calendarHeading: cva({
+    base: 'text-sm font-medium',
+  }),
+  calendarListboxButton: cva({
+    base: [
+      'rounded-md text-sm font-medium transition-[color,box-shadow]',
+      'px-4 py-2',
+      'focus-visible:ui-state-focus outline-none',
+      'cursor-pointer',
+      'hover:bg-hover',
+      'aria-selected:bg-brand aria-selected:text-brand-foreground aria-selected:shadow-elevation-border aria-selected:hover:bg-brand/90',
+    ],
+  }),
+  select: cva({
+    base: [
+      '[&svg]:text-muted-foreground',
+      'flex w-full px-3 py-2 rounded-lg shadow-elevation-border border border-input bg-background text-sm text-foreground transition-shadow',
+      'focus-visible:ui-state-focus outline-none',
+      'h-input',
+      'disabled:cursor-not-allowed disabled:text-disabled-foreground disabled:bg-disabled',
+      'cursor-pointer',
+    ],
+  }),
+  errorMessage: cva({
+    base: 'text-error text-xs mt-2',
+  }),
+};

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -12,7 +12,7 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
   calendarMonth: cva({ base: 'min-w-[250px] flex-1' }),
   calendarCell: cva({
     base: [
-      'relative flex size-9 items-center justify-center whitespace-nowrap rounded-none justify-self-center',
+      'relative flex h-9 w-full items-center justify-center whitespace-nowrap rounded-none justify-self-center',
       'my-0.5',
       'border border-transparent p-0 text-sm font-normal text-foreground',
       'outline-offset-2 duration-150 transition-[color,background-color]',
@@ -40,7 +40,7 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
     ],
   }),
   calendarGrid: cva({
-    base: '[&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
+    base: 'border-collapse border-spacing-0 [&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
   }),
   calendarHeading: cva({
     base: 'text-sm font-medium',

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -1,15 +1,8 @@
 import { type ThemeComponent, cva } from '@marigold/system';
+import { Calendar } from './Calendar.styles';
 
 export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
-  calendar: cva({
-    base: [
-      'min-h-[350px] ui-surface shadow-elevation-border p-2',
-      'group-data-trigger/popover:shadow-elevation-overlay',
-      'group-[[role=dialog]]/tray:shadow-none group-[[role=dialog]]/tray:border-0 group-[[role=dialog]]/tray:p-0 group-[[role=dialog]]/tray:place-self-center',
-    ],
-  }),
-  calendarContainer: cva({ base: 'flex gap-4' }),
-  calendarMonth: cva({ base: 'min-w-[250px] flex-1' }),
+  ...Calendar,
   calendarCell: cva({
     base: [
       'relative flex h-9 w-full items-center justify-center whitespace-nowrap rounded-none justify-self-center',
@@ -26,44 +19,8 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
       'outside-month:hidden',
     ],
   }),
-  calendarControllers: cva({
-    base: [
-      'inline-flex items-center justify-center gap-[0.5ch]',
-      'size-9 rounded-lg',
-      'text-muted-foreground',
-      'focus-visible:ui-state-focus outline-none',
-    ],
-  }),
-  calendarHeader: cva({
-    base: [
-      'size-9 rounded-lg p-0 text-xs font-medium text-muted-foreground text-center',
-    ],
-  }),
   calendarGrid: cva({
     base: 'border-collapse border-spacing-0 [&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
-  }),
-  calendarHeading: cva({
-    base: 'text-sm font-medium',
-  }),
-  calendarListboxButton: cva({
-    base: [
-      'rounded-md text-sm font-medium transition-[color,box-shadow]',
-      'px-4 py-2',
-      'focus-visible:ui-state-focus outline-none',
-      'cursor-pointer',
-      'hover:bg-hover',
-      'aria-selected:bg-brand aria-selected:text-brand-foreground aria-selected:shadow-elevation-border aria-selected:hover:bg-brand/90',
-    ],
-  }),
-  select: cva({
-    base: [
-      '[&svg]:text-muted-foreground',
-      'flex w-full px-3 py-2 rounded-lg shadow-elevation-border border border-input bg-background text-sm text-foreground transition-shadow',
-      'focus-visible:ui-state-focus outline-none',
-      'h-input',
-      'disabled:cursor-not-allowed disabled:text-disabled-foreground disabled:bg-disabled',
-      'cursor-pointer',
-    ],
   }),
   errorMessage: cva({
     base: 'text-error text-xs mt-2',

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -22,7 +22,4 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
   calendarGrid: cva({
     base: 'border-collapse border-spacing-0 [&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
   }),
-  errorMessage: cva({
-    base: 'text-error text-xs mt-2',
-  }),
 };

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -9,7 +9,7 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
       'my-0.5',
       'border border-transparent p-0 text-sm font-normal text-foreground',
       'outline-offset-2 duration-150 transition-[color,background-color]',
-      'selected:bg-brand/15 selected:text-foreground',
+      'data-[in-range]:bg-brand/15 data-[in-range]:text-foreground',
       'selection-start:bg-brand selection-start:text-brand-foreground selection-start:rounded-l-lg',
       'selection-end:bg-brand selection-end:text-brand-foreground selection-end:rounded-r-lg',
       'data-hovered:bg-hover data-hovered:text-foreground',

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -1,25 +1,15 @@
 import { type ThemeComponent, cva } from '@marigold/system';
-import { Calendar } from './Calendar.styles';
+import { Calendar, calendarCellBase } from './Calendar.styles';
 
 export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
   ...Calendar,
   calendarCell: cva({
     base: [
-      'relative flex h-9 w-full items-center justify-center whitespace-nowrap rounded-none justify-self-center',
-      'my-0.5',
-      'border border-transparent p-0 text-sm font-normal text-foreground',
-      'outline-offset-2 duration-150 transition-[color,background-color]',
+      'h-9 w-full rounded-none',
       'data-[in-range]:bg-brand/15 data-[in-range]:text-foreground',
       'selection-start:bg-brand selection-start:text-brand-foreground selection-start:rounded-l-lg',
       'selection-end:bg-brand selection-end:text-brand-foreground selection-end:rounded-r-lg',
-      'data-hovered:bg-hover data-hovered:text-foreground',
-      'data-focus-visible:z-10 focus-visible:ui-state-focus outline-none',
-      'disabled:pointer-events-none disabled:opacity-30',
-      'unavailable:pointer-events-none unavailable:opacity-30 unavailable:line-through',
-      'outside-month:hidden',
+      ...calendarCellBase,
     ],
-  }),
-  calendarGrid: cva({
-    base: 'border-collapse border-spacing-0 [&_td]:p-0 [&_td]:group-[[role=dialog]]/tray:p-0',
   }),
 };

--- a/themes/theme-rui/src/components/index.ts
+++ b/themes/theme-rui/src/components/index.ts
@@ -34,6 +34,7 @@ export { Popover } from './Popover.styles';
 export { Radio } from './Radio.styles';
 export { Pagination } from './Pagination.styles';
 export { ProgressCircle } from './ProgressCircle.styles';
+export { RangeCalendar } from './RangeCalendar.styles';
 export { SectionMessage } from './SectionMessage.styles';
 export { Select } from './Select.styles';
 export { SelectList } from './SelectList.styles';


### PR DESCRIPTION
## Summary

> [!CAUTION]
> If we want to give this the Portal Team fast we should cut a release onto main?
 
Adds a new `<RangeCalendar>` for picking a contiguous (or non-contiguous) date range, built on react-aria's `<RangeCalendar>` with Marigold conventions on top.

- **Multi-month layout** — `visibleDuration={{ months: 1 | 2 | 3 }}`. Months stack vertically below the `sm` (640px) breakpoint and flow side-by-side from `sm` upward (also applied to single-month `<Calendar>` for parity).
- **Range visuals** — cells render as a continuous bar between the `selection-start` and `selection-end` (rounded caps, `bg-brand/15` mid-range, hard `bg-brand` on the ends).
- **Form-component parity** — description and error rendering go through `<FieldBase>` so the help/error UI matches `<DateField>`/`<DatePicker>` (TriangleAlert icon + HelpText container). Because react-aria's `<RangeCalendar>` is a picker rather than a form input, the component wraps `FieldBase` in a `FieldErrorContext.Provider` so `HelpText` sees `isInvalid`.
- **Picker dropdown overlays** — month and year selection via listbox dropdowns. Native `pointerup` is stopped at the dropdown overlay so react-aria's window-level commit handler doesn't drop the first click on a `role="option"` ListBoxItem.
- **Shared with Calendar** — reuses `Calendar`'s context, header, grid, and listbox primitives. `RangeCalendar.styles.ts` spreads `Calendar.styles.ts` and overrides only `calendarCell` and `calendarGrid` (the two visual differences). `errorMessage` lives where it's used.
- **Stories** — `Basic`, `Controlled`, `Disabled`, `ReadOnly`, `WithError`, `Unavailable`, `NonContiguous`, `TwoMonths`, `ThreeMonths`, `TwoMonthsMobile`, `ThreeMonthsMobile`, `MultiMonthNavigation`, `WithDescription`. `MultiMonthNavigation` uses `step()` blocks for clearer test reporting.

## Test plan

- [ ] Visit `RangeCalendar/Basic` and select a range across two clicks; the strip renders with rounded caps and a `bg-brand/15` middle.
- [ ] `RangeCalendar/NonContiguous` — click a weekday, then a weekday past a weekend; the range spans the weekend with the unavailable days as gaps.
- [ ] `RangeCalendar/TwoMonthsMobile` and `ThreeMonthsMobile` — months stack vertically; reset the viewport and confirm side-by-side at ≥640px.
- [ ] `RangeCalendar/MultiMonthNavigation` — prev/next paging moves both visible months in lockstep; story tests cover this.
- [ ] `RangeCalendar/WithError` — TriangleAlert icon and message render below the calendar; aria-describedby wiring intact.
- [ ] Open the month or year dropdown and click an option; range selection isn't committed mid-pick.
- [ ] `pnpm typecheck:only` clean.
- [ ] `pnpm test:sb` clean for `Components/Calendar` and `Components/RangeCalendar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)