### PR TITLE
feat(DST-1098): persistent idle sort indicator on Table.Column

### DIFF
--- a/.changeset/table-idle-sort-indicator.md
+++ b/.changeset/table-idle-sort-indicator.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+feat(Table): persistent idle sort indicator on sortable columns
+
+`Table.Column` with `allowsSorting` now shows a Lucide `arrow-down-up` icon when the column is sortable but not currently the active sort column. The active ascending/descending icons (`SortAscending` / `SortDescending`) are unchanged.

--- a/.changeset/table-idle-sort-indicator.md
+++ b/.changeset/table-idle-sort-indicator.md
@@ -1,7 +1,7 @@
 ---
-'@marigold/components': patch
+'@marigold/components': minor
 ---
 
-feat(Table): persistent idle sort indicator on sortable columns
+feat(DST-1098): persistent idle sort indicator on sortable columns
 
 `Table.Column` with `allowsSorting` now shows a Lucide `arrow-down-up` icon when the column is sortable but not currently the active sort column. The active ascending/descending icons (`SortAscending` / `SortDescending`) are unchanged.

--- a/packages/components/src/Table/Table.stories.tsx
+++ b/packages/components/src/Table/Table.stories.tsx
@@ -626,6 +626,11 @@ export const Sorting = meta.story({
       expect(canvas.getByText(/Sort:.*\/ ascending/)).toBeInTheDocument();
     });
 
+    await step('Verify idle sort icon is visible', async () => {
+      const nameHeader = canvas.getByRole('columnheader', { name: /Name/i });
+      expect(nameHeader.querySelector('svg')).toBeInTheDocument();
+    });
+
     await step('Click Name column header to sort', async () => {
       const nameHeader = canvas.getByRole('columnheader', { name: /Name/i });
       await userEvent.click(nameHeader);

--- a/packages/components/src/Table/TableColumn.tsx
+++ b/packages/components/src/Table/TableColumn.tsx
@@ -86,13 +86,9 @@ const TableColumn = ({
         >
           {allowsSorting && (
             <span aria-hidden="true">
-              {sortDirection === 'ascending' ? (
-                <SortAscending size={14} />
-              ) : sortDirection === 'descending' ? (
-                <SortDescending size={14} />
-              ) : (
-                <Sortable size={14} />
-              )}
+              {sortDirection === 'ascending' && <SortAscending size={14} />}
+              {sortDirection === 'descending' && <SortDescending size={14} />}
+              {!sortDirection && <Sortable size={14} />}
             </span>
           )}
           <Group

--- a/packages/components/src/Table/TableColumn.tsx
+++ b/packages/components/src/Table/TableColumn.tsx
@@ -4,6 +4,7 @@ import { Column, Group } from 'react-aria-components';
 import { alignment, cn, textAlign } from '@marigold/system';
 import { SortAscending } from '../icons/SortAscending';
 import { SortDescending } from '../icons/SortDescending';
+import { Sortable } from '../icons/Sortable';
 import { useTableContext } from './Context';
 
 // Helper
@@ -83,12 +84,14 @@ const TableColumn = ({
             alignment.horizontal.alignmentX[alignX]
           )}
         >
-          {allowsSorting && sortDirection != null && (
+          {allowsSorting && (
             <span aria-hidden="true">
               {sortDirection === 'ascending' ? (
                 <SortAscending size={14} />
-              ) : (
+              ) : sortDirection === 'descending' ? (
                 <SortDescending size={14} />
+              ) : (
+                <Sortable size={14} />
               )}
             </span>
           )}

--- a/packages/components/src/icons/Sortable.tsx
+++ b/packages/components/src/icons/Sortable.tsx
@@ -1,0 +1,19 @@
+// From: https://lucide.dev/icons/arrow-down-up
+import { SVG, cn } from '@marigold/system';
+import { IconProps } from './Icons.types';
+
+export const Sortable = ({ size = 24, className, ...props }: IconProps) => (
+  <SVG
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2}
+    className={cn('flex-none shrink-0 stroke-current', className)}
+    {...props}
+  >
+    <path d="M3 16l4 4 4-4M7 20V4M21 8l-4-4-4 4M17 4v16" />
+  </SVG>
+);


### PR DESCRIPTION
# Description

Aligns Marigold's `Table.Column` sort iconography with the Reservix Core System per [DST-1098](https://reservix.atlassian.net/browse/DST-1098). Sortable columns now show a persistent Lucide [`arrow-down-up`](https://lucide.dev/icons/arrow-down-up) indicator when idle, in addition to the existing `SortAscending` / `SortDescending` icons for the active sort state.

- New `Sortable` icon at `packages/components/src/icons/Sortable.tsx` (Lucide `arrow-down-up`), co-located with the existing `SortAscending` / `SortDescending` siblings.
- `TableColumn` renders the idle icon whenever `allowsSorting` is set and `sortDirection` is `null`.
- No public API change — `allowsSorting` was already a passthrough RAC prop.
- A11y unchanged — the icon is `aria-hidden="true"`; sort state is conveyed via the `aria-sort` attribute on `<th>` set by react-aria.

**Note:** the Core System refactor of `css/transform-to-bem.mjs` referenced in the ticket is a separate task in a separate repo and is not part of this PR.

# Test Instructions:

1. `pnpm sb` → open **Components / Table / Sorting** and confirm:
   - All sortable columns (Name, Height, Mass) show the idle `arrow-down-up` icon before any click.
   - Clicking *Name* swaps the idle icon to `SortAscending`; clicking again to `SortDescending`.
   - Clicking *Height* moves the active icon there and *Name* reverts to the idle icon.
2. `pnpm test:sb -t Sorting` — the `Sorting` play function passes (now also asserts the idle icon is rendered before any sort).
3. `pnpm start` → the Table sorting demo at `/components/collection/table` picks up the new icons automatically (no demo changes required).
4. `pnpm typecheck:only && pnpm lint` — both pass.

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1098]: https://reservix.atlassian.net/browse/DST-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ