### PR TITLE
fix(DST-1403): restore list bullets in Do/Don't guideline tiles

### DIFF
--- a/docs/ui/DosAndDonts.tsx
+++ b/docs/ui/DosAndDonts.tsx
@@ -102,7 +102,7 @@ const Guideline = ({
           </p>
         </div>
         {description.length > 0 && (
-          <div className="text-fd-card-foreground text-sm text-pretty">
+          <div className="text-fd-card-foreground text-sm text-pretty [&_li]:mt-0.5 [&_ol]:list-decimal [&_ol]:ps-5 [&_ul]:list-disc [&_ul]:ps-5">
             {description}
           </div>
         )}


### PR DESCRIPTION
# Description

Restore disc bullets and decimal numbering inside `<DoDescription>` / `<DontDescription>` tiles. The regression was introduced by PR #5336 (DST-1348, "redesign Do/Don't guideline cards to match fumadocs"), which moved `not-prose` from the figure-only div to the entire tile wrapper. As a side effect, `@tailwindcss/typography` defaults for the description area were disabled, and `<ul>` / `<ol>` rendered as flat lists. It was easy to miss because every existing tile only had two or three short `<li>` items that read fine as a comma list.

Surfaced during DST-1382 (Drawer docs rewrite), where the new Do/Don't tiles have longer bullet lists.

The fix adds descendant selectors to the description container in `docs/ui/DosAndDonts.tsx`:

```tsx
[&_ul]:list-disc [&_ul]:ps-5
[&_ol]:list-decimal [&_ol]:ps-5
[&_li]:mt-0.5
```

All Do/Don't tiles repo-wide benefit automatically — no MDX changes required.

Jira: [DST-1403](https://reservix.atlassian.net/browse/DST-1403)

# Test Instructions:

1. Open any docs page with a Do/Don't tile that contains a `<ul>` — e.g. `/components/overlay/drawer` once DST-1382 lands, or stage a quick `<ul>` inside an existing tile to verify locally.
2. Confirm bullets render with disc markers, items have a small vertical gap, and existing single-line tiles (no `<ul>`) are visually unchanged.
3. Light/dark mode both unaffected (selectors don't touch color).

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)

> Note on the unchecked boxes: docs UI infrastructure component without unit tests/stories; visual change is in `docs/` (not in VRT scope, which covers `packages/components`).

[DST-1403]: https://reservix.atlassian.net/browse/DST-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ