### PR TITLE
feat([DST-1388]): split prop tables into main, aria and handler groups

### DIFF
--- a/.changeset/split-prop-tables-into-groups.md
+++ b/.changeset/split-prop-tables-into-groups.md
@@ -4,6 +4,6 @@
 
 feat([DST-1388]): split prop tables into main, aria and handler groups
 
-The interactive `<AutoTypeTable>` on each component page now shows the meaningful API props by default and tucks `aria-*` / `role` attributes and React DOM event handlers into separate collapsible sections (e.g. Button drops from 112 visible props to 39 main + 10 aria + 63 handlers). The static markdown pipeline that feeds the LLM/MCP `search_docs` index is intentionally untouched, so machine-readable docs continue to expose the full prop list.
+The interactive Props table (`<AutoTypeTable>`) on each component page now shows the meaningful API props by default and tucks `aria-*` / `role` attributes and React DOM event handlers into separate collapsible sections (e.g. Button drops from 112 visible props to 39 main + 10 aria + 63 handlers). The static markdown pipeline that feeds the LLM/MCP `search_docs` index is intentionally untouched, so machine-readable docs continue to expose the full prop list.
 
 [DST-1388](https://reservix.atlassian.net/browse/DST-1388)

--- a/.changeset/split-prop-tables-into-groups.md
+++ b/.changeset/split-prop-tables-into-groups.md
@@ -1,0 +1,9 @@
+---
+'@marigold/docs': patch
+---
+
+feat([DST-1388]): split prop tables into main, aria and handler groups
+
+The interactive `<AutoTypeTable>` on each component page now shows the meaningful API props by default and tucks `aria-*` / `role` attributes and React DOM event handlers into separate collapsible sections (e.g. Button drops from 112 visible props to 39 main + 10 aria + 63 handlers). The static markdown pipeline that feeds the LLM/MCP `search_docs` index is intentionally untouched, so machine-readable docs continue to expose the full prop list.
+
+[DST-1388](https://reservix.atlassian.net/browse/DST-1388)

--- a/docs/lib/props-filter.ts
+++ b/docs/lib/props-filter.ts
@@ -1,14 +1,14 @@
 import type { DocEntry } from 'fumadocs-typescript';
 
 const EVENT_HANDLER_TYPE =
-  /\b(?:Mouse|Keyboard|Focus|Touch|Pointer|Drag|Animation|Transition|Wheel|Clipboard|Composition|UI|Form|Reaction|Toggle|React)EventHandler\b/;
+  /\b(?:Mouse|Keyboard|Focus|Touch|Pointer|Drag|Animation|Transition|Wheel|Clipboard|Composition|UI|Form|Toggle|React)EventHandler\b/;
 
 const isAriaEntry = (entry: DocEntry): boolean =>
   entry.name.startsWith('aria-') || entry.name === 'role';
 
 const isEventHandlerEntry = (entry: DocEntry): boolean =>
   entry.name.endsWith('Capture') ||
-  EVENT_HANDLER_TYPE.test(entry.simplifiedType ?? entry.type);
+  EVENT_HANDLER_TYPE.test(entry.simplifiedType || entry.type);
 
 const byName = (a: DocEntry, b: DocEntry) => a.name.localeCompare(b.name);
 
@@ -18,12 +18,7 @@ export interface PropEntryGroups {
   handlers: DocEntry[];
 }
 
-const cache = new WeakMap<DocEntry[], PropEntryGroups>();
-
 export const splitPropEntries = (entries: DocEntry[]): PropEntryGroups => {
-  const cached = cache.get(entries);
-  if (cached) return cached;
-
   const groups: PropEntryGroups = { main: [], aria: [], handlers: [] };
   for (const entry of entries) {
     if (isAriaEntry(entry)) groups.aria.push(entry);
@@ -34,6 +29,5 @@ export const splitPropEntries = (entries: DocEntry[]): PropEntryGroups => {
   groups.aria.sort(byName);
   groups.handlers.sort(byName);
 
-  cache.set(entries, groups);
   return groups;
 };

--- a/docs/lib/props-filter.ts
+++ b/docs/lib/props-filter.ts
@@ -1,0 +1,39 @@
+import type { DocEntry } from 'fumadocs-typescript';
+
+const EVENT_HANDLER_TYPE =
+  /\b(?:Mouse|Keyboard|Focus|Touch|Pointer|Drag|Animation|Transition|Wheel|Clipboard|Composition|UI|Form|Reaction|Toggle|React)EventHandler\b/;
+
+const isAriaEntry = (entry: DocEntry): boolean =>
+  entry.name.startsWith('aria-') || entry.name === 'role';
+
+const isEventHandlerEntry = (entry: DocEntry): boolean =>
+  entry.name.endsWith('Capture') ||
+  EVENT_HANDLER_TYPE.test(entry.simplifiedType ?? entry.type);
+
+const byName = (a: DocEntry, b: DocEntry) => a.name.localeCompare(b.name);
+
+export interface PropEntryGroups {
+  main: DocEntry[];
+  aria: DocEntry[];
+  handlers: DocEntry[];
+}
+
+const cache = new WeakMap<DocEntry[], PropEntryGroups>();
+
+export const splitPropEntries = (entries: DocEntry[]): PropEntryGroups => {
+  const cached = cache.get(entries);
+  if (cached) return cached;
+
+  const groups: PropEntryGroups = { main: [], aria: [], handlers: [] };
+  for (const entry of entries) {
+    if (isAriaEntry(entry)) groups.aria.push(entry);
+    else if (isEventHandlerEntry(entry)) groups.handlers.push(entry);
+    else groups.main.push(entry);
+  }
+  groups.main.sort(byName);
+  groups.aria.sort(byName);
+  groups.handlers.sort(byName);
+
+  cache.set(entries, groups);
+  return groups;
+};

--- a/docs/ui/AutoTypeTable.tsx
+++ b/docs/ui/AutoTypeTable.tsx
@@ -1,37 +1,43 @@
-import type { Generator } from 'fumadocs-typescript';
+import type { DocEntry, Generator } from 'fumadocs-typescript';
 import { AutoTypeTable as FumadocsAutoTypeTable } from 'fumadocs-typescript/ui';
+import { ChevronRight } from 'lucide-react';
 import { type Pkg, getPropTable } from '../lib/props-data';
+import { splitPropEntries } from '../lib/props-filter';
 
-// FumadocsAutoTypeTable forwards only `path`/`name`/`type` to its generator,
-// so we encode `package` into `path` as `pkg:rawPath` to carry it through.
-const PATH_PREFIX_SEPARATOR = ':';
-
-const generator: Generator = {
+const makeGenerator = (
+  id: string,
+  name: string,
+  entries: DocEntry[]
+): Generator => ({
   generateDocumentation: async () => {
     throw new Error('AutoTypeTable: generateDocumentation is not used');
   },
-  generateTypeTable: async ({ path, name }) => {
-    if (!path || !name) return [];
-    const sep = path.indexOf(PATH_PREFIX_SEPARATOR);
-    const [pkg, rawPath] =
-      sep !== -1
-        ? [path.slice(0, sep), path.slice(sep + 1)]
-        : ['components', path];
-    const data = getPropTable({
-      path: rawPath,
-      name,
-      package: pkg as Pkg,
-    });
-    if (!data) return [];
-    return [
-      {
-        id: encodeURI(`${rawPath}-${name}`),
-        name,
-        entries: data.entries,
-      },
-    ];
-  },
-};
+  generateTypeTable: async () =>
+    entries.length === 0 ? [] : [{ id, name, entries }],
+});
+
+interface ExtraSectionProps {
+  id: string;
+  name: string;
+  label: string;
+  entries: DocEntry[];
+}
+
+const ExtraSection = ({ id, name, label, entries }: ExtraSectionProps) => (
+  <details className="group my-4">
+    <summary className="text-fd-muted-foreground hover:text-fd-foreground flex cursor-pointer list-none items-center gap-1 text-sm font-medium select-none [&::-webkit-details-marker]:hidden [&::marker]:hidden">
+      <ChevronRight className="size-3.5 shrink-0 transition-transform group-open:rotate-90" />
+      {label} ({entries.length})
+    </summary>
+    <div className="mt-2">
+      <FumadocsAutoTypeTable
+        path=""
+        name={name}
+        generator={makeGenerator(id, name, entries)}
+      />
+    </div>
+  </details>
+);
 
 export interface AutoTypeTableProps {
   path: string;
@@ -43,10 +49,34 @@ export const AutoTypeTable = ({
   path,
   name,
   package: pkg = 'components',
-}: AutoTypeTableProps) => (
-  <FumadocsAutoTypeTable
-    path={`${pkg}${PATH_PREFIX_SEPARATOR}${path}`}
-    name={name}
-    generator={generator}
-  />
-);
+}: AutoTypeTableProps) => {
+  const data = getPropTable({ path, name, package: pkg });
+  const groups = splitPropEntries(data?.entries ?? []);
+  const baseId = encodeURI(`${path}-${name}`);
+
+  return (
+    <>
+      <FumadocsAutoTypeTable
+        path=""
+        name={name}
+        generator={makeGenerator(`${baseId}-main`, name, groups.main)}
+      />
+      {groups.aria.length > 0 && (
+        <ExtraSection
+          id={`${baseId}-aria`}
+          name={name}
+          label="Accessibility props"
+          entries={groups.aria}
+        />
+      )}
+      {groups.handlers.length > 0 && (
+        <ExtraSection
+          id={`${baseId}-handlers`}
+          name={name}
+          label="DOM event handlers"
+          entries={groups.handlers}
+        />
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
# Description

The interactive prop tables on the docs site now show only the meaningful API props by default, with separate collapsible sections for `aria-*` / `role` props and React DOM event handlers (which were previously dwarfing the actual API — Button went from 112 props to 39 main + 10 aria + 63 handlers). The static markdown pipeline that feeds the LLM/MCP search is intentionally untouched so `search_docs` continues to return the full prop list.

# Test Instructions:

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [ ] Marigold docs and Storybook Preview is available
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR)
