### PR TITLE
fix(DST-1406): restore focus outline on virtualized ListBox items

### DIFF
--- a/.changeset/dst-1406-listbox-focus-clipping.md
+++ b/.changeset/dst-1406-listbox-focus-clipping.md
@@ -1,0 +1,5 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1406): restore focus outline on virtualized ListBox items. RAC's virtualizer wrapper sets an inline `z-index: 0` per item, creating a stacking context the option's `focus-visible:z-1` cannot escape — adjacent wrappers paint on top in DOM order and clip the focused outline (most visible when the next item is `selected`). Lift the wrapper containing the focused option above its siblings so the outline is fully visible. Affects all virtualized listboxes (`Select`, `ComboBox`, `Autocomplete`).

--- a/themes/theme-rui/src/components/ListBox.styles.ts
+++ b/themes/theme-rui/src/components/ListBox.styles.ts
@@ -15,7 +15,11 @@ export const ListBox: ThemeComponent<'ListBox'> = {
     ],
   }),
   list: cva({
-    base: ['p-1 text-sm outline-0 space-y-px overflow-y-auto w-full'],
+    base: [
+      'p-1 text-sm outline-0 space-y-px overflow-y-auto w-full',
+      // `!` overrides the inline `z-index: 0` set by RAC's virtualizer wrapper
+      '[&_:has(>:focus-visible)]:z-1!',
+    ],
   }),
   item: cva({
     base: [


### PR DESCRIPTION
## Summary

- Fixes [DST-1406](https://reservix.atlassian.net/browse/DST-1406)
- The focus outline of a keyboard-focused option in `Select` (and other virtualized listboxes — `ComboBox`, `Autocomplete`) is partially clipped at the bottom by adjacent items, most visible when the next option is `selected`.
- RAC's virtualizer wraps each item in a `[role="presentation"]` div with an inline `z-index: 0`, creating a stacking context that the option's existing `focus-visible:z-1` cannot escape. Sibling wrappers paint on top in DOM order and cover the outline.
- Lift the wrapper containing the focused option above its siblings via `[&_:has(>:focus-visible)]:z-1!`. The `!` is required to win over RAC's inline `z-index: 0`.

## Test plan

- [ ] Storybook → `Components/Select` → `Basic`: open trigger (Star Wars preselected), `ArrowUp` to "Lord of the Rings", focus outline is fully visible on all four sides.
- [ ] Same check in `ComboBox` and `Autocomplete` stories — virtualized listboxes share the styles.
- [ ] Non-virtualized listboxes still render focus correctly (no regression).
- [ ] Chromatic VRT passes.

[DST-1406]: https://reservix.atlassian.net/browse/DST-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ