### PR TITLE
fix([DST-1408]): drop position: relative from body in theme-rui preflight

### DIFF
--- a/.changeset/preflight-unposition-body.md
+++ b/.changeset/preflight-unposition-body.md
@@ -2,7 +2,7 @@
 '@marigold/theme-rui': patch
 ---
 
-fix(theme-rui): drop `position: relative` from body in preflight
+fix([DST-1408]): drop `position: relative` from body in theme-rui preflight
 
 `themes/theme-rui/src/preflight.css` previously set
 `body { position: relative; overflow-x: clip }` to contain

--- a/.changeset/preflight-unposition-body.md
+++ b/.changeset/preflight-unposition-body.md
@@ -1,0 +1,33 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(theme-rui): drop `position: relative` from body in preflight
+
+`themes/theme-rui/src/preflight.css` previously set
+`body { position: relative; overflow-x: clip }` to contain
+`@react-aria/live-announcer`'s portal. Empirically that containment
+isn't needed: the live-announcer node is a 1×1 px element with
+`overflow: hidden` and `clip-path: inset(50%)`, so its content cannot
+expand the document's scrollable area in any state — a synthetic
+test toggling `body.position` between `relative` and `static` with
+the announcer mounted produces identical `body.scrollWidth/scrollHeight`.
+
+Meanwhile, `position: relative` on `<body>` makes it the containing
+block for absolute portals (Tooltip, Popover, Menu, Select dropdown).
+React-aria's `useOverlayPosition` then takes a special-case branch
+that adds the page's scroll offset on top of itself when computing
+"available space above the trigger", producing a near-zero number
+even when the viewport has hundreds of pixels of headroom. Every
+overlay with a `top` placement (notably `<Tooltip>`) flips to
+`bottom`, and forcing `placement="top"` positions the overlay far
+off-screen because the same math is broken in both directions.
+
+Removing `position: relative` while keeping `overflow-x: clip`
+restores correct overlay placement without losing the defensive
+horizontal-scroll guard. `clip` does not establish a containing
+block for absolute descendants (per CSS Overflow Module Level 3), so
+the bug cannot reappear from this rule alone — but the file's
+comment now warns that `position`, `transform`, `contain`,
+`filter`, `backdrop-filter`, or `will-change: transform` on `<body>`
+would re-introduce it.

--- a/themes/theme-rui/src/preflight.css
+++ b/themes/theme-rui/src/preflight.css
@@ -1,14 +1,25 @@
 /*
  * Required base rules for Marigold peer dependencies.
  *
- * - `html { scrollbar-gutter: stable }` reserves the scrollbar gutter
- *   so content does not reflow when the document grows past one viewport
+ * - `html { scrollbar-gutter: stable }` reserves the scrollbar gutter so
+ *   content does not reflow when the document grows past one viewport
  *   (or when `@react-aria/overlays` locks the page by setting
  *   `overflow: hidden` on `<html>`).
- * - `body { position: relative; overflow-x: clip }` contains absolutely
- *   positioned portals (e.g. `@react-aria/live-announcer`) so they
- *   cannot expand the document's scrollable area. `clip` (not `hidden`)
- *   keeps `position: sticky` on descendants working.
+ * - `body { overflow-x: clip }` is defensive: prevents accidental
+ *   horizontal scroll if a descendant overflows and keeps a single
+ *   document scroll axis. `clip` (not `hidden`) avoids creating a new
+ *   scroll context that would break `position: sticky` on descendants.
+ *
+ * The body MUST stay a non-positioned, non-transformed, non-contained
+ * element. Any of `position` (other than `static`), `transform`,
+ * `contain: layout|paint|strict|content`, `filter`, `backdrop-filter`, or
+ * `will-change: transform` on the body makes it the containing block for
+ * absolute portals (Tooltip, Popover, Menu, Select dropdown). When that
+ * happens, `@react-aria/overlays`' `useOverlayPosition` takes a code path
+ * that miscomputes available space above the trigger, forcing every
+ * overlay with a `top` placement to flip to `bottom`. If you need a
+ * containing block for a specific subtree, put it on a child element
+ * (and accept that overlays inside that subtree will flip the same way).
  *
  * Shipped as its own file so the rules can ride inside the composed
  * `theme.css` (for Tailwind setups) and the pre-built `styles.css` (for
@@ -21,7 +32,6 @@
   }
 
   body {
-    position: relative;
     overflow-x: clip;
   }
 }


### PR DESCRIPTION
Jira: [DST-1408](https://reservix.atlassian.net/browse/DST-1408)

## Summary

`themes/theme-rui/src/preflight.css` previously set `body { position: relative; overflow-x: clip }` to contain `@react-aria/live-announcer`'s portal. Verification shows the containment is unnecessary, and the rule causes a real overlay placement bug for every consumer of `theme-rui`.

## The bug

`body { position: relative }` makes `<body>` the containing block for absolute portals (Tooltip, Popover, Menu, Select dropdown). React-aria's `useOverlayPosition` ([source](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/overlays/src/calculatePosition.ts)) takes a special-case branch when boundary is `<body>` AND the overlay's containing block is also `<body>`: it computes `containerOffsetWithBoundary.top` as the negation of body's bounding-rect top. With the page scrolled, that value equals the scroll offset, and it gets added on top of the regular scroll handling. The "available space above trigger" calculation comes out as ~0 even when the viewport has hundreds of pixels of headroom, so `shouldFlip` flips every overlay with `placement="top"` (notably `<Tooltip>`) to `bottom`. Forcing `placement="top"` doesn't fix it — the same math positions the overlay far off-screen.

I traced the full math against the live page in `feat/DST-1366-slot-configuration-primitives` and reproduced the flip; setting `body.position = "static"` in the running browser made the tooltip render correctly at top.

## Why the original rationale doesn't hold

The PR that introduced the rule (#5343 on `beta-release`) said live-announcer "portals into document.body at `top: -10000px; left: -10000px`" and would expand body's scrollable area without containment.

Two factual issues:

1. **Live-announcer doesn't use `top: -10000px`.** Current `@react-aria/live-announcer@3.48.0` uses the standard visually-hidden CSS pattern: `width: 1px; height: 1px; clip-path: inset(50%); overflow: hidden; margin: -1px; position: absolute`.
2. **The expansion concern doesn't reproduce.** I synthesized the live-announcer node with massive content (200× a long string) and toggled `body.position` between `relative` and `static`. `body.scrollWidth/scrollHeight` were identical in both states (1512 / 12941 px). The 1×1 + `overflow: hidden` self-contains.

## Counter-questions considered

- **"Move `position: relative` to MarigoldProvider?"** Doesn't help. Live-announcer mounts via `document.body.prepend` outside MarigoldProvider's tree, and any overlay portaled inside a positioned wrapper would hit the same flip bug because the wrapper would become its containing block.
- **"Sticky positioning?"** Unaffected. Sticky cares about the nearest scroll ancestor; `overflow: clip` (vs `hidden`) is what protects sticky descendants, and we keep it.
- **"Could `overflow-x: clip` alone reintroduce the bug?"** No. Per CSS Overflow Module Level 3, `overflow` values do not establish a containing block for `position: absolute`. Only `position`, `transform`, `contain: layout/paint/strict/content`, `filter`, `backdrop-filter`, and `will-change: transform` do.
- **"Anything else relying on body being positioned?"** I greppped the repo — no tests or styles assert it.

## Change

- Drop `position: relative` from the body rule in `preflight.css`.
- Keep `overflow-x: clip` as defensive horizontal-scroll guard.
- Update the file's comment to explain the new reasoning and warn future maintainers that `position`, `transform`, `contain`, `filter`, `backdrop-filter`, or `will-change: transform` on `<body>` would re-introduce the flip bug.

`patch` changeset on `@marigold/theme-rui`.

## Test plan

- [x] `pnpm typecheck:only`
- [x] Synthetic live-announcer test confirms `body.scrollWidth/scrollHeight` unchanged when body becomes `static`
- [x] Tooltip in docs renders at `top` placement when `body.position` is set to `static` in DevTools
- [ ] After merging: verify Tooltip, Menu, ToggleButton tooltips render at `top` placement on real pages
- [ ] After merging: verify Select/Popover dropdowns still position correctly (their default is `bottom`, so should be visually unchanged)
- [ ] After merging: verify modal Drawer/Dialog still position correctly
- [ ] After merging: smoke-test the docs site for any layout regressions

Targets `beta-release` since `preflight.css` only exists on that branch (introduced by #5343 / [DST-1351](https://reservix.atlassian.net/browse/DST-1351)).

[DST-1408]: https://reservix.atlassian.net/browse/DST-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DST-1351]: https://reservix.atlassian.net/browse/DST-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ