### PR TITLE
fix([DST-1410]): restore RangeCalendar build by using createWidthVar

### DIFF
--- a/.changeset/dst-1410-rangecalendar-width-import.md
+++ b/.changeset/dst-1410-rangecalendar-width-import.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix([DST-1410]): restore RangeCalendar build by using `createWidthVar` for the width prop. The component still imported the `width` runtime map from `@marigold/system`, which DST-901 removed when it migrated dimension props to CSS variables. This broke `main` for everyone — typecheck, unit tests, and Storybook tests all failed on every open PR. Apply the same migration pattern Calendar already uses: `w-(--width)` className plus `style={createWidthVar('width', width)}`.
+
+[DST-1410](https://reservix.atlassian.net/browse/DST-1410)

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -5,12 +5,7 @@ import {
   DateValue,
   FieldErrorContext,
 } from 'react-aria-components';
-import {
-  WidthProp,
-  cn,
-  width as twWidth,
-  useClassNames,
-} from '@marigold/system';
+import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
 import { CalendarGrid } from '../Calendar/CalendarGrid';
 import { CalendarHeader } from '../Calendar/CalendarHeader';
 import { CalendarListBox } from '../Calendar/CalendarListBox';
@@ -220,10 +215,10 @@ const _RangeCalendar = <T extends DateValue>({
           <AriaRangeCalendar
             {...props}
             className={cn(
-              'relative flex flex-col',
-              twWidth[width],
+              'relative flex w-(--width) flex-col',
               classNames.calendar
             )}
+            style={createWidthVar('width', width)}
           >
             {isMultiMonth ? (
               <div className={classNames.calendarContainer}>


### PR DESCRIPTION
## Summary

- Fixes [DST-1410](https://reservix.atlassian.net/browse/DST-1410)
- `main` is currently broken — every open PR (e.g. #5397) is showing red Typecheck, Unit Tests, and Storybook Tests:
  ```
  packages/components/src/RangeCalendar/RangeCalendar.tsx(11,3): error TS2305:
    Module '"@marigold/system"' has no exported member 'width'.
  ```
- DST-901 / #5380 removed the `width` runtime map from `@marigold/system` and migrated existing dimension-prop consumers to `createWidthVar` / `createHeightVar`. The new `<RangeCalendar>` component (DST-1134 / #5385) was authored before that landed and still imported `width as twWidth`, so the union of both PRs on `main` doesn't compile.
- This PR applies the same migration pattern that's already in `Calendar.tsx`: drop the `twWidth[width]` className lookup in favor of `w-(--width)` plus `style={createWidthVar('width', width)}` on the same element.
- No behavior change — width tokens still resolve to identical CSS, just via a `--width` custom property instead of a class-name map.

## Test plan

- [x] `pnpm typecheck:only` — passes locally
- [x] `pnpm test:unit` — full suite passes locally (1116 tests across 106 files)
- [ ] CI green on this PR (Typecheck, Unit Tests, Storybook Tests)
- [ ] Verify in Storybook → `Components/RangeCalendar` that the `width` prop still applies (e.g. `width="1/2"`, `width="fit"`)
- [ ] Confirm previously-blocked PR #5397 picks up green CI once this lands and the branch is rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1410]: https://reservix.atlassian.net/browse/DST-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ