### PR TITLE
chore(changeset): downgrade DST-901 @marigold/system bump to minor

### DIFF
--- a/.changeset/dst-901-styleprops-numeric-strings.md
+++ b/.changeset/dst-901-styleprops-numeric-strings.md
@@ -1,5 +1,5 @@
 ---
-'@marigold/system': major
+'@marigold/system': minor
 '@marigold/components': minor
 '@marigold/theme-rui': patch
 ---
@@ -10,4 +10,4 @@ Components that previously resolved `width`, `maxWidth`, and `height` via class-
 
 `createWidthVar` gained support for the previously missing keywords (`svh`, `lvh`, `dvh`, `px`, `container`), and a new `createHeightVar` helper was added. Both share a common factory and a base keyword set, so they remain trivially in sync.
 
-**Breaking** (`@marigold/system`): The runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom` are no longer exported. Use the prop types (`WidthProp`, `HeightProp`, …) and the CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) instead. The corresponding TypeScript prop types are unchanged.
+The runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom` are no longer exported from `@marigold/system`. These were internal utilities consumed only by `@marigold/components`. Use the prop types (`WidthProp`, `HeightProp`, …) and the CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) instead. The corresponding TypeScript prop types are unchanged.


### PR DESCRIPTION
## Summary

- The DST-901 changeset (#5380) bumped `@marigold/system` to **major** because it removed the runtime class-name maps `width`, `maxWidth`, `height`, `gapSpace`, `paddingSpace`, `paddingSpaceX`, `paddingSpaceY`, `paddingRight`, `paddingLeft`, `paddingTop`, `paddingBottom`.
- Those maps were internal utilities consumed only by `@marigold/components` (and one internal `docs/ui/Token.tsx` import, replaced in the same PR). No public API or external consumer depended on them.
- Downgrading `@marigold/system` to **minor** and dropping the "Breaking" framing from the changelog entry.

The corresponding TypeScript prop types (`WidthProp`, `HeightProp`, …) are unchanged, and the new CSS-var helpers (`createWidthVar`, `createHeightVar`, `createSpacingVar`) replace the maps for any downstream that did reach into them.

## Test plan

- [ ] Verify changeset preview reflects `@marigold/system: minor` instead of `major`
- [ ] CI green