### PR TITLE
fix(docs): update filter example to new lucide icon names

### DIFF
--- a/docs/app/(examples)/examples/filter/page.tsx
+++ b/docs/app/(examples)/examples/filter/page.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text,
 } from '@marigold/components';
-import { Add } from '@marigold/icons';
+import { Plus } from '@marigold/icons';
 import { AppliedFilter } from './applied-filter';
 import { Toolbar } from './toolbar';
 import { VenuesTable } from './venues-table';
@@ -24,7 +24,7 @@ const FilterPage = () => (
         </Stack>
         {/* Will be wired up in DST-1288 */}
         <Button disabled>
-          <Add /> Add Venue
+          <Plus /> Add Venue
         </Button>
       </Inline>
       <Panel aria-label="Venues">

--- a/docs/app/(examples)/examples/filter/toolbar.tsx
+++ b/docs/app/(examples)/examples/filter/toolbar.tsx
@@ -15,7 +15,7 @@ import {
   Tag,
   parseFormData,
 } from '@marigold/components';
-import { Filter } from '@marigold/icons';
+import { ListFilter } from '@marigold/icons';
 import {
   MAX_CAPACITY,
   MAX_PRICE,
@@ -130,7 +130,7 @@ export const Toolbar = () => {
         />
         <Drawer.Trigger>
           <Button>
-            <Filter /> Filter
+            <ListFilter /> Filter
           </Button>
           <Drawer closeButton>
             <Form onSubmit={onFilterSubmit} unstyled>

--- a/docs/app/(examples)/examples/filter/venues-table.tsx
+++ b/docs/app/(examples)/examples/filter/venues-table.tsx
@@ -22,7 +22,7 @@ import {
   Text,
   VisuallyHidden,
 } from '@marigold/components';
-import { Delete, Download, Star } from '@marigold/icons';
+import { Download, Star, Trash2 } from '@marigold/icons';
 import { NumericFormat } from '@marigold/system';
 import type { VenueFilter, VenueSortDescriptor } from './utils';
 import { PAGE_SIZE, useFilter, usePage, useSearch, useSort } from './utils';
@@ -208,7 +208,7 @@ export const VenuesTable = () => {
             <ActionBar>
               {/* Will be wired up in DST-1288 */}
               <ActionBar.Button onPress={() => alert('Delete element')}>
-                <Delete /> Delete
+                <Trash2 /> Delete
               </ActionBar.Button>
               <ActionBar.Button
                 onPress={() => exportToCsv(getSelectedVenues(selectedKeys))}


### PR DESCRIPTION
## Summary

- Replace legacy `@marigold/icons` names that were dropped by the lucide-react migration (DST-1213) in the `/examples/filter` pages.
- Without this, the docs build fails on `Add` (no lucide equivalent of that name) and `<Delete />` would render the wrong glyph (lucide's `Delete` is the backspace key, not a trash icon).

| File | Old | New |
| --- | --- | --- |
| `page.tsx` | `Add` | `Plus` |
| `toolbar.tsx` | `Filter` | `ListFilter` |
| `venues-table.tsx` | `Delete` | `Trash2` |

## Test plan

- [ ] `pnpm build:docs` succeeds.
- [ ] `/examples/filter` renders the Plus, ListFilter, and Trash2 glyphs in their respective buttons.