### PR TITLE
chore: restrict /run-chromatic comment trigger to trusted authors

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -27,7 +27,8 @@ jobs:
         (
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
-          contains(github.event.comment.body, '/run-chromatic')
+          contains(github.event.comment.body, '/run-chromatic') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       )
 


### PR DESCRIPTION
## Summary

The `visual-regression-tests.yml` workflow has an `issue_comment` trigger that lets anyone with the ability to comment on a PR run the workflow against the PR's HEAD code, with full access to repository secrets. This PR adds an `author_association` check so only **OWNER**, **MEMBER**, or **COLLABORATOR** comments can trigger it.

## Why this matters

`issue_comment` is in the same trust-boundary category as `pull_request_target`. When it fires:

| Property | Value |
|----------|-------|
| Workflow file source | **Default branch** (trusted) |
| Permissions / secrets | **Full** (`CHROMATIC_PROJECT_TOKEN`, `SLACK_HOOK_DST_REPO_STREAM`) |
| Code being run | **PR HEAD** — `refs/pull/{N}/head` (untrusted) |

Today's gate is only:

```yaml
github.event_name == 'issue_comment' &&
github.event.issue.pull_request &&
contains(github.event.comment.body, '/run-chromatic')
```

There is no check on **who** posts the comment. Concretely, a malicious PR author can:

1. Open a PR that adds a `postinstall` script to any package, or modifies `pnpm build:sb` to do anything they want.
2. Post `/run-chromatic` on their own PR.
3. The workflow runs the malicious code with secret access — exfiltrating the Chromatic token (which could be used to poison visual baselines) and the Slack webhook.

The fact that the workflow runs `pnpm install` and `pnpm build:sb` directly on untrusted code means there's no realistic way to make this trigger safe without restricting who can invoke it.

## The fix

Add an `author_association` allowlist alongside the existing `/run-chromatic` check:

```yaml
contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
```

Author association values come from GitHub itself (not user-controllable). The allowed values mean:

- **OWNER** — the user owns the repo
- **MEMBER** — a member of the organization that owns the repo
- **COLLABORATOR** — has been explicitly granted write access to the repo

Everyone else (`CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, `NONE`) is blocked.

## Background

This is the same class of issue called out in recent supply-chain advisories for OSS maintainers:

> NEVER use `pull_request_target` workflows
> NEVER use shared caches in your publish pipeline

`issue_comment` shares the dangerous property of `pull_request_target`: trusted execution context combined with untrusted code checkout. The mitigation is the same — gate strictly on who is allowed to initiate the run.

## Test plan

- [ ] Maintainer comments `/run-chromatic` on a PR → workflow runs (existing behavior preserved)
- [ ] External contributor comments `/run-chromatic` on their own PR → workflow does **not** run
- [ ] Push to main / merged PR / manual `workflow_dispatch` → workflow still runs (unaffected paths)