### PR TITLE
feat([DST-1429]): align Card padding API with Panel

### DIFF
--- a/.changeset/card-padding-api-align-with-panel.md
+++ b/.changeset/card-padding-api-align-with-panel.md
@@ -1,0 +1,25 @@
+---
+'@marigold/components': minor
+'@marigold/theme-rui': minor
+---
+
+feat([DST-1429]): `Card` now exposes a `Panel`-aligned padding API.
+
+**What changed:**
+
+- `Card` accepts `p` / `px` / `py` props (mutually exclusive `p` vs `px+py`), resolving to CSS custom properties `--card-px` and `--card-py` on the container. Defaults to `square-regular`.
+- A new `space` prop controls the gap between slots, resolving to `--card-gap`. Defaults to `regular`.
+- `Card.Body` and `Card.Footer` accept an opt-in `bleed` prop to skip horizontal padding for tables, media, or full-width action bars.
+- Internally, `Card` switched from CSS grid with `grid-template-areas` to a flex column with `gap-y`. JSX order now determines visual order — place `Card.Preview` first when used.
+- Slot theme styles (`header`, `body`, `footer`) no longer hardcode `px-4` / `py-*`; padding lives in the component layer and is driven by the CSS variables above.
+- `Card.Preview` automatically escapes the container's vertical padding when used as the first or last child via negative margins.
+
+**Why:**
+
+Cards previously had no consumer-controllable padding API and no default padding on the container — content rendered as direct children of `<Card>` was visually broken. The new API mirrors `Panel`'s padding model so the two surfaces behave consistently.
+
+**Migration:**
+
+- Wrap bare children in `<Card.Body>`. Bare children inside `<Card>` are no longer rendered with horizontal padding; this matches `Panel`'s composition contract.
+- If you used `Card.Preview` for media at the top, keep doing so — it stays edge-to-edge.
+- No changes needed for the canonical composition (`Preview` + `Header` + `Body` + `Footer`).

--- a/docs/content/components/actions/toggle-button/togglebutton-favorite.demo.tsx
+++ b/docs/content/components/actions/toggle-button/togglebutton-favorite.demo.tsx
@@ -29,49 +29,51 @@ export default () => {
     <Stack space={3}>
       {venues.slice(0, 3).map(venue => (
         <Card key={venue.id} stretch>
-          <div className="flex gap-4">
-            <img
-              src={venue.image}
-              alt={venue.name}
-              className="size-28 shrink-0 rounded-lg object-cover"
-            />
-            <div className="flex min-w-0 flex-1 flex-col justify-between py-1">
-              <Inline alignX="between" alignY="top" space={3}>
-                <Stack space={0.5}>
-                  <Headline level={4}>{venue.name}</Headline>
-                  <Inline space={1} alignY="center">
-                    <MapPin className="text-secondary-500 size-3.5" />
-                    <Text size="xs">
-                      {venue.city}, {venue.country}
-                    </Text>
-                  </Inline>
-                </Stack>
-                <ToggleButton
-                  size="icon"
-                  selected={favorites.has(venue.id)}
-                  onChange={() => toggle(venue.id)}
-                  aria-label={
-                    favorites.has(venue.id)
-                      ? `Remove ${venue.name} from favorites`
-                      : `Add ${venue.name} to favorites`
-                  }
-                >
-                  <Heart
-                    fill={favorites.has(venue.id) ? 'currentColor' : 'none'}
-                  />
-                </ToggleButton>
-              </Inline>
-              <Inline space={2}>
-                <Badge>{venueTypes[venue.type]}</Badge>
-                <Badge>
-                  <Inline space={1} alignY="center">
-                    <Users className="size-3" />
-                    {venue.capacity}
-                  </Inline>
-                </Badge>
-              </Inline>
+          <Card.Body>
+            <div className="flex gap-4">
+              <img
+                src={venue.image}
+                alt={venue.name}
+                className="size-28 shrink-0 rounded-lg object-cover"
+              />
+              <div className="flex min-w-0 flex-1 flex-col justify-between py-1">
+                <Inline alignX="between" alignY="top" space={3}>
+                  <Stack space={0.5}>
+                    <Headline level={4}>{venue.name}</Headline>
+                    <Inline space={1} alignY="center">
+                      <MapPin className="text-secondary-500 size-3.5" />
+                      <Text size="xs">
+                        {venue.city}, {venue.country}
+                      </Text>
+                    </Inline>
+                  </Stack>
+                  <ToggleButton
+                    size="icon"
+                    selected={favorites.has(venue.id)}
+                    onChange={() => toggle(venue.id)}
+                    aria-label={
+                      favorites.has(venue.id)
+                        ? `Remove ${venue.name} from favorites`
+                        : `Add ${venue.name} to favorites`
+                    }
+                  >
+                    <Heart
+                      fill={favorites.has(venue.id) ? 'currentColor' : 'none'}
+                    />
+                  </ToggleButton>
+                </Inline>
+                <Inline space={2}>
+                  <Badge>{venueTypes[venue.type]}</Badge>
+                  <Badge>
+                    <Inline space={1} alignY="center">
+                      <Users className="size-3" />
+                      {venue.capacity}
+                    </Inline>
+                  </Badge>
+                </Inline>
+              </div>
             </div>
-          </div>
+          </Card.Body>
         </Card>
       ))}
     </Stack>

--- a/docs/content/components/actions/toggle-button/togglebutton-filter.demo.tsx
+++ b/docs/content/components/actions/toggle-button/togglebutton-filter.demo.tsx
@@ -45,29 +45,33 @@ export default () => {
       <Tiles tilesWidth="200px" space={3} stretch>
         {filtered.map(venue => (
           <Card key={venue.id} stretch>
-            <Stack space={2}>
+            <Card.Preview>
               <img
                 src={venue.image}
                 alt={venue.name}
-                className="h-28 w-full rounded-lg object-cover"
+                className="h-28 w-full object-cover"
               />
-              <Stack space={1}>
-                <Headline level={4}>{venue.name}</Headline>
-                <Inline space={1} alignY="center">
-                  <MapPin className="text-secondary-500 size-3.5 shrink-0" />
-                  <Text size="xs">{venue.city}</Text>
+            </Card.Preview>
+            <Card.Body>
+              <Stack space={2}>
+                <Stack space={1}>
+                  <Headline level={4}>{venue.name}</Headline>
+                  <Inline space={1} alignY="center">
+                    <MapPin className="text-secondary-500 size-3.5 shrink-0" />
+                    <Text size="xs">{venue.city}</Text>
+                  </Inline>
+                </Stack>
+                <Inline space={2}>
+                  <Badge>{venueTypes[venue.type]}</Badge>
+                  <Badge>
+                    <Inline space={1} alignY="center">
+                      <Users className="size-3" />
+                      {venue.capacity}
+                    </Inline>
+                  </Badge>
                 </Inline>
               </Stack>
-              <Inline space={2}>
-                <Badge>{venueTypes[venue.type]}</Badge>
-                <Badge>
-                  <Inline space={1} alignY="center">
-                    <Users className="size-3" />
-                    {venue.capacity}
-                  </Inline>
-                </Badge>
-              </Inline>
-            </Stack>
+            </Card.Body>
           </Card>
         ))}
       </Tiles>

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -38,7 +38,7 @@ The Card component supports variants for general content grouping as well as acc
 
 The `<Card>` component enhances the visual hierarchy and organization of content, making it easier for users to engage with various pieces of information.
 
-Cards use a compound component pattern, you compose the card layout using the provided sub-components. Not all slots need to be used: combine only the ones relevant to your content.
+Cards use a compound component pattern, you compose the card layout using the provided sub-components. `Card.Body` is the minimum for any non-preview content — bare children inside `<Card>` get no horizontal padding. `Card.Header`, `Card.Footer`, and `Card.Preview` are optional and combine on top of `Card.Body` as needed.
 
 ### Card.Preview
 
@@ -117,6 +117,41 @@ The following example shows a typical card composition using all available slots
     </DontDescription>
   </Dont>
 </GuidelineTiles>
+
+### Spacing and padding
+
+Card controls two kinds of spacing — the padding applied to its slots, and the gap between slots. The defaults suit most card layouts. Reach for the overrides when a card is unusually dense or unusually roomy.
+
+#### Padding
+
+Every slot is inset with `p="square-regular"`, mirroring `Panel`. Use `square-loose` for cards that hold long prose or stand alone on the page, and `px`/`py` to control the axes separately when uniform padding feels off.
+
+```tsx
+<Card p="square-loose">…</Card>
+<Card px="padding-relaxed" py="padding-snug">…</Card>
+```
+
+#### Slot gap
+
+`space` controls the vertical gap between `Preview`, `Header`, `Body`, and `Footer`. Default `regular` works almost everywhere. Drop to `tight` when the slots should read as one dense surface, or step up to `group` when the card carries several distinct blocks that need more breathing room.
+
+```tsx
+<Card space="tight">…</Card>
+<Card space="group">…</Card>
+```
+
+#### Bleed
+
+`Card.Body` and `Card.Footer` accept a `bleed` prop that skips the card's horizontal padding for that slot. Use it for tables, media, or full-width action bars that should reach the card's edges.
+
+```tsx
+<Card>
+  <Card.Header>Pricing</Card.Header>
+  <Card.Body bleed>
+    <Table>…</Table>
+  </Card.Body>
+</Card>
+```
 
 ## Props
 

--- a/docs/content/components/content/loader/loader-section.demo.tsx
+++ b/docs/content/components/content/loader/loader-section.demo.tsx
@@ -54,26 +54,28 @@ const Venues = () => {
       <Stack space={2}>
         {data.map(v => (
           <Card key={v.id}>
-            <Aside sideWidth="160px" space={8}>
-              <img alt="" src={v.image} />
-              <Stack
-                space={6}
-                id="venueDetails"
-                role="region"
-                aria-live="polite"
-              >
-                <Stack>
-                  <Text weight="extrabold" fontSize="2xl">
-                    {v.name}
-                  </Text>
-                  <Text fontStyle="italic">{v.type}</Text>
+            <Card.Body>
+              <Aside sideWidth="160px" space={8}>
+                <img alt="" src={v.image} />
+                <Stack
+                  space={6}
+                  id="venueDetails"
+                  role="region"
+                  aria-live="polite"
+                >
+                  <Stack>
+                    <Text weight="extrabold" fontSize="2xl">
+                      {v.name}
+                    </Text>
+                    <Text fontStyle="italic">{v.type}</Text>
+                  </Stack>
+                  <Stack>
+                    <Text weight="bold">Description</Text>
+                    <Text>{v.description}</Text>
+                  </Stack>
                 </Stack>
-                <Stack>
-                  <Text weight="bold">Description</Text>
-                  <Text>{v.description}</Text>
-                </Stack>
-              </Stack>
-            </Aside>
+              </Aside>
+            </Card.Body>
           </Card>
         ))}
       </Stack>

--- a/docs/content/components/form/switch/switch-card.demo.tsx
+++ b/docs/content/components/form/switch/switch-card.demo.tsx
@@ -3,29 +3,33 @@ import { Badge, Card, Inline, Stack, Switch, Text } from '@marigold/components';
 export default () => (
   <Stack space={4}>
     <Card stretch>
-      <Inline alignY="center" space={4}>
-        <Stack space="tight" stretch>
-          <Inline space={2} alignY="center">
-            <Text weight="bold">Weekly digest</Text>
-            <Badge variant="success">Active</Badge>
-          </Inline>
-          <Text variant="muted" size="sm">
-            A summary of activity from the past week, delivered every Monday.
-          </Text>
-        </Stack>
-        <Switch label="Active" defaultSelected />
-      </Inline>
+      <Card.Body>
+        <Inline alignY="center" space={4}>
+          <Stack space="tight" stretch>
+            <Inline space={2} alignY="center">
+              <Text weight="bold">Weekly digest</Text>
+              <Badge variant="success">Active</Badge>
+            </Inline>
+            <Text variant="muted" size="sm">
+              A summary of activity from the past week, delivered every Monday.
+            </Text>
+          </Stack>
+          <Switch label="Active" defaultSelected />
+        </Inline>
+      </Card.Body>
     </Card>
     <Card stretch>
-      <Inline alignY="center" space={4}>
-        <Stack space="tight" stretch>
-          <Text weight="bold">Slack integration</Text>
-          <Text variant="muted" size="sm">
-            Post updates to your team's Slack channel automatically.
-          </Text>
-        </Stack>
-        <Switch label="Active" />
-      </Inline>
+      <Card.Body>
+        <Inline alignY="center" space={4}>
+          <Stack space="tight" stretch>
+            <Text weight="bold">Slack integration</Text>
+            <Text variant="muted" size="sm">
+              Post updates to your team's Slack channel automatically.
+            </Text>
+          </Stack>
+          <Switch label="Active" />
+        </Inline>
+      </Card.Body>
     </Card>
   </Stack>
 );

--- a/docs/content/components/layout/tiles/tiles-autoRows.demo.tsx
+++ b/docs/content/components/layout/tiles/tiles-autoRows.demo.tsx
@@ -4,14 +4,20 @@ import { Rectangle } from '@/ui/Rectangle';
 export default () => (
   <Tiles space={1} tilesWidth="200px" equalHeight>
     <Card>
-      <Rectangle height="100px" />
+      <Card.Body>
+        <Rectangle height="100px" />
+      </Card.Body>
     </Card>
     <Card>
-      <Rectangle height="100px" />
-      <Rectangle height="100px" />
+      <Card.Body>
+        <Rectangle height="100px" />
+        <Rectangle height="100px" />
+      </Card.Body>
     </Card>
     <Card>
-      <Rectangle height="100px" />
+      <Card.Body>
+        <Rectangle height="100px" />
+      </Card.Body>
     </Card>
   </Tiles>
 );

--- a/docs/content/components/overlay/drawer/drawer-comments-activity.demo.tsx
+++ b/docs/content/components/overlay/drawer/drawer-comments-activity.demo.tsx
@@ -14,72 +14,74 @@ import type { DrawerProps } from '@marigold/components';
 export default function (props: DrawerProps) {
   return (
     <Card>
-      <Stack space="regular">
+      <Card.Body>
         <Stack space="regular">
-          <Inline space="related" alignY="center">
-            <Headline level={3}>Ticket #4521 – Login issue</Headline>
-            <Badge variant="warning">High priority</Badge>
+          <Stack space="regular">
+            <Inline space="related" alignY="center">
+              <Headline level={3}>Ticket #4521 – Login issue</Headline>
+              <Badge variant="warning">High priority</Badge>
+            </Inline>
+            <Text>
+              User reports being unable to log in after the latest update.
+              Error: <em>"Invalid session token."</em>
+            </Text>
+            <Text>
+              Assigned to <strong>Jane Doe</strong> · Updated 2 hours ago
+            </Text>
+          </Stack>
+
+          <Inline>
+            <Drawer.Trigger>
+              <Button variant="secondary">View activity (3)</Button>
+              <Drawer {...props} size="medium">
+                <Drawer.Title>Activity · Ticket #4521</Drawer.Title>
+                <Drawer.Content>
+                  <Stack space="group">
+                    <Stack space="tight">
+                      <Inline space="related" alignY="center">
+                        <Text weight="bold">Jane Doe</Text>
+                        <Text>changed status to Open</Text>
+                      </Inline>
+                      <Text>2 hours ago</Text>
+                    </Stack>
+
+                    <Stack space="tight">
+                      <Inline space="related" alignY="center">
+                        <Text weight="bold">Sam Müller</Text>
+                        <Text>commented</Text>
+                      </Inline>
+                      <Text>
+                        Customer reset their password but is still locked out.
+                        Asked them to clear cookies and try again.
+                      </Text>
+                      <Text>4 hours ago</Text>
+                    </Stack>
+
+                    <Stack space="tight">
+                      <Inline space="related" alignY="center">
+                        <Text weight="bold">Jane Doe</Text>
+                        <Text>assigned to Sam Müller</Text>
+                      </Inline>
+                      <Text>Yesterday</Text>
+                    </Stack>
+
+                    <TextField
+                      label="Add a comment"
+                      placeholder="Write a reply…"
+                    />
+                  </Stack>
+                </Drawer.Content>
+                <Drawer.Actions>
+                  <Button slot="close">Close</Button>
+                  <Button slot="close" variant="primary">
+                    Post comment
+                  </Button>
+                </Drawer.Actions>
+              </Drawer>
+            </Drawer.Trigger>
           </Inline>
-          <Text>
-            User reports being unable to log in after the latest update. Error:{' '}
-            <em>"Invalid session token."</em>
-          </Text>
-          <Text>
-            Assigned to <strong>Jane Doe</strong> · Updated 2 hours ago
-          </Text>
         </Stack>
-
-        <Inline>
-          <Drawer.Trigger>
-            <Button variant="secondary">View activity (3)</Button>
-            <Drawer {...props} size="medium">
-              <Drawer.Title>Activity · Ticket #4521</Drawer.Title>
-              <Drawer.Content>
-                <Stack space="group">
-                  <Stack space="tight">
-                    <Inline space="related" alignY="center">
-                      <Text weight="bold">Jane Doe</Text>
-                      <Text>changed status to Open</Text>
-                    </Inline>
-                    <Text>2 hours ago</Text>
-                  </Stack>
-
-                  <Stack space="tight">
-                    <Inline space="related" alignY="center">
-                      <Text weight="bold">Sam Müller</Text>
-                      <Text>commented</Text>
-                    </Inline>
-                    <Text>
-                      Customer reset their password but is still locked out.
-                      Asked them to clear cookies and try again.
-                    </Text>
-                    <Text>4 hours ago</Text>
-                  </Stack>
-
-                  <Stack space="tight">
-                    <Inline space="related" alignY="center">
-                      <Text weight="bold">Jane Doe</Text>
-                      <Text>assigned to Sam Müller</Text>
-                    </Inline>
-                    <Text>Yesterday</Text>
-                  </Stack>
-
-                  <TextField
-                    label="Add a comment"
-                    placeholder="Write a reply…"
-                  />
-                </Stack>
-              </Drawer.Content>
-              <Drawer.Actions>
-                <Button slot="close">Close</Button>
-                <Button slot="close" variant="primary">
-                  Post comment
-                </Button>
-              </Drawer.Actions>
-            </Drawer>
-          </Drawer.Trigger>
-        </Inline>
-      </Stack>
+      </Card.Body>
     </Card>
   );
 }

--- a/docs/content/foundations/elevation/elevation-raised.demo.tsx
+++ b/docs/content/foundations/elevation/elevation-raised.demo.tsx
@@ -4,16 +4,22 @@ export default () => (
   <div className="bg-background rounded-xl p-8">
     <Tiles space={4} tilesWidth="200px" stretch equalHeight>
       <Card stretch>
-        <Headline level={4}>Tickets sold</Headline>
-        <Text>1.240</Text>
+        <Card.Body>
+          <Headline level={4}>Tickets sold</Headline>
+          <Text>1.240</Text>
+        </Card.Body>
       </Card>
       <Card stretch>
-        <Headline level={4}>Revenue</Headline>
-        <Text>38.120 EUR</Text>
+        <Card.Body>
+          <Headline level={4}>Revenue</Headline>
+          <Text>38.120 EUR</Text>
+        </Card.Body>
       </Card>
       <Card stretch>
-        <Headline level={4}>Events</Headline>
-        <Text>12 upcoming</Text>
+        <Card.Body>
+          <Headline level={4}>Events</Headline>
+          <Text>12 upcoming</Text>
+        </Card.Body>
       </Card>
     </Tiles>
   </div>

--- a/docs/content/patterns/layout/admin-master-mark/admin-master-mark-placement.demo.tsx
+++ b/docs/content/patterns/layout/admin-master-mark/admin-master-mark-placement.demo.tsx
@@ -37,32 +37,36 @@ export default () => (
           <Select.Option id="freelancer">Freelancer</Select.Option>
         </Select>
         <Card variant="master">
-          <Select
-            label={
-              <>
-                Associated Team <Badge variant="master">Master</Badge>
-              </>
-            }
-            width={56}
-            description="Select the team responsible for this organizer."
-            defaultSelectedKey={'regional'}
-          >
-            <Select.Option id="inbound">Inbound Sales</Select.Option>
-            <Select.Option id="outbound">Outbound Sales</Select.Option>
-            <Select.Option id="keyaccounts">Key Accounts</Select.Option>
-            <Select.Option id="regional">Regional Sales</Select.Option>
-          </Select>
+          <Card.Body>
+            <Select
+              label={
+                <>
+                  Associated Team <Badge variant="master">Master</Badge>
+                </>
+              }
+              width={56}
+              description="Select the team responsible for this organizer."
+              defaultSelectedKey={'regional'}
+            >
+              <Select.Option id="inbound">Inbound Sales</Select.Option>
+              <Select.Option id="outbound">Outbound Sales</Select.Option>
+              <Select.Option id="keyaccounts">Key Accounts</Select.Option>
+              <Select.Option id="regional">Regional Sales</Select.Option>
+            </Select>
+          </Card.Body>
         </Card>
         <Card variant="admin">
-          <Checkbox
-            label={
-              <>
-                Enable Diagnostics <Badge variant="admin">Admin</Badge>
-              </>
-            }
-            description="Allow system diagnostics and data collection for this organizer to improve service quality."
-            defaultChecked
-          />
+          <Card.Body>
+            <Checkbox
+              label={
+                <>
+                  Enable Diagnostics <Badge variant="admin">Admin</Badge>
+                </>
+              }
+              description="Allow system diagnostics and data collection for this organizer to improve service quality."
+              defaultChecked
+            />
+          </Card.Body>
         </Card>
       </Stack>
     </Tabs.TabPanel>

--- a/packages/components/src/Card/Card.stories.tsx
+++ b/packages/components/src/Card/Card.stories.tsx
@@ -100,6 +100,94 @@ export const Stretch = meta.story({
   ),
 });
 
+export const WithPaddingProp = meta.story({
+  args: {
+    p: 'square-loose',
+  },
+  argTypes: {
+    p: {
+      control: { type: 'select' },
+      options: [
+        'square-tight',
+        'square-snug',
+        'square-regular',
+        'square-relaxed',
+        'square-loose',
+      ],
+      description:
+        'Inset recipe applied uniformly. Resolves --card-px and --card-py.',
+    },
+  },
+  render: args => (
+    <Card {...args}>
+      <Card.Header>Custom Padding</Card.Header>
+      <Card.Body>
+        <Text>
+          This card uses the `p` prop to set inset padding. Use Storybook
+          controls to try different values.
+        </Text>
+      </Card.Body>
+    </Card>
+  ),
+});
+
+export const WithBleedBody = meta.story({
+  render: args => (
+    <Card {...args}>
+      <Card.Header>Bleed Body</Card.Header>
+      <Card.Body bleed>
+        <div className="bg-info/10 border-info-accent border-y px-4 py-3">
+          Edge-to-edge banner — spans the full card width.
+        </div>
+      </Card.Body>
+      <Card.Footer>
+        <Button variant="primary">Action</Button>
+      </Card.Footer>
+    </Card>
+  ),
+});
+
+export const WithBleedFooter = meta.story({
+  render: args => (
+    <Card {...args}>
+      <Card.Header>Bleed Footer</Card.Header>
+      <Card.Body>
+        <Text>The footer below uses `bleed` to span the full card width.</Text>
+      </Card.Body>
+      <Card.Footer bleed>
+        <div className="flex w-full justify-center border-t py-3">
+          <Button variant="primary">Full-width action</Button>
+        </div>
+      </Card.Footer>
+    </Card>
+  ),
+});
+
+/**
+ * Anti-pattern: rendering bare children inside `<Card>` is unsupported.
+ * Content will have no horizontal padding. Wrap content in `Card.Body` instead.
+ */
+export const BareChildrenAntiPattern = meta.story({
+  render: args => (
+    <Stack space={4}>
+      <Card {...args}>
+        <Text>
+          <strong>Don&apos;t do this:</strong> bare text inside `&lt;Card&gt;`
+          has no horizontal padding.
+        </Text>
+      </Card>
+      <Card {...args}>
+        <Card.Body>
+          <Text>
+            <strong>Do this:</strong> wrap content in `Card.Body` to get proper
+            padding.
+          </Text>
+        </Card.Body>
+      </Card>
+    </Stack>
+  ),
+});
+
 export const MasterAndAdmin = meta.story({
   render: args => (
     <Stack space={5}>

--- a/packages/components/src/Card/Card.test.tsx
+++ b/packages/components/src/Card/Card.test.tsx
@@ -1,5 +1,14 @@
+/* eslint-disable testing-library/no-node-access */
 import { render, screen } from '@testing-library/react';
-import { Basic, MasterAndAdmin, Stretch, WithFooter } from './Card.stories';
+import {
+  Basic,
+  MasterAndAdmin,
+  Stretch,
+  WithBleedBody,
+  WithBleedFooter,
+  WithFooter,
+  WithPreview,
+} from './Card.stories';
 
 describe('Card', () => {
   describe('Rendering', () => {
@@ -30,12 +39,13 @@ describe('Card', () => {
   });
 
   describe('Layout', () => {
-    test('uses grid display with w-fit by default', () => {
+    test('uses flex column with w-fit by default', () => {
       render(<Basic.Component data-testid="card" />);
 
       const card = screen.getByTestId('card');
 
-      expect(card).toHaveClass('grid');
+      expect(card).toHaveClass('flex');
+      expect(card).toHaveClass('flex-col');
       expect(card).toHaveClass('w-fit');
     });
 
@@ -44,16 +54,120 @@ describe('Card', () => {
 
       const card = screen.getByTestId('card');
 
-      expect(card).toHaveClass('grid');
+      expect(card).toHaveClass('flex');
       expect(card).not.toHaveClass('w-fit');
     });
+  });
 
-    test('uses grid-template-areas for ordering', () => {
+  describe('Padding props (--card-px / --card-py / --card-gap)', () => {
+    test('sets default spacing variables on the container', () => {
       render(<Basic.Component data-testid="card" />);
 
       const card = screen.getByTestId('card');
 
-      expect(card.className).toContain('grid-template-areas');
+      expect(card.style.getPropertyValue('--card-px')).toBe(
+        'var(--spacing-square-regular-x)'
+      );
+      expect(card.style.getPropertyValue('--card-py')).toBe(
+        'var(--spacing-square-regular-y)'
+      );
+      expect(card.style.getPropertyValue('--card-gap')).toBe(
+        'var(--spacing-regular)'
+      );
+    });
+
+    test('`p` recipe drives both --card-px and --card-py', () => {
+      render(<Basic.Component p="square-relaxed" data-testid="card" />);
+
+      const card = screen.getByTestId('card');
+
+      expect(card.style.getPropertyValue('--card-px')).toBe(
+        'var(--spacing-square-relaxed-x)'
+      );
+      expect(card.style.getPropertyValue('--card-py')).toBe(
+        'var(--spacing-square-relaxed-y)'
+      );
+    });
+
+    test('`px` and `py` set independently', () => {
+      render(
+        <Basic.Component
+          px="padding-loose"
+          py="padding-tight"
+          data-testid="card"
+        />
+      );
+
+      const card = screen.getByTestId('card');
+
+      expect(card.style.getPropertyValue('--card-px')).toBe(
+        'var(--spacing-padding-loose)'
+      );
+      expect(card.style.getPropertyValue('--card-py')).toBe(
+        'var(--spacing-padding-tight)'
+      );
+    });
+
+    test('`space` prop overrides --card-gap', () => {
+      render(<Basic.Component space="section" data-testid="card" />);
+
+      const card = screen.getByTestId('card');
+
+      expect(card.style.getPropertyValue('--card-gap')).toBe(
+        'var(--spacing-section)'
+      );
+    });
+  });
+
+  describe('Slots', () => {
+    test('Card.Header has data-card-header and applies horizontal padding', () => {
+      render(<Basic.Component />);
+
+      const header = screen
+        .getAllByText(/Professor Severus Snape/)[0]
+        .closest('[data-card-header]');
+      expect(header).not.toBeNull();
+      expect(header!.className).toContain('px-(--card-px)');
+    });
+
+    test('Card.Body has data-card-body and applies horizontal padding by default', () => {
+      render(<Basic.Component />);
+
+      const body = screen
+        .getByText(/was an English/)
+        .closest('[data-card-body]');
+      expect(body).not.toBeNull();
+      expect(body!.className).toContain('px-(--card-px)');
+    });
+
+    test('Card.Body with bleed opts out of horizontal padding', () => {
+      render(<WithBleedBody.Component />);
+
+      const body = screen
+        .getByText(/Edge-to-edge banner/)
+        .closest('[data-card-body]');
+      expect(body).not.toBeNull();
+      expect(body!.className).not.toContain('px-(--card-px)');
+    });
+
+    test('Card.Footer with bleed opts out of horizontal padding', () => {
+      render(<WithBleedFooter.Component />);
+
+      const footer = screen
+        .getByRole('button', { name: 'Full-width action' })
+        .closest('[data-card-footer]');
+      expect(footer).not.toBeNull();
+      expect(footer!.className).not.toContain('px-(--card-px)');
+    });
+
+    test('Card.Preview has data-card-preview and escapes container padding when first child', () => {
+      render(<WithPreview.Component />);
+
+      const preview = screen
+        .getByAltText('Landscape')
+        .closest('[data-card-preview]');
+      expect(preview).not.toBeNull();
+      expect(preview!.className).toContain('-mt-(--card-py)');
     });
   });
 

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -1,5 +1,11 @@
 import type { HTMLAttributes, ReactNode } from 'react';
-import { cn, useClassNames } from '@marigold/system';
+import type {
+  InsetSpacingTokens,
+  PaddingSpacingTokens,
+  SpaceProp,
+  SpacingTokens,
+} from '@marigold/system';
+import { cn, createSpacingVar, useClassNames } from '@marigold/system';
 import { CardBody } from './CardBody';
 import { CardProvider } from './CardContext';
 import { CardFooter } from './CardFooter';
@@ -8,7 +14,7 @@ import { CardPreview } from './CardPreview';
 
 // Props
 // ---------------
-export interface CardProps extends Omit<
+interface CardBaseProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'className' | 'style'
 > {
@@ -21,7 +27,35 @@ export interface CardProps extends Omit<
    * @default false
    */
   stretch?: boolean;
+
+  /**
+   * Spacing between Card slots (Preview, Header, Body, Footer).
+   * @default 'regular'
+   */
+  space?: SpaceProp<SpacingTokens>['space'];
 }
+
+/**
+ * Padding applied to the Card. Either set `p` for uniform padding, or use
+ * `px`/`py` to control the axes separately — setting both forms is a TypeScript
+ * error, mirroring the `<Panel>` component's `p` / `px`+`py` split.
+ */
+type CardPaddingProps =
+  | {
+      /** Padding on all sides. Cannot be combined with `px` or `py`. */
+      p?: SpaceProp<InsetSpacingTokens>['space'];
+      px?: never;
+      py?: never;
+    }
+  | {
+      p?: never;
+      /** Horizontal padding applied to every slot. */
+      px?: SpaceProp<PaddingSpacingTokens>['space'];
+      /** Vertical padding applied at the top and bottom of the card. */
+      py?: SpaceProp<PaddingSpacingTokens>['space'];
+    };
+
+export type CardProps = CardBaseProps & CardPaddingProps;
 
 // Component
 // ---------------
@@ -30,21 +64,33 @@ export const Card = ({
   variant,
   size,
   stretch,
+  space = 'regular',
+  p,
+  px,
+  py,
   ...props
 }: CardProps) => {
   const classNames = useClassNames({ component: 'Card', variant, size });
+
+  const inset = p ?? 'square-regular';
+  const resolvedPx = px ?? `${inset}-x`;
+  const resolvedPy = py ?? `${inset}-y`;
 
   return (
     <CardProvider value={{ classNames }}>
       <div
         {...props}
         className={cn(
-          'grid overflow-hidden',
-          "[grid-template-areas:'preview'_'header'_'body'_'footer']",
-          'grid-rows-[auto_auto_1fr_auto]',
+          'flex flex-col overflow-hidden',
+          'gap-y-(--card-gap) py-(--card-py)',
           stretch ? '' : 'w-fit',
           classNames.container
         )}
+        style={{
+          ...createSpacingVar('card-px', `${resolvedPx}`),
+          ...createSpacingVar('card-py', `${resolvedPy}`),
+          ...createSpacingVar('card-gap', `${space}`),
+        }}
       >
         {children}
       </div>

--- a/packages/components/src/Card/CardBody.tsx
+++ b/packages/components/src/Card/CardBody.tsx
@@ -5,11 +5,22 @@ import { useCardContext } from './CardContext';
 export interface CardBodyProps {
   /** Main content of the card, such as descriptive text or form elements. */
   children?: ReactNode;
+  /**
+   * Render the body edge-to-edge horizontally, skipping the Card's horizontal
+   * padding. Useful for tables or media that should span the full width.
+   * @default false
+   */
+  bleed?: boolean;
 }
 
-export const CardBody = ({ children }: CardBodyProps) => {
+export const CardBody = ({ children, bleed }: CardBodyProps) => {
   const { classNames } = useCardContext();
   return (
-    <div className={cn('[grid-area:body]', classNames.body)}>{children}</div>
+    <div
+      data-card-body
+      className={cn(!bleed && 'px-(--card-px)', classNames.body)}
+    >
+      {children}
+    </div>
   );
 };

--- a/packages/components/src/Card/CardFooter.tsx
+++ b/packages/components/src/Card/CardFooter.tsx
@@ -5,12 +5,21 @@ import { useCardContext } from './CardContext';
 export interface CardFooterProps {
   /** Content rendered in the card footer, typically actions like buttons or metadata. */
   children?: ReactNode;
+  /**
+   * Render the footer edge-to-edge horizontally, skipping the Card's horizontal
+   * padding.
+   * @default false
+   */
+  bleed?: boolean;
 }
 
-export const CardFooter = ({ children }: CardFooterProps) => {
+export const CardFooter = ({ children, bleed }: CardFooterProps) => {
   const { classNames } = useCardContext();
   return (
-    <div className={cn('[grid-area:footer]', classNames.footer)}>
+    <div
+      data-card-footer
+      className={cn(!bleed && 'px-(--card-px)', classNames.footer)}
+    >
       {children}
     </div>
   );

--- a/packages/components/src/Card/CardHeader.tsx
+++ b/packages/components/src/Card/CardHeader.tsx
@@ -10,7 +10,7 @@ export interface CardHeaderProps {
 export const CardHeader = ({ children }: CardHeaderProps) => {
   const { classNames } = useCardContext();
   return (
-    <div className={cn('[grid-area:header]', classNames.header)}>
+    <div data-card-header className={cn('px-(--card-px)', classNames.header)}>
       {children}
     </div>
   );

--- a/packages/components/src/Card/CardPreview.tsx
+++ b/packages/components/src/Card/CardPreview.tsx
@@ -10,7 +10,13 @@ export interface CardPreviewProps {
 export const CardPreview = ({ children }: CardPreviewProps) => {
   const { classNames } = useCardContext();
   return (
-    <div className={cn('[grid-area:preview]', classNames.preview)}>
+    <div
+      data-card-preview
+      className={cn(
+        'first:-mt-(--card-py) last:-mb-(--card-py)',
+        classNames.preview
+      )}
+    >
       {children}
     </div>
   );

--- a/packages/components/src/Stack/Stack.stories.tsx
+++ b/packages/components/src/Stack/Stack.stories.tsx
@@ -193,23 +193,27 @@ export const WithCards = meta.story({
   render: args => (
     <Stack {...args}>
       <Card>
-        <Container>
-          <Headline level={2}>Card Title</Headline>
-          <Text>
-            This is an example of a card component used within a Stack layout.
-            Cards are useful for grouping related information together in a
-            visually distinct container.
-          </Text>
-        </Container>
+        <Card.Body>
+          <Container>
+            <Headline level={2}>Card Title</Headline>
+            <Text>
+              This is an example of a card component used within a Stack layout.
+              Cards are useful for grouping related information together in a
+              visually distinct container.
+            </Text>
+          </Container>
+        </Card.Body>
       </Card>
       <Card>
-        <Container>
-          <Headline level={2}>Another Card</Headline>
-          <Text>
-            Stacks make it easy to maintain consistent spacing between cards and
-            other components, ensuring a clean and organized layout.
-          </Text>
-        </Container>
+        <Card.Body>
+          <Container>
+            <Headline level={2}>Another Card</Headline>
+            <Text>
+              Stacks make it easy to maintain consistent spacing between cards
+              and other components, ensuring a clean and organized layout.
+            </Text>
+          </Container>
+        </Card.Body>
       </Card>
     </Stack>
   ),

--- a/themes/theme-rui/src/components/Card.styles.ts
+++ b/themes/theme-rui/src/components/Card.styles.ts
@@ -15,15 +15,13 @@ export const Card: ThemeComponent<'Card'> = {
     },
   }),
   header: cva({
-    base: 'px-4 pt-4 pb-2 text-lg font-semibold',
+    base: 'text-lg font-semibold',
   }),
   body: cva({
-    base: 'px-4 py-2 text-sm',
+    base: 'text-sm',
   }),
   footer: cva({
-    base: 'flex items-center gap-2 px-4 pt-2 pb-4',
+    base: 'flex items-center gap-2',
   }),
-  preview: cva({
-    base: '',
-  }),
+  preview: cva({}),
 };


### PR DESCRIPTION
# Description

Closes [DST-1429](https://reservix.atlassian.net/browse/DST-1429).

`Card` now exposes the same padding API as `Panel` so the two composable surfaces behave consistently. After the compound-component refactor (#5320), `Card` had no consumer-controllable padding API and no default container padding — content rendered as direct children of `<Card>` was visually broken across docs and Storybook. This PR closes that gap.

**Component changes**

- New `p` / `px` / `py` props (discriminated union — `p` is mutually exclusive with `px`+`py`). Defaults to `square-regular`. Resolves to CSS custom properties `--card-px` and `--card-py` on the container via `createSpacingVar`.
- New `space` prop (default `regular`) → `--card-gap`, used for vertical gap between slots.
- `Card.Body` and `Card.Footer` accept a new `bleed` prop to opt out of horizontal padding (tables, media, full-width action bars), matching `Panel.Content`.
- Internally switched from CSS grid with `grid-template-areas` to a flex column with `gap-y`. JSX order now determines visual order — place `Card.Preview` first when used.
- `Card.Preview` automatically escapes the container's vertical padding via `first:-mt-(--card-py) last:-mb-(--card-py)` so media stays edge-to-edge.

**Theme changes**

- `themes/theme-rui/src/components/Card.styles.ts` — stripped hardcoded `px-4` / `py-*` from slot styles. Slots keep typography and layout (`text-lg font-semibold`, `flex items-center gap-2`) only; padding lives in the component layer.

**Migrations (9 demos / stories)**

These rendered bare children inside `<Card>`, which is not a supported composition. All updated to use `Card.Body` (and `Card.Preview` where there was an image at the top):

- `docs/content/foundations/elevation/elevation-raised.demo.tsx`
- `docs/content/components/form/switch/switch-card.demo.tsx`
- `docs/content/components/actions/toggle-button/togglebutton-favorite.demo.tsx`
- `docs/content/components/actions/toggle-button/togglebutton-filter.demo.tsx` (split into `Preview` + `Body`)
- `docs/content/patterns/layout/admin-master-mark/admin-master-mark-placement.demo.tsx`
- `docs/content/components/overlay/drawer/drawer-comments-activity.demo.tsx`
- `docs/content/components/layout/tiles/tiles-autoRows.demo.tsx`
- `docs/content/components/content/loader/loader-section.demo.tsx`
- `packages/components/src/Stack/Stack.stories.tsx` (`WithCards` story)

# Test Instructions:

1. `pnpm install && pnpm build`
2. `pnpm test:unit --run packages/components/src/Card` — 16 tests should pass.
3. `pnpm sb` and check the new stories under **Components → Card**:
    - `WithPaddingProp` (knob-driven `p` recipe)
    - `WithBleedBody`
    - `WithBleedFooter`
    - `BareChildrenAntiPattern` (teaches that bare children inside `<Card>` are unsupported)
4. `pnpm start` and verify the 9 migrated demos render with sensible padding — content no longer sits flush against the card border.
5. Confirm `Card.Preview` stays edge-to-edge in `WithPreview` and in `togglebutton-filter.demo.tsx`.

# Reviewers:

@marigold-ui/developer

# Pull Request Checklist:

- [x] Marigold docs and Storybook Preview is available
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Added/Updated documentation (if it already exists for this component).
- [ ] Updated visual regression tests (only necessary when ui changes in the PR) — VRT diff expected; run `/vrt` before merge.

[DST-1429]: https://reservix.atlassian.net/browse/DST-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ