### PR TITLE
chore: remove unreachable push condition from VRT workflow

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -18,7 +18,6 @@ jobs:
     # Unset or any other value keeps the workflow active (fail-open).
     if: >
       vars.VRT_ENABLED != 'false' && (
-        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary

- Leftover from [DST-1409](https://reservix.atlassian.net/browse/DST-1409) (#5397): that PR removed the `push:` trigger from the workflow's `on:` section but left `github.event_name == 'push'` behind in the `if:` guard.
- Since the workflow no longer subscribes to `push` events, that branch of the condition is unreachable — drop the dead line.

## Test plan

- [ ] CI passes on this PR
- [ ] No behavior change expected: workflow still triggers on merged PRs, `workflow_dispatch`, and `/run-chromatic` comments from trusted authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1409]: https://reservix.atlassian.net/browse/DST-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ