### PR TITLE
feat([DST-761]): export useLandmark and document landmarks

### DIFF
--- a/.changeset/export-useLandmark-hook.md
+++ b/.changeset/export-useLandmark-hook.md
@@ -1,0 +1,20 @@
+---
+'@marigold/components': minor
+---
+
+feat([DST-761]): export `useLandmark` from `@marigold/components`.
+
+Marigold now re-exports React Aria's `useLandmark` hook (and its `AriaLandmarkRole` / `AriaLandmarkProps` types) so consumers can register custom regions as ARIA landmarks without adding `@react-aria/landmark` as a direct dependency.
+
+```tsx
+import { useRef } from 'react';
+import { useLandmark } from '@marigold/components';
+
+const ref = useRef<HTMLElement>(null);
+const { landmarkProps } = useLandmark(
+  { role: 'search', 'aria-label': 'Site search' },
+  ref,
+);
+```
+
+A new accessibility guide on landmarks and a dedicated `useLandmark` reference page have been added to the documentation.

--- a/docs/content/components/hooks-and-utils/meta.json
+++ b/docs/content/components/hooks-and-utils/meta.json
@@ -5,6 +5,7 @@
     "extendTheme",
     "parseFormData",
     "useAsyncListData",
+    "useLandmark",
     "useListData",
     "useResponsiveValue",
     "useTheme",

--- a/docs/content/components/hooks-and-utils/useLandmark/index.mdx
+++ b/docs/content/components/hooks-and-utils/useLandmark/index.mdx
@@ -3,9 +3,9 @@ title: useLandmark
 description: Register a region as an ARIA landmark and enable F6 navigation between landmarks.
 ---
 
-We re-export the `useLandmark` hook from [`react-aria`](https://react-spectrum.adobe.com/react-aria/useLandmark.html). It registers an element as an [ARIA landmark](/foundations/accessibility#landmarks) and wires it into React Aria's keyboard navigation. Once at least two landmarks are registered, users can move between them with `F6` (forward) and `Shift + F6` (backward), independent of the regular `Tab` order.
+We re-export the `useLandmark` hook from [`react-aria`](https://react-spectrum.adobe.com/react-aria/useLandmark.html). It registers an element with React Aria's landmark controller so users can move between regions with `F6` (forward) and `Shift + F6` (backward), independent of the regular `Tab` order.
 
-Marigold's structural components (`<AppLayout>`, `<Sidebar>`, `<TopNavigation>`, `<Drawer>`) already use this hook internally. Reach for it directly when you build a custom region that should be exposed to assistive technologies as a landmark, for example a search shell, a feed of cards, or a co-pilot panel.
+Marigold's structural components (`<AppLayout>`, `<Sidebar>`, `<TopNavigation>`, `<Panel>`) expose [ARIA landmarks](/foundations/accessibility#landmarks) through semantic HTML, so screen readers list them automatically. Today only `<Drawer>` registers with the `F6` controller — use this hook to add any other region to the cycle (search shells, feeds, co-pilot panels).
 
 More information can be found in the [react-aria documentation](https://react-spectrum.adobe.com/react-aria/useLandmark.html).
 
@@ -52,7 +52,7 @@ const SearchRegion = ({ children }: { children: React.ReactNode }) => {
 - `banner`, site-wide content such as the masthead or top navigation.
 - `contentinfo`, site-wide footer information.
 - `search`, a search facility.
-- `form`, a form, when it is a major region of the page.
+- `form`, a form, when it is a major region of the page. It **must** have an `aria-label` or `aria-labelledby`.
 - `region`, a generic landmark when none of the others fit. It **must** have an `aria-label` or `aria-labelledby`.
 
 ### Labelling multiple landmarks of the same role

--- a/docs/content/components/hooks-and-utils/useLandmark/index.mdx
+++ b/docs/content/components/hooks-and-utils/useLandmark/index.mdx
@@ -1,0 +1,96 @@
+---
+title: useLandmark
+description: Register a region as an ARIA landmark and enable F6 navigation between landmarks.
+---
+
+We re-export the `useLandmark` hook from [`react-aria`](https://react-spectrum.adobe.com/react-aria/useLandmark.html). It registers an element as an [ARIA landmark](/foundations/accessibility#landmarks) and wires it into React Aria's keyboard navigation. Once at least two landmarks are registered, users can move between them with `F6` (forward) and `Shift + F6` (backward), independent of the regular `Tab` order.
+
+Marigold's structural components (`<AppLayout>`, `<Sidebar>`, `<TopNavigation>`, `<Drawer>`) already use this hook internally. Reach for it directly when you build a custom region that should be exposed to assistive technologies as a landmark, for example a search shell, a feed of cards, or a co-pilot panel.
+
+More information can be found in the [react-aria documentation](https://react-spectrum.adobe.com/react-aria/useLandmark.html).
+
+## Import
+
+To import the hook you just have to use this code below.
+
+```tsx
+import { useLandmark } from '@marigold/components';
+```
+
+## Examples
+
+### Basic landmark region
+
+Pass a `role` and a ref to the DOM element that should become the landmark, then spread the returned `landmarkProps` onto that element. Use a semantic element (`<main>`, `<nav>`, `<aside>`, `<section>`, `<form>`) whenever possible. The explicit `role` is what registers the element with React Aria.
+
+```tsx
+import { useRef } from 'react';
+import { useLandmark } from '@marigold/components';
+
+const SearchRegion = ({ children }: { children: React.ReactNode }) => {
+  const ref = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark(
+    { role: 'search', 'aria-label': 'Site search' },
+    ref
+  );
+
+  return (
+    <section ref={ref} {...landmarkProps}>
+      {children}
+    </section>
+  );
+};
+```
+
+### Allowed roles
+
+`AriaLandmarkRole` accepts the eight ARIA landmark roles.
+
+- `main`, the primary content of the page. There should be exactly one per page.
+- `navigation`, collections of links used for navigating the page or related pages.
+- `complementary`, content that is meaningful on its own but supports the main content (e.g. a sidebar, filters).
+- `banner`, site-wide content such as the masthead or top navigation.
+- `contentinfo`, site-wide footer information.
+- `search`, a search facility.
+- `form`, a form, when it is a major region of the page.
+- `region`, a generic landmark when none of the others fit. It **must** have an `aria-label` or `aria-labelledby`.
+
+### Labelling multiple landmarks of the same role
+
+When a page contains more than one landmark with the same role, give each one an accessible name so screen reader users can tell them apart.
+
+```tsx
+const ref = useRef<HTMLElement>(null);
+const { landmarkProps } = useLandmark(
+  { role: 'navigation', 'aria-label': 'Footer' },
+  ref
+);
+
+return (
+  <nav ref={ref} {...landmarkProps}>
+    {/* Footer links */}
+  </nav>
+);
+```
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Use `useLandmark` for the major regions of a page (header, primary nav,
+      main content, complementary panels, search).
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't apply `useLandmark` to every section or card. It dilutes the
+      navigation list and makes the page harder to scan with a screen reader.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
+## Related
+
+- [Accessibility, Landmarks](/foundations/accessibility#landmarks), conceptual guide and best practices.
+- [AppLayout](/components/layout/app-layout), renders `main`, `banner`, and `complementary` landmarks out of the box.
+- [Sidebar](/components/navigation/sidebar) and [TopNavigation](/components/navigation/topnavigation), expose `navigation` and `banner` landmarks.
+- [Panel](/components/layout/panel), renders a `region` landmark labelled by its title.

--- a/docs/content/components/layout/app-layout/index.mdx
+++ b/docs/content/components/layout/app-layout/index.mdx
@@ -65,7 +65,7 @@ Page-level scroll keeps native browser behaviour (mobile URL-bar collapse, pull-
 
 ### Accessibility
 
-- **Landmarks:** `<AppLayout.Main>` renders as `<main>`, providing a standard landmark region for screen readers. `<AppLayout.Sidebar>` renders an `<aside>` landmark automatically.
+- **Landmarks:** `<AppLayout.Main>` renders as `<main>`, providing a standard landmark region for screen readers. `<AppLayout.Sidebar>` renders an `<aside>` landmark automatically. See the [Landmarks foundation](/foundations/accessibility#landmarks) for the full landmark map and `F6` navigation.
 - **Scrollable region:** The main area is scrollable and can be navigated with keyboard (arrow keys, Page Up/Down, Home/End)
 - **Stacking order:** The header uses `z-index: 1` to ensure it stays above main content during scroll
 

--- a/docs/content/components/layout/app-layout/index.mdx
+++ b/docs/content/components/layout/app-layout/index.mdx
@@ -65,7 +65,7 @@ Page-level scroll keeps native browser behaviour (mobile URL-bar collapse, pull-
 
 ### Accessibility
 
-- **Landmarks:** `<AppLayout.Main>` renders as `<main>`, providing a standard landmark region for screen readers. `<AppLayout.Sidebar>` renders an `<aside>` landmark automatically. See the [Landmarks foundation](/foundations/accessibility#landmarks) for the full landmark map and `F6` navigation.
+- **Landmarks:** `<AppLayout.Main>` renders `<main>` and `<AppLayout.Sidebar>` renders `<aside>`, so both appear in the screen reader's landmark list automatically. Wrap them with [`useLandmark`](/components/hooks-and-utils/useLandmark) to add them to the `F6` cycle. See the [Landmarks foundation](/foundations/accessibility#landmarks) for details.
 - **Scrollable region:** The main area is scrollable and can be navigated with keyboard (arrow keys, Page Up/Down, Home/End)
 - **Stacking order:** The header uses `z-index: 1` to ensure it stays above main content during scroll
 

--- a/docs/content/components/layout/panel/index.mdx
+++ b/docs/content/components/layout/panel/index.mdx
@@ -239,7 +239,7 @@ Panel renders a `<section>` and wires up the heading outline. Most of the story 
 
 ### Labeling
 
-A `<section>` only becomes a region landmark once it has an accessible name. Without one, it's just a grouping element. Give the Panel a name in one of two ways:
+A `<section>` only becomes a [region landmark](/foundations/accessibility#landmarks) once it has an accessible name. Without one, it's just a grouping element. Give the Panel a name in one of two ways:
 
 - **Preferred.** Include a Panel.Title. The Panel is automatically labelled by the title.
 - **Fallback.** If the Panel has no visible title (a Collapsible-only Panel, for example), pass an `aria-label` on the Panel itself.

--- a/docs/content/components/navigation/sidebar/index.mdx
+++ b/docs/content/components/navigation/sidebar/index.mdx
@@ -147,7 +147,7 @@ Users can collapse or expand the sidebar with the toggle button or the keyboard 
 
 ### Accessibility
 
-The sidebar renders as a `<nav>` element so screen readers can identify it as a navigation landmark. The keyboard shortcut <kbd>Cmd+B</kbd> / <kbd>Ctrl+B</kbd> toggles it globally. When drilling into a sub-panel, focus moves to the back button, and returns to the branch trigger when navigating back. The active item is announced as the current page. On mobile, the overlay traps focus and can be dismissed with <kbd>Escape</kbd>. Built-in strings support German and English localization.
+The sidebar renders as a `<nav>` element so screen readers can identify it as a [navigation landmark](/foundations/accessibility#landmarks). The keyboard shortcut <kbd>Cmd+B</kbd> / <kbd>Ctrl+B</kbd> toggles it globally. When drilling into a sub-panel, focus moves to the back button, and returns to the branch trigger when navigating back. The active item is announced as the current page. On mobile, the overlay traps focus and can be dismissed with <kbd>Escape</kbd>. Built-in strings support German and English localization.
 
 ## Props
 

--- a/docs/content/components/navigation/topnavigation/index.mdx
+++ b/docs/content/components/navigation/topnavigation/index.mdx
@@ -83,7 +83,7 @@ The `<TopNavigation>` itself does not handle responsive behavior — the compone
 
 ## Accessibility
 
-The `<TopNavigation>` renders a semantic `<header>` element, while `<TopNavigation.Middle>` and `<TopNavigation.End>` each render a `<nav>` landmark. When both are present, screen readers detect multiple navigation landmarks, so provide distinct `aria-label` values to help users differentiate them (e.g., "Main navigation" vs "User actions").
+The `<TopNavigation>` renders a semantic `<header>` element, while `<TopNavigation.Middle>` and `<TopNavigation.End>` each render a `<nav>` landmark. When both are present, screen readers detect multiple [navigation landmarks](/foundations/accessibility#landmarks), so provide distinct `aria-label` values to help users differentiate them (e.g., "Main navigation" vs "User actions").
 
 ## Props
 

--- a/docs/content/components/overlay/drawer/index.mdx
+++ b/docs/content/components/overlay/drawer/index.mdx
@@ -157,7 +157,7 @@ The drawer keeps the selected rows visible so users can confirm the selection wh
 
 ### Accessibility
 
-A drawer renders with the ARIA role `complementary` by default, which fits almost every use case in this guide. Two exceptions are worth knowing:
+A drawer renders with the ARIA role `complementary` by default, which fits almost every use case in this guide. The `role` prop accepts any [ARIA landmark role](/foundations/accessibility#landmarks), and two exceptions are worth knowing:
 
 - For a filter panel, consider `role="search"` to give screen-reader users a more precise landmark.
 - For long-lived activity panels, consider `role="region"` with an `aria-label` if the panel is part of the persistent layout.

--- a/docs/content/foundations/accessibility/accessibility-landmarks.demo.tsx
+++ b/docs/content/foundations/accessibility/accessibility-landmarks.demo.tsx
@@ -1,0 +1,55 @@
+import { useRef } from 'react';
+import type { AriaLandmarkRole } from '@marigold/components';
+import { Headline, Stack, Text, useLandmark } from '@marigold/components';
+
+interface RegionProps {
+  role: AriaLandmarkRole;
+  label: string;
+  description: string;
+}
+
+const Region = ({ role, label, description }: RegionProps) => {
+  const ref = useRef<HTMLElement>(null);
+  const { landmarkProps } = useLandmark({ role, 'aria-label': label }, ref);
+
+  return (
+    <section
+      ref={ref}
+      {...landmarkProps}
+      className="rounded-sm border border-dashed border-stone-300 p-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+    >
+      <Stack space={1}>
+        <Headline level={6}>{label}</Headline>
+        <Text variant="muted">role="{role}"</Text>
+        <Text>{description}</Text>
+      </Stack>
+    </section>
+  );
+};
+
+export default () => (
+  <Stack space={3}>
+    <Region
+      role="search"
+      label="Search"
+      description="Click anywhere in the demo, then press F6 to jump to the next landmark."
+    />
+    <div className="grid grid-cols-[1fr_2fr] gap-3">
+      <Region
+        role="navigation"
+        label="Site navigation"
+        description="Top-level links."
+      />
+      <Region
+        role="main"
+        label="Main content"
+        description="Primary content area of the page."
+      />
+    </div>
+    <Region
+      role="complementary"
+      label="Related"
+      description="Supporting links and metadata."
+    />
+  </Stack>
+);

--- a/docs/content/foundations/accessibility/accessibility-landmarks.demo.tsx
+++ b/docs/content/foundations/accessibility/accessibility-landmarks.demo.tsx
@@ -16,7 +16,7 @@ const Region = ({ role, label, description }: RegionProps) => {
     <section
       ref={ref}
       {...landmarkProps}
-      className="rounded-sm border border-dashed border-stone-300 p-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+      className="border-border focus-visible:outline-ring rounded-sm border border-dashed p-4 focus-visible:outline-2 focus-visible:outline-offset-2"
     >
       <Stack space={1}>
         <Headline level={6}>{label}</Headline>

--- a/docs/content/foundations/accessibility/index.mdx
+++ b/docs/content/foundations/accessibility/index.mdx
@@ -92,9 +92,11 @@ To test this, try the demo below using only your keyboard. Tab through all the e
 
 Landmarks are regions of the page that screen reader users can jump to directly without tabbing through every interactive element. They make large applications navigable in the same way that a sighted user might scan for the sidebar, header, or main content area.
 
-Landmarks are defined either by semantic HTML elements (`<main>`, `<nav>`, `<aside>`, `<header>`, `<footer>`, `<form>`) or by an explicit [ARIA landmark role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#3._landmark_roles). Most assistive technologies expose a list of all landmarks on the page so users can move between them. Once two or more landmarks are on the page, screen reader users press `F6` to move focus to the next landmark and `Shift + F6` to move to the previous one, independent of the regular `Tab` order.
+Landmarks are defined either by semantic HTML elements (`<main>`, `<nav>`, `<aside>`, `<header>`, `<footer>`, `<form>`) or by an explicit [ARIA landmark role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#3._landmark_roles). Most assistive technologies expose a list of all landmarks on the page so users can move between them, regardless of how the landmark was authored.
 
-The [App Shell pattern](/patterns/layout/app-shell) wires up the major landmarks of a typical Marigold page for you, so most applications get this structure by default. When you build a custom region that should appear in the landmark outline outside that pattern, reach for the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook. It registers the element with React Aria's landmark navigation and applies the correct ARIA role and labelling.
+`F6` / `Shift + F6` keyboard cycling is a separate feature — it only works for regions registered with the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook, which wires the element into React Aria's landmark controller.
+
+The [App Shell pattern](/patterns/layout/app-shell) wires up the major landmarks via semantic HTML, so they appear in the screen reader's landmark list automatically. To make a custom region (search shell, AI assistant, activity feed) discoverable in the same list and reachable with `F6`, register it with `useLandmark`.
 
 Try the demo below. Click anywhere inside it, then use `F6` to move forward through the landmarks. Each region announces its role and accessible name to the screen reader.
 

--- a/docs/content/foundations/accessibility/index.mdx
+++ b/docs/content/foundations/accessibility/index.mdx
@@ -88,6 +88,39 @@ To test this, try the demo below using only your keyboard. Tab through all the e
 
 <ComponentDemo name="accessibility-focus" />
 
+### Landmarks
+
+Landmarks are regions of the page that screen reader users can jump to directly without tabbing through every interactive element. They make large applications navigable in the same way that a sighted user might scan for the sidebar, header, or main content area.
+
+Landmarks are defined either by semantic HTML elements (`<main>`, `<nav>`, `<aside>`, `<header>`, `<footer>`, `<form>`) or by an explicit [ARIA landmark role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles#3._landmark_roles). Most assistive technologies expose a list of all landmarks on the page so users can move between them. Once two or more landmarks are on the page, screen reader users press `F6` to move focus to the next landmark and `Shift + F6` to move to the previous one, independent of the regular `Tab` order.
+
+The [App Shell pattern](/patterns/layout/app-shell) wires up the major landmarks of a typical Marigold page for you, so most applications get this structure by default. When you build a custom region that should appear in the landmark outline outside that pattern, reach for the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook. It registers the element with React Aria's landmark navigation and applies the correct ARIA role and labelling.
+
+Try the demo below. Click anywhere inside it, then use `F6` to move forward through the landmarks. Each region announces its role and accessible name to the screen reader.
+
+<ComponentDemo name="accessibility-landmarks" />
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      <ul>
+        <li>Use one `main` landmark per page so screen reader users can jump straight to the primary content.</li>
+        <li>Provide an `aria-label` when a page has multiple landmarks of the same role (e.g. two `navigation` regions) so they can be distinguished.</li>
+        <li>Reserve landmarks for the major regions of the page.</li>
+      </ul>
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      <ul>
+        <li>Don't nest landmarks of the same role. Keep the structure flat so users can navigate between regions efficiently.</li>
+        <li>Don't add a landmark role to every container. The outline gets noisy and stops being useful.</li>
+        <li>Don't rely on visual layout alone to convey structure. An unlabelled `<div>` is invisible to assistive technologies.</li>
+      </ul>
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
 ### Dynamic content
 
 Apps often dynamically update their user interface, such as when displaying search results or showing alerts. To make these updates accessible, ARIA live regions are used. They enable screen readers to automatically announce changes, ensuring users stay informed without needing to shift focus.

--- a/docs/content/patterns/layout/app-shell/index.mdx
+++ b/docs/content/patterns/layout/app-shell/index.mdx
@@ -93,6 +93,19 @@ Each area has a clear purpose. Mixing responsibilities between them makes the la
   </Dont>
 </GuidelineTiles>
 
+### Landmarks
+
+The App Shell exposes the page structure to assistive technologies through ARIA landmarks. Screen reader users can jump between regions with `F6` / `Shift + F6` without tabbing through every interactive element.
+
+| Slot                                     | Landmark        |
+| ---------------------------------------- | --------------- |
+| `<AppLayout.Header>` / `<TopNavigation>` | `banner`        |
+| `<AppLayout.Sidebar>`                    | `complementary` |
+| `<Sidebar.Nav>`                          | `navigation`    |
+| `<AppLayout.Main>`                       | `main`          |
+
+When you compose multiple navigation regions inside the header (e.g. `<TopNavigation.Middle>` plus `<TopNavigation.End>`), give each a distinct `aria-label` so they can be told apart. Each [`<Panel>`](/components/layout/panel) inside `<AppLayout.Main>` adds its own `region` landmark, labelled by its title. For other custom regions (search shells, AI assistants, activity feeds), use the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook and the [Landmarks foundation](/foundations/accessibility#landmarks) for guidance.
+
 ### Responsive behavior
 
 `<AppLayout>` always renders the L-shape grid and doesn't change at breakpoints. Responsive behavior comes from the components inside it. The sidebar collapses on desktop and becomes a modal sheet on mobile. The top navigation adapts its content at smaller widths. See the [Sidebar](/components/navigation/sidebar#collapsing) and [TopNavigation](/components/navigation/topnavigation#mobile-navigation) docs for details.

--- a/docs/content/patterns/layout/app-shell/index.mdx
+++ b/docs/content/patterns/layout/app-shell/index.mdx
@@ -95,7 +95,7 @@ Each area has a clear purpose. Mixing responsibilities between them makes the la
 
 ### Landmarks
 
-The App Shell exposes the page structure to assistive technologies through ARIA landmarks. Screen reader users can jump between regions with `F6` / `Shift + F6` without tabbing through every interactive element.
+Each App Shell slot renders semantic HTML, so the screen reader's landmark list reflects the layout automatically.
 
 | Slot                                     | Landmark        |
 | ---------------------------------------- | --------------- |
@@ -104,7 +104,9 @@ The App Shell exposes the page structure to assistive technologies through ARIA 
 | `<Sidebar.Nav>`                          | `navigation`    |
 | `<AppLayout.Main>`                       | `main`          |
 
-When you compose multiple navigation regions inside the header (e.g. `<TopNavigation.Middle>` plus `<TopNavigation.End>`), give each a distinct `aria-label` so they can be told apart. Each [`<Panel>`](/components/layout/panel) inside `<AppLayout.Main>` adds its own `region` landmark, labelled by its title. For other custom regions (search shells, AI assistants, activity feeds), use the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook and the [Landmarks foundation](/foundations/accessibility#landmarks) for guidance.
+When you compose multiple navigation regions inside the header (e.g. `<TopNavigation.Middle>` plus `<TopNavigation.End>`), give each a distinct `aria-label` so they can be told apart. Each [`<Panel>`](/components/layout/panel) inside `<AppLayout.Main>` adds its own `region` landmark, labelled by its title.
+
+`F6` / `Shift + F6` cycling is opt-in via the [`useLandmark`](/components/hooks-and-utils/useLandmark) hook. Today only `<Drawer>` opts in by default — wrap the slots above (or any custom region) with `useLandmark` to add them to the cycle. See the [Landmarks foundation](/foundations/accessibility#landmarks) for details.
 
 ### Responsive behavior
 

--- a/packages/components/src/hooks.ts
+++ b/packages/components/src/hooks.ts
@@ -4,3 +4,5 @@ export {
   useDragAndDrop,
 } from 'react-aria-components';
 export { DateFormat, NumericFormat } from '@marigold/system';
+export { useLandmark } from '@react-aria/landmark';
+export type { AriaLandmarkRole, AriaLandmarkProps } from '@react-aria/landmark';


### PR DESCRIPTION
## Summary

- Re-exports React Aria's `useLandmark` hook (plus `AriaLandmarkRole` / `AriaLandmarkProps` types) from `@marigold/components` so consumers can register custom regions as ARIA landmarks without taking a direct dependency on `@react-aria/landmark`.
- Adds a **Landmarks** section to the accessibility foundation explaining what landmarks are, `F6` / `Shift + F6` navigation, when to reach for the hook, and a live demo of four regions.
- Adds a dedicated **`useLandmark`** reference page under `components/hooks-and-utils/`, following the existing convention (intro → Import → Examples) and linking to the upstream React Aria documentation for the full API.
- Cross-references the new foundation section from `AppLayout`, `Sidebar`, `TopNavigation`, `Drawer`, and `Panel` accessibility sections, and adds a Landmarks subsection to the App Shell pattern.

Closes [DST-761](https://reservix.atlassian.net/browse/DST-761).

## Test plan

- [ ] `pnpm typecheck:only` passes for changed files.
- [ ] `pnpm lint` passes.
- [ ] `pnpm build:themes && pnpm start` and visit:
  - [ ] `/foundations/accessibility#landmarks` renders the new section + demo.
  - [ ] Clicking into the demo and pressing `F6` / `Shift + F6` moves focus through the four landmark regions, with a visible focus outline.
  - [ ] `/components/hooks-and-utils/useLandmark` renders.
  - [ ] `/patterns/layout/app-shell` includes the new Landmarks subsection.
  - [ ] Cross-reference links on AppLayout / Sidebar / TopNavigation / Drawer / Panel resolve to the foundation anchor.
- [ ] `import { useLandmark } from '@marigold/components'` resolves after `pnpm --filter @marigold/components build`.

[DST-761]: https://reservix.atlassian.net/browse/DST-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ