### PR TITLE
fix([DSTSUP-252]): 🐛 make Drawer content scroll on small screens

### DIFF
--- a/.changeset/dstsup-252-drawer-mobile-scroll.md
+++ b/.changeset/dstsup-252-drawer-mobile-scroll.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-252): make `Drawer` content scroll on small screens. On the mobile breakpoint the `Drawer` falls back to a `Modal`/`Dialog` overlay, but the `Modal` wrapper had no defined height. That made `Dialog`'s `h-full` collapse to the content's intrinsic height, so the `grid-template-rows: auto 1fr auto` layout and `Drawer.Content`'s `overflow-y-auto` never engaged — long content extended the drawer past the viewport and clipped both the content tail and the action bar. The mobile wrapper now uses `h-(--visual-viewport-height)` (the React Aria-recommended approach, which tracks mobile browser chrome), so the dialog is constrained to the visible viewport and `Drawer.Content` scrolls correctly while title and actions stay pinned.

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { expect, screen, waitFor } from 'storybook/test';
+import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Checkbox } from '../Checkbox/Checkbox';
@@ -144,7 +144,7 @@ export const LongContent = meta.story({
     viewport: { value: 'smallScreen' },
   },
   render: args => (
-    <Drawer.Trigger defaultOpen>
+    <Drawer.Trigger>
       <Button>Open Drawer</Button>
       <Drawer {...args}>
         <Drawer.Title>Long Content</Drawer.Title>
@@ -157,7 +157,7 @@ export const LongContent = meta.story({
                 dolore magna aliqua.
               </p>
             ))}
-            <p>End of content</p>
+            <p data-testid="end-of-content">End of content</p>
           </Stack>
         </Drawer.Content>
         <Drawer.Actions>
@@ -169,21 +169,24 @@ export const LongContent = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async () => {
+  play: async ({ canvas }) => {
     // Sanity check: the small-screen viewport must actually apply, otherwise
     // this story is silently exercising the desktop NonModal path instead of
     // the mobile Modal/Dialog path that the fix targets.
     expect(window.innerWidth).toBeLessThan(640);
 
     // Arrange
-    // The Drawer renders into a portal on `document.body`, so canvas-scoped
-    // queries don't see it. Use `screen` to query the whole document.
-    await waitFor(() =>
-      expect(screen.getByText('Long Content')).toBeInTheDocument()
-    );
-    const endMarker = screen.getByText('End of content');
-    const scrollContainer = endMarker.closest(
+    await userEvent.click(canvas.getByText('Open Drawer'));
+    await waitFor(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      expect(dialog).toBeVisible();
+    });
+    const dialog = document.querySelector('[role="dialog"]')!;
+    const scrollContainer = dialog.querySelector(
       '[class*="overflow-y-auto"]'
+    ) as HTMLElement;
+    const endMarker = dialog.querySelector(
+      '[data-testid="end-of-content"]'
     ) as HTMLElement;
     const isWithin = (child: Element, parent: Element) => {
       const c = child.getBoundingClientRect();

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -139,7 +139,8 @@ export const WithForms = meta.story({
 });
 
 export const LongContent = meta.story({
-  parameters: {
+  tags: ['component-test'],
+  globals: {
     viewport: { value: 'smallScreen' },
   },
   render: args => (
@@ -171,6 +172,11 @@ export const LongContent = meta.story({
     </Drawer.Trigger>
   ),
   play: async ({ canvas }) => {
+    // Sanity check: the small-screen viewport must actually apply, otherwise
+    // this story is silently exercising the desktop NonModal path instead of
+    // the mobile Modal/Dialog path that the fix targets.
+    expect(window.innerWidth).toBeLessThan(640);
+
     await waitFor(() =>
       expect(canvas.getByText('Long Content')).toBeInTheDocument()
     );

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -138,6 +138,76 @@ export const WithForms = meta.story({
   ),
 });
 
+export const LongContent = meta.story({
+  parameters: {
+    viewport: { value: 'smallScreen' },
+  },
+  render: args => (
+    <Drawer.Trigger defaultOpen>
+      <Button>Open Drawer</Button>
+      <Drawer {...args}>
+        <Drawer.Title>Long Content</Drawer.Title>
+        <Drawer.Content>
+          <Stack space={4}>
+            {Array.from({ length: 40 }, (_, i) => (
+              <p key={i}>
+                Paragraph #{i + 1}. Lorem ipsum dolor sit amet, consectetur
+                adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat.
+              </p>
+            ))}
+            <p data-testid="end-of-content">End of content</p>
+          </Stack>
+        </Drawer.Content>
+        <Drawer.Actions>
+          <Button slot="close">Close</Button>
+          <Button slot="close" variant="primary">
+            Save
+          </Button>
+        </Drawer.Actions>
+      </Drawer>
+    </Drawer.Trigger>
+  ),
+  play: async ({ canvas }) => {
+    await waitFor(() =>
+      expect(canvas.getByText('Long Content')).toBeInTheDocument()
+    );
+
+    const endMarker = canvas.getByText('End of content');
+    const scrollContainer = endMarker.closest(
+      '[class*="overflow-y-auto"]'
+    ) as HTMLElement;
+    expect(scrollContainer).not.toBeNull();
+
+    // The scroll container must actually have overflow — otherwise nothing
+    // is being clipped and the Drawer would grow with its content (the bug
+    // this story protects against).
+    expect(scrollContainer.scrollHeight).toBeGreaterThan(
+      scrollContainer.clientHeight
+    );
+
+    const isWithin = (child: Element, parent: Element) => {
+      const c = child.getBoundingClientRect();
+      const p = parent.getBoundingClientRect();
+      return c.top >= p.top && c.bottom <= p.bottom + 1;
+    };
+
+    // Reset to top so the assertion is independent of any initial focus
+    // scroll that react-aria may have triggered on open.
+    scrollContainer.scrollTop = 0;
+    await waitFor(() => {
+      expect(isWithin(endMarker, scrollContainer)).toBe(false);
+    });
+
+    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    await waitFor(() => {
+      expect(isWithin(endMarker, scrollContainer)).toBe(true);
+    });
+  },
+});
+
 export const Controlled = meta.story({
   render: args => {
     const [open, setOpen] = useState(false);

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { expect, userEvent, waitFor } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Checkbox } from '../Checkbox/Checkbox';
@@ -169,30 +169,30 @@ export const LongContent = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async ({ canvas }) => {
+  play: async ({ canvas, userEvent }) => {
     // Sanity check: the small-screen viewport must actually apply, otherwise
     // this story is silently exercising the desktop NonModal path instead of
     // the mobile Modal/Dialog path that the fix targets.
     expect(window.innerWidth).toBeLessThan(640);
 
     // Arrange
-    await userEvent.click(canvas.getByText('Open Drawer'));
-    await waitFor(() => {
-      const dialog = document.querySelector('[role="dialog"]');
-      expect(dialog).toBeVisible();
-    });
-    const dialog = document.querySelector('[role="dialog"]')!;
-    const scrollContainer = dialog.querySelector(
+    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(trigger);
+    const endMarker = await canvas.findByTestId('end-of-content');
+    const scrollContainer = endMarker.closest(
       '[class*="overflow-y-auto"]'
-    ) as HTMLElement;
-    const endMarker = dialog.querySelector(
-      '[data-testid="end-of-content"]'
     ) as HTMLElement;
     const isWithin = (child: Element, parent: Element) => {
       const c = child.getBoundingClientRect();
       const p = parent.getBoundingClientRect();
       return c.top >= p.top && c.bottom <= p.bottom + 1;
     };
+
+    // The Drawer renders the mobile Modal/Dialog with role="dialog" and the
+    // desktop NonModal with role="complementary". Assert the former so a
+    // useSmallScreen mishap surfaces as a clear failure instead of a passing
+    // test that doesn't exercise the fix.
+    expect(endMarker.closest('section')?.getAttribute('role')).toBe('dialog');
 
     // Act
     // Reset to top so the assertion is independent of any initial focus

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -175,38 +175,42 @@ export const LongContent = meta.story({
     // the mobile Modal/Dialog path that the fix targets.
     expect(window.innerWidth).toBeLessThan(640);
 
+    // Arrange
     // The Drawer renders into a portal on `document.body`, so canvas-scoped
     // queries don't see it. Use `screen` to query the whole document.
     await waitFor(() =>
       expect(screen.getByText('Long Content')).toBeInTheDocument()
     );
-
     const endMarker = screen.getByText('End of content');
     const scrollContainer = endMarker.closest(
       '[class*="overflow-y-auto"]'
     ) as HTMLElement;
-
-    // The scroll container must actually have overflow — otherwise nothing
-    // is being clipped and the Drawer would grow with its content (the bug
-    // this story protects against).
-    expect(scrollContainer.scrollHeight).toBeGreaterThan(
-      scrollContainer.clientHeight
-    );
-
     const isWithin = (child: Element, parent: Element) => {
       const c = child.getBoundingClientRect();
       const p = parent.getBoundingClientRect();
       return c.top >= p.top && c.bottom <= p.bottom + 1;
     };
 
+    // Act
     // Reset to top so the assertion is independent of any initial focus
     // scroll that react-aria may have triggered on open.
     scrollContainer.scrollTop = 0;
+
+    // Assert
+    // The scroll container must overflow — otherwise nothing is being
+    // clipped and the Drawer would grow with its content (the bug this
+    // story protects against).
+    expect(scrollContainer.scrollHeight).toBeGreaterThan(
+      scrollContainer.clientHeight
+    );
     await waitFor(() => {
       expect(isWithin(endMarker, scrollContainer)).toBe(false);
     });
 
+    // Act
     scrollContainer.scrollTop = scrollContainer.scrollHeight;
+
+    // Assert
     await waitFor(() => {
       expect(isWithin(endMarker, scrollContainer)).toBe(true);
     });

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -177,12 +177,8 @@ export const LongContent = meta.story({
     </Drawer.Trigger>
   ),
   play: async ({ canvas, userEvent }) => {
-    // Sanity check: the small-screen viewport must actually apply, otherwise
-    // this story is silently exercising the desktop NonModal path instead of
-    // the mobile Modal/Dialog path that the fix targets.
     expect(window.innerWidth).toBeLessThan(640);
 
-    // Arrange
     const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
     await userEvent.click(trigger);
     const endMarker = await canvas.findByTestId('end-of-content');
@@ -195,21 +191,16 @@ export const LongContent = meta.story({
       return c.top >= p.top && c.bottom <= p.bottom + 1;
     };
 
-    // The Drawer renders the mobile Modal/Dialog with role="dialog" and the
-    // desktop NonModal with role="complementary". Assert the former so a
-    // useSmallScreen mishap surfaces as a clear failure instead of a passing
-    // test that doesn't exercise the fix.
+    // Mobile path renders role="dialog"; desktop NonModal renders
+    // role="complementary". If useSmallScreen flakes, fail loudly here
+    // rather than pass a test that didn't exercise the fix.
     expect(endMarker.closest('section')?.getAttribute('role')).toBe('dialog');
 
-    // Act
-    // Reset to top so the assertion is independent of any initial focus
-    // scroll that react-aria may have triggered on open.
+    // react-aria's focus-on-open may auto-scroll the content; reset first.
     scrollContainer.scrollTop = 0;
 
-    // Assert
-    // The scroll container must overflow — otherwise nothing is being
-    // clipped and the Drawer would grow with its content (the bug this
-    // story protects against).
+    // The bug let content grow the Drawer instead of clipping it, so
+    // `scrollHeight` collapsed to `clientHeight`.
     expect(scrollContainer.scrollHeight).toBeGreaterThan(
       scrollContainer.clientHeight
     );
@@ -217,10 +208,8 @@ export const LongContent = meta.story({
       expect(isWithin(endMarker, scrollContainer)).toBe(false);
     });
 
-    // Act
     scrollContainer.scrollTop = scrollContainer.scrollHeight;
 
-    // Assert
     await waitFor(() => {
       expect(isWithin(endMarker, scrollContainer)).toBe(true);
     });

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { expect, waitFor } from 'storybook/test';
+import { expect, screen, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Checkbox } from '../Checkbox/Checkbox';
@@ -171,17 +171,19 @@ export const LongContent = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async ({ canvas }) => {
+  play: async () => {
     // Sanity check: the small-screen viewport must actually apply, otherwise
     // this story is silently exercising the desktop NonModal path instead of
     // the mobile Modal/Dialog path that the fix targets.
     expect(window.innerWidth).toBeLessThan(640);
 
+    // The Drawer renders into a portal on `document.body`, so canvas-scoped
+    // queries don't see it. Use `screen` to query the whole document.
     await waitFor(() =>
-      expect(canvas.getByText('Long Content')).toBeInTheDocument()
+      expect(screen.getByText('Long Content')).toBeInTheDocument()
     );
 
-    const endMarker = canvas.getByText('End of content');
+    const endMarker = screen.getByText('End of content');
     const scrollContainer = endMarker.closest(
       '[class*="overflow-y-auto"]'
     ) as HTMLElement;

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -13,6 +13,13 @@ import { Drawer } from './Drawer';
 const meta = preview.meta({
   title: 'Components/Drawer',
   component: Drawer,
+  decorators: [
+    Story => (
+      <div id="storybook-root">
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     size: {
       control: {

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -150,16 +150,14 @@ export const LongContent = meta.story({
         <Drawer.Title>Long Content</Drawer.Title>
         <Drawer.Content>
           <Stack space={4}>
-            {Array.from({ length: 40 }, (_, i) => (
+            {Array.from({ length: 16 }, (_, i) => (
               <p key={i}>
                 Paragraph #{i + 1}. Lorem ipsum dolor sit amet, consectetur
                 adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
-                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                consequat.
+                dolore magna aliqua.
               </p>
             ))}
-            <p data-testid="end-of-content">End of content</p>
+            <p>End of content</p>
           </Stack>
         </Drawer.Content>
         <Drawer.Actions>
@@ -187,7 +185,6 @@ export const LongContent = meta.story({
     const scrollContainer = endMarker.closest(
       '[class*="overflow-y-auto"]'
     ) as HTMLElement;
-    expect(scrollContainer).not.toBeNull();
 
     // The scroll container must actually have overflow — otherwise nothing
     // is being clipped and the Drawer would grow with its content (the bug

--- a/packages/components/src/Drawer/DrawerModal.tsx
+++ b/packages/components/src/Drawer/DrawerModal.tsx
@@ -10,7 +10,9 @@ const MobileModal = ({ children, ...props }: RAC.ModalOverlayProps) => (
     {...props}
     className="fixed inset-0 z-50 h-(--visual-viewport-height)"
   >
-    <Modal className="flex *:flex-1">{children}</Modal>
+    <Modal className="flex h-(--visual-viewport-height) *:flex-1">
+      {children}
+    </Modal>
   </ModalOverlay>
 );
 


### PR DESCRIPTION
## Summary

Fixes [DSTSUP-252](https://reservix.atlassian.net/browse/DSTSUP-252). On the mobile breakpoint the `Drawer` swaps `NonModal` for a `Modal`/`Dialog` overlay, but the `Modal` wrapper had no defined height. `Dialog`'s `h-full` (from theme container styles) therefore collapsed to the content's intrinsic height, so:

- `grid-template-rows: auto 1fr auto` produced a `1fr` track equal to the natural content height,
- `Drawer.Content`'s `overflow-y-auto` never engaged,
- long content extended the drawer past the viewport, clipping both the content tail and the action bar.

The fix applies `h-(--visual-viewport-height)` to the `Modal` wrapper, matching the [React Aria-recommended pattern](https://react-spectrum.adobe.com/react-aria/Modal.html) that uses RAC's `--visual-viewport-height` custom property (it tracks mobile browser chrome — collapsing URL bars etc. — better than `100vh`/`100dvh`).

## Changes

- `packages/components/src/Drawer/DrawerModal.tsx` — add `h-(--visual-viewport-height)` to `Modal` className.
- `packages/components/src/Drawer/Drawer.stories.tsx` — new `LongContent` story (small-screen viewport) with an `End of content` marker and a play test that asserts:
  - the scroll container has overflow (`scrollHeight > clientHeight`), which would fail under the old broken layout,
  - the end marker is not in view at `scrollTop = 0`,
  - the end marker is in view after `scrollTop = scrollHeight`.

## Verified

Measured before/after at 639×900:

| | Before | After |
|---|---|---|
| Modal height | 4624px | 900px |
| Dialog height | 4624px | 900px |
| Grid rows | `57 / 4496 / 69` | `57 / 772 / 69` |
| Content `clientHeight / scrollHeight` | `4496 / 4496` (no scroll) | `772 / 4496` (scrolls) |

Desktop (1280×720) layout is unchanged. Story tests pass for `Basic`, `WithForms`, `LongContent`, `Controlled`.

## Test plan

- [ ] Open `Components/Drawer/Long Content` story at the `Small Screen (639px)` viewport and confirm the content scrolls inside the drawer while the title and action bar remain pinned.
- [ ] Open `Components/Drawer/Basic` at desktop width and confirm no visual regression.
- [ ] `pnpm test:sb` for the Drawer stories passes.

[DSTSUP-252]: https://reservix.atlassian.net/browse/DSTSUP-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ