### PR TITLE
chore([DST-1440]): update pnpm to v11.1.2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "node": "24.x"
   },
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@11.1.2",
   "dependencies": {
     "@babel/core": "7.29.0",
     "@changesets/changelog-git": "0.2.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@ packages:
   - docs
   - packages/*
   - themes/*
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

- Bump `packageManager` from `pnpm@10.29.3` → `pnpm@11.1.2` to pick up the latest major.
- Populate the new `allowBuilds` section pnpm 11 introduced in `pnpm-workspace.yaml`. Each entry maps a package to an explicit `true`/`false` allowing install scripts to run; without this, pnpm 11 skips native install scripts and prints `ERR_PNPM_IGNORED_BUILDS`. The four packages (`@parcel/watcher`, `esbuild`, `sharp`, `unrs-resolver`) all need their build scripts to install platform-specific binaries, so all are set to `true` to match prior pnpm 10 behavior.
- All GitHub workflows (`build.yml`, `lint.yml`, `typecheck.yml`, `release.yml`, `visual-regression-tests.yml`) read the pnpm version from `package.json#packageManager` via `pnpm/action-setup@v4` — no workflow edits required.
- `pnpm-lock.yaml` remains unchanged: pnpm 11 reads `lockfileVersion: 9.0` without rewriting it, so the dep graph is identical.

Linked Jira: [DST-1440](https://reservix.atlassian.net/browse/DST-1440)

## Test plan

- [x] `corepack pnpm install` succeeds with pnpm 11.1.2 active; all native install scripts (`@parcel/watcher`, `esbuild`, `sharp`, `unrs-resolver`) run cleanly.
- [x] `pnpm build` (full turbo pipeline across components + themes) completes without errors.
- [x] `postinstall` (turbo build + husky + fumadocs-mdx + docs registry) completes end-to-end.
- [ ] CI build, lint, typecheck, and VRT workflows pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DST-1440]: https://reservix.atlassian.net/browse/DST-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ