### PR TITLE
fix: point Patterns nav link to first item (App Shell)

### DIFF
--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -25,7 +25,7 @@ export const baseOptions = (): BaseLayoutProps => {
       },
       {
         text: 'Patterns',
-        url: '/patterns/layout/admin-master-mark',
+        url: '/patterns/layout/app-shell',
         on: 'all',
       },
       { text: 'Releases', url: '/releases/release-notes', on: 'all' },


### PR DESCRIPTION
## Summary

- Previously, clicking the **Patterns** link in the top navigation landed on **Admin & Mastermark**, even though it is not the first item under Patterns → Layout.
- Updated the link in `docs/lib/layout.shared.tsx` to point to **App Shell**, which is the first item in `content/patterns/layout/meta.json`.

## Test plan

- [ ] Run `pnpm start` and confirm clicking **Patterns** in the top nav opens `/patterns/layout/app-shell`.
- [ ] Verify the App Shell page renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)