### PR TITLE
chore(renovate): make dashboard checkboxes responsive

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
   ],
   "timezone": "Europe/Berlin",
 
-  "requireConfig": "optional",
   "ignoreScripts": true,
   "branchConcurrentLimit": 5,
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -5,6 +5,8 @@ on:
     # Monday at 2am Europe/Berlin (0am UTC)
     - cron: '0 0 * * 1'
   workflow_dispatch:
+  issues:
+    types: [edited]
 
 concurrency:
   group: renovate
@@ -12,6 +14,10 @@ concurrency:
 
 jobs:
   renovate:
+    # On issue edits, only react to the Renovate Dependency Dashboard.
+    if: >-
+      github.event_name != 'issues' ||
+      github.event.issue.title == 'Dependency Dashboard'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `issues: edited` trigger to `.github/workflows/renovate.yml`, gated to runs where the edited issue is the Renovate **Dependency Dashboard**. Ticking a checkbox on issue #5292 now triggers a Renovate run within ~1–2 min instead of waiting until the weekly Monday cron.
- Drop `"requireConfig": "optional"` from `.github/renovate.json` — it's a Renovate **global-only** option and is rejected from repo-level config, surfacing as the ⚠️ "Repository Problems" warning on the dashboard.

## Why

Until now, ticking one of the "force creation now" checkboxes on the dashboard had no effect for up to 7 days. Renovate only reads ticked boxes during a run, and the workflow was scheduled `cron: '0 0 * * 1'` only. This made the dashboard feel broken — checkboxes silently did nothing.

The job-level `if:` guard ensures unrelated issue edits don't spin up a Renovate run; the existing `concurrency` group prevents racing.

## Test plan

- [ ] After merge, edit issue #5292 (tick any rate-limited checkbox, e.g. `tsx → v4.22.0`) and confirm a new "Renovate" run starts in the Actions tab within ~30s.
- [ ] Confirm a PR matching the ticked entry is opened by \`marigold-renovate\` within ~2 min.
- [ ] Edit an unrelated issue and confirm the workflow does **not** run (job should show as skipped).
- [ ] Trigger \`gh workflow run renovate.yml\` manually and confirm the scheduled/manual paths still work.
- [ ] On the next Renovate run, confirm the ⚠️ "Repository Problems" section disappears from #5292 and the run log no longer contains \`WARN: Found renovate config warnings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)