### PR TITLE
fix(ci): use pnpm dlx for cdxgen to fix SBOM workflow on pnpm 11

### DIFF
--- a/.github/workflows/dependency-track.yml
+++ b/.github/workflows/dependency-track.yml
@@ -21,13 +21,9 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install cdxgen
-        run: |
-          pnpm install -g @cyclonedx/cdxgen
-
       - name: Generate SBOM
         run: |
-          cdxgen -r -o sbom.json
+          pnpm dlx @cyclonedx/cdxgen -r -o sbom.json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- The `Generate and Upload SBOM to Dependency-Track` workflow has been failing on every push to `main` since the pnpm 11 bump (#5425) with: `[ERROR] The configured global bin directory "/home/runner/setup-pnpm/node_modules/.bin/bin" is not in PATH`.
- Root cause: pnpm 11 derives `global-bin-dir` as `$PNPM_HOME/bin` (instead of `$PNPM_HOME` as in pnpm 10). `pnpm/action-setup@v4.2.0` only puts `$PNPM_HOME` on `PATH`, so `pnpm install -g` refuses to run.
- Fix: drop the global install and run cdxgen via `pnpm dlx @cyclonedx/cdxgen` — this avoids the global-bin resolution entirely and removes a step.

## Test plan

- [ ] Merge to `main` and watch the post-merge SBOM run go green.
- [ ] Confirm `sbom.json` artifact is produced on the run.
- [ ] Confirm `Trigger GitLab Pipeline` step returns 2xx from `git.reservix.io`.
- [ ] Confirm the new SBOM appears in Dependency-Track for the marigold project shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)