### PR TITLE
test([DST-1442]): 🐛⚡️ stop VRT play functions racing RAC collections

### DIFF
--- a/packages/components/src/SelectList/SelectList.stories.tsx
+++ b/packages/components/src/SelectList/SelectList.stories.tsx
@@ -219,7 +219,7 @@ export const Basic = meta.story({
     </SelectList>
   ),
   play: async ({ args, canvas, step }) => {
-    const creditRow = canvas.getByRole('row', { name: /credit card/i });
+    const creditRow = await canvas.findByRole('row', { name: /credit card/i });
     const paypalRow = canvas.getByRole('row', { name: /paypal/i });
 
     await step('default selection comes from defaultSelectedKeys', () => {
@@ -282,7 +282,7 @@ export const WithMultiSelection = meta.story({
     </SelectList>
   ),
   play: async ({ args, canvas, step }) => {
-    const insuranceRow = canvas.getByRole('row', {
+    const insuranceRow = await canvas.findByRole('row', {
       name: /parcel insurance/i,
     });
     const giftWrapRow = canvas.getByRole('row', { name: /gift wrap/i });
@@ -360,7 +360,7 @@ export const WithIconAction = meta.story({
     </SelectList>
   ),
   play: async ({ canvas, step }) => {
-    const button = canvas.getByRole('button', {
+    const button = await canvas.findByRole('button', {
       name: 'Learn more about Credit card',
     });
     const row = button.closest('[role="row"]')!;
@@ -435,7 +435,7 @@ export const WithActionMenu = meta.story({
     </SelectList>
   ),
   play: async ({ canvas, step }) => {
-    const trigger = canvas.getByRole('button', {
+    const trigger = await canvas.findByRole('button', {
       name: 'Manage Visa ending in 4242',
     });
     const row = trigger.closest('[role="row"]')!;
@@ -572,7 +572,7 @@ export const WithCustomPadding = meta.story({
     </SelectList>
   ),
   play: async ({ canvas }) => {
-    const standardRow = canvas.getByRole('row', { name: /standard/i });
+    const standardRow = await canvas.findByRole('row', { name: /standard/i });
     expect(standardRow).toHaveClass(
       'px-(--selectlist-item-px)',
       'py-(--selectlist-item-py)'
@@ -640,7 +640,7 @@ export const Disabled = meta.story({
     </SelectList>
   ),
   play: async ({ args, canvas }) => {
-    const expressRow = canvas.getByRole('row', { name: /express/i });
+    const expressRow = await canvas.findByRole('row', { name: /express/i });
 
     await userEvent.click(expressRow);
 
@@ -725,7 +725,7 @@ export const WithForm = meta.story({
   ),
   play: async ({ canvas }) => {
     await userEvent.click(
-      canvas.getByRole('row', { name: /parcel insurance/i })
+      await canvas.findByRole('row', { name: /parcel insurance/i })
     );
     await userEvent.click(canvas.getByRole('row', { name: /gift wrap/i }));
     await userEvent.click(canvas.getByRole('button', { name: /submit/i }));

--- a/packages/components/src/TextValue/TextValue.stories.tsx
+++ b/packages/components/src/TextValue/TextValue.stories.tsx
@@ -42,7 +42,7 @@ export const InsideListBoxItem = meta.story({
   ),
   play: async ({ canvas }) => {
     await expect(
-      canvas.getByRole('option', { name: 'Apple' })
+      await canvas.findByRole('option', { name: 'Apple' })
     ).toBeInTheDocument();
     await expect(
       canvas.getByRole('option', { name: 'Banana' })


### PR DESCRIPTION
## Summary

Chromatic build [#673](https://www.chromatic.com/build?appId=68679799bacf3b2432835044&number=673) reported play-function errors for several SelectList stories and the TextValue `InsideListBoxItem` story:

```
TestingLibraryElementError: Unable to find an accessible element with the role "row" and name `/credit card/i`
TestingLibraryElementError: Unable to find an accessible element with the role "option" and name "Apple"
```

The captured DOM showed the collection container rendered but `data-empty="true"` — no items in the collection at the moment the play function ran.

**Root cause:** RAC's `GridList` / `ListBox` use `CollectionBuilder`, a portal-based two-pass render. Items first register in a hidden collection document, then the inner component re-renders with a populated collection. Local Storybook tests run slow enough that the second render lands before the play function fires, so a synchronous `canvas.getByRole(...)` resolves. Chromatic's runner is faster: the play function fires while the grid/listbox is still in its first-pass "empty" state, and the synchronous query throws.

**Fix:** swap the first query in each affected play function to `await canvas.findByRole(...)` so it waits for the second-render items. Subsequent queries stay synchronous since the collection is settled once the first item is found.

Affected stories:
- `Components/SelectList`: `Basic`, `WithMultiSelection`, `WithIconAction`, `WithActionMenu`, `WithCustomPadding`, `Disabled`, `WithForm`
- `Components/TextValue`: `InsideListBoxItem`

Component implementations are unchanged — the race is purely in the test code.

Refs [DST-1442](https://reservix.atlassian.net/browse/DST-1442).

## Test plan

- [x] `pnpm test:sb --run packages/components/src/SelectList/SelectList.stories.tsx` — 7/7 pass locally
- [x] `pnpm test:sb --run packages/components/src/TextValue/TextValue.stories.tsx` — 1/1 pass locally
- [ ] Re-run Chromatic on this branch and confirm SelectList / TextValue stories no longer throw play-function errors

[DST-1442]: https://reservix.atlassian.net/browse/DST-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ