### PR TITLE
chore([DST-1441]): 🏗️ reduce Chromatic snapshot usage

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -96,6 +96,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           branchName: ${{ steps.resolve-branch.outputs.branch }}
           onlyChanged: true # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
+          zip: true # Zip the Storybook build for faster uploads
           # Files whose changes should NOT trigger story re-snapshots via
           # dependency tracing. Keep this list focused on files that change
           # often but cannot affect rendered output.
@@ -104,6 +105,11 @@ jobs:
             **/*.md
             **/*.mdx
             .changeset/**
+            **/*.test.{ts,tsx}
+            **/vitest.*.{ts,mjs,js}
+            **/vitest.setup.{ts,mjs,js}
+            eslint.config.*
+            **/tsconfig*.json
           storybookConfigDir: './.storybook'
           storybookBuildDir: './storybook-static'
           storybookBaseDir: '.'

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    # Skip when only visual-irrelevant files change.
+    # Lockfile/package.json are intentionally NOT here — they're handled via
+    # `untraced` below so TurboSnap can still detect runtime-dep changes.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
+      - '.changeset/**'
 
   # Manual trigger
   workflow_dispatch:
@@ -87,12 +95,33 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           branchName: ${{ steps.resolve-branch.outputs.branch }}
-          onlyChanged: true # set to true to enable TurboSnap https://www.chromatic.com/docs/turbosnap/setup/
-          untraced: './.storybook/decorators.tsx'
+          onlyChanged: true # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
+          # Files whose changes should NOT trigger story re-snapshots via
+          # dependency tracing. Keep this list focused on files that change
+          # often but cannot affect rendered output.
+          untraced: |
+            ./.storybook/decorators.tsx
+            **/*.md
+            **/*.mdx
+            .changeset/**
           storybookConfigDir: './.storybook'
           storybookBuildDir: './storybook-static'
           storybookBaseDir: '.'
           debug: true
+          # One-shot diagnostics so we can see WHY TurboSnap chose to
+          # snapshot what it did. Inspect via the uploaded artifact below.
+          diagnosticsFile: true
+          traceChanged: expanded
+
+      - name: Upload Chromatic diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chromatic-diagnostics-${{ github.run_id }}
+          path: |
+            chromatic-diagnostics.json
+            chromatic.log
+          if-no-files-found: ignore
 
       - name: Send Slack notification
         if: always() && steps.chromatic.outputs.changeCount != '0'

--- a/.storybook/chromatic.config.json
+++ b/.storybook/chromatic.config.json
@@ -1,8 +1,0 @@
-{
-  "onlyChanged": true,
-  "projectId": "Project:68679799bacf3b2432835044",
-  "storybookBaseDir": "config/storybook",
-  "storybookConfigDir": "./.storybook",
-  "zip": true,
-  "buildScriptName": "build"
-}


### PR DESCRIPTION
## Summary

Cut Chromatic snapshot consumption (we're burning ~500/PR against a 35k/month limit) by trimming when the workflow runs and what TurboSnap considers a "change". Also wires up one-shot diagnostics so we can confirm whether TurboSnap is actually working — and pinpoint any future regressions. More information about the ways to solve this in [Jira](https://reservix.atlassian.net/jira/software/projects/DST/boards/134?selectedIssue=DST-1441)

## What changed

`.github/workflows/visual-regression-tests.yml`:

- **`paths-ignore`** on the `pull_request` trigger — skip the workflow entirely when a merged PR only touches `docs/**`, `**/*.md`, `**/*.mdx`, or `.changeset/**`.
- **Expanded `untraced`** — markdown, MDX, and changesets no longer count as "changed" for TurboSnap dependency tracing. Now also covers files that can't affect rendered story output: `**/*.test.{ts,tsx}`, `**/vitest.*.{ts,mjs,js}`, `**/vitest.setup.{ts,mjs,js}`, `eslint.config.*`, `**/tsconfig*.json`. (Lockfile / `package.json` intentionally left out so runtime-dep bumps like `react-aria-components` still trigger snapshots.)
- **`zip: true`** — Storybook build is zipped before upload for faster CI.
- **`diagnosticsFile: true` + `traceChanged: expanded`** — chromatic CLI writes a structured trace explaining which stories were re-snapshotted and why.
- **Upload-artifact step** — `chromatic-diagnostics-<run-id>` artifact attached to every run for inspection.

`.storybook/chromatic.config.json`:

- **Deleted.** Chromatic only reads `chromatic.config.json` at repo root, so this file was never consumed. Its `storybookBaseDir: "config/storybook"` pointed at the ESLint config directory (wrong) and `buildScriptName: "build"` didn't match the actual Storybook script (`build:sb`). All authoritative config now lives in the workflow YAML.

## Why

We have TurboSnap (`onlyChanged: true`) enabled, but snapshot counts suggest most PRs trigger a near-full rebuild. Suspects: (a) doc/changeset-only PRs running VRT for no reason, (b) TurboSnap tracing pulling in stories that shouldn't depend on a given change, (c) test files / tooling configs cascading through their imports. The diagnostics flags will tell us how much each contributes.

The additional `untraced` patterns follow Chromatic's [TurboSnap monorepo](https://www.chromatic.com/docs/turbosnap/monorepo-usage/) and [best practices](https://www.chromatic.com/docs/turbosnap/best-practices/) guidance: only untrace files that genuinely can't affect rendered output — test files, vitest config, eslint config, tsconfigs — all of which were silently triggering full rebuilds via their import chain.

## What this does **not** do

- Doesn't add lockfile/`package.json` to `untraced`. Tempting, but it would silence real runtime-dep regressions (root `package.json` has `react`, `react-dom`, `react-select`, `tailwindcss` as runtime deps).
- Doesn't add a CSS `externals` declaration yet. Tailwind v4 `@source` globs aren't tracked by Vite's import graph, so theme/CSS-only changes might not trigger snapshots — but this needs a real diagnostics run to confirm before we touch it.

## Test plan

- [ ] Merge a doc-only PR to `main` and confirm this workflow is **not** triggered (look at the Actions tab).
- [ ] Merge a component-touching PR to `main`, then on the resulting workflow run:
  - [ ] Download the `chromatic-diagnostics-<run-id>` artifact from the run summary.
  - [ ] Inspect `chromatic-diagnostics.json` — look at `turboSnap.bailReason` (should be empty), `actualTestCount` vs `inheritedCaptureCount` (high inherited = TurboSnap working), and the `tracedFiles` list.
  - [ ] Compare against the previous baseline run's snapshot count.
- [ ] If diagnostics show CSS-only changes not triggering snapshots, follow up by adding `externals: themes/theme-rui/src/**/*.css`.
- [ ] Once we've verified TurboSnap is behaving, consider whether to keep `diagnosticsFile`/`traceChanged` on long-term or drop back to `debug: true` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)