### PR TITLE
feat(DST-1462)!: support selectionMode="multiple" in ComboBox and align prop names with React Aria

### DIFF
--- a/.changeset/combobox-multiple-selection.md
+++ b/.changeset/combobox-multiple-selection.md
@@ -1,15 +1,26 @@
 ---
-'@marigold/components': minor
+'@marigold/components': major
 ---
 
-feat(DST-1462): support `selectionMode="multiple"` in `ComboBox`
+feat(DST-1462): support `selectionMode="multiple"` in `ComboBox` and align prop names with React Aria
 
 `<ComboBox>` now accepts `selectionMode="multiple"`, allowing users to filter and select more than one option from the list. The new `<ComboBox.Value>` (re-export of react-aria's `ComboBoxValue`) can be used to render the selected items in custom layouts. On mobile, the trigger automatically shows a comma-separated list of selected values.
 
 ```tsx
-<ComboBox label="Animals" selectionMode="multiple">
+<ComboBox label="Animals" selectionMode="multiple" onChange={setSelected}>
   <ComboBox.Option id="cat">Cat</ComboBox.Option>
   <ComboBox.Option id="dog">Dog</ComboBox.Option>
   <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
 </ComboBox>
 ```
+
+**Breaking changes** — prop names now match React Aria Components and Marigold's `<Select>`:
+
+| Before              | After               | Purpose                      |
+| ------------------- | ------------------- | ---------------------------- |
+| `value`             | `inputValue`        | Controlled input filter text |
+| `defaultValue`      | `defaultInputValue` | Default input filter text    |
+| `onChange`          | `onInputChange`     | Input filter change handler  |
+| `onSelectionChange` | `onChange`          | Selection change handler     |
+
+In multiple selection mode `onChange` receives `Key[]`; in single mode it receives `Key | null` (matching React Aria's `ChangeValueType<M>`).

--- a/.changeset/combobox-multiple-selection.md
+++ b/.changeset/combobox-multiple-selection.md
@@ -1,0 +1,15 @@
+---
+'@marigold/components': minor
+---
+
+feat(DST-1462): support `selectionMode="multiple"` in `ComboBox`
+
+`<ComboBox>` now accepts `selectionMode="multiple"`, allowing users to filter and select more than one option from the list. The new `<ComboBox.Value>` (re-export of react-aria's `ComboBoxValue`) can be used to render the selected items in custom layouts. On mobile, the trigger automatically shows a comma-separated list of selected values.
+
+```tsx
+<ComboBox label="Animals" selectionMode="multiple">
+  <ComboBox.Option id="cat">Cat</ComboBox.Option>
+  <ComboBox.Option id="dog">Dog</ComboBox.Option>
+  <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+</ComboBox>
+```

--- a/.changeset/combobox-multiple-selection.md
+++ b/.changeset/combobox-multiple-selection.md
@@ -4,7 +4,7 @@
 
 feat(DST-1462): support `selectionMode="multiple"` in `ComboBox` and align prop names with React Aria
 
-`<ComboBox>` now accepts `selectionMode="multiple"`, allowing users to filter and select more than one option from the list. The new `<ComboBox.Value>` (re-export of react-aria's `ComboBoxValue`) can be used to render the selected items in custom layouts. On mobile, the trigger automatically shows a comma-separated list of selected values.
+`<ComboBox>` now supports multi-select via `selectionMode="multiple"`, mirroring the API on `<Select>`. While at it, the props for selection vs. input filtering are renamed to match React Aria Components and `<Select>`.
 
 ```tsx
 <ComboBox label="Animals" selectionMode="multiple" onChange={setSelected}>
@@ -13,6 +13,13 @@ feat(DST-1462): support `selectionMode="multiple"` in `ComboBox` and align prop 
   <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
 </ComboBox>
 ```
+
+Additions:
+
+- New generic signature `ComboBoxProps<T, M extends SelectionMode>`; `M` defaults to `'single'`.
+- New `renderValue?: (selectedItems: T[]) => ReactNode` prop for customizing the mobile trigger when items are selected.
+- The mobile trigger uses `<ComboBoxValue>` internally, so a comma-separated list of selected items renders in both single and multi modes.
+- Re-exports react-aria's `ComboBoxValue` as `ComboBox.Value` for rendering selected items in custom layouts.
 
 **Breaking changes** — prop names now match React Aria Components and Marigold's `<Select>`:
 

--- a/docs/content/components/form/combobox/combobox-action.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-action.demo.tsx
@@ -10,7 +10,7 @@ export default () => {
       <ComboBox
         label="Projects"
         menuTrigger="focus"
-        onSelectionChange={key => setSelectedKey(key as string)}
+        onChange={key => setSelectedKey(key as string)}
       >
         <ComboBox.Section key="actions" header="Actions">
           <ComboBox.Option

--- a/docs/content/components/form/combobox/combobox-async.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-async.demo.tsx
@@ -19,8 +19,8 @@ export default () => {
   return (
     <ComboBox
       label="Star Wars Character Lookup"
-      value={list.filterText}
-      onChange={list.setFilterText}
+      inputValue={list.filterText}
+      onInputChange={list.setFilterText}
       items={list.items}
     >
       {(item: { name: string }) => (

--- a/docs/content/components/form/combobox/combobox-controlled.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-controlled.demo.tsx
@@ -8,7 +8,6 @@ export default () => {
       <ComboBox
         inputValue={currentValue}
         onInputChange={setCurrentValue}
-        defaultValue="dog"
         label="Animals"
       >
         <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>

--- a/docs/content/components/form/combobox/combobox-controlled.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-controlled.demo.tsx
@@ -6,9 +6,9 @@ export default () => {
   return (
     <Stack>
       <ComboBox
-        value={currentValue}
-        onChange={setCurrentValue}
-        defaultSelectedKey={3}
+        inputValue={currentValue}
+        onInputChange={setCurrentValue}
+        defaultValue="dog"
         label="Animals"
       >
         <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>

--- a/docs/content/components/form/combobox/combobox-multiple.demo.tsx
+++ b/docs/content/components/form/combobox/combobox-multiple.demo.tsx
@@ -1,0 +1,12 @@
+import { ComboBox } from '@marigold/components';
+
+export default () => (
+  <ComboBox label="Animals" width={64} selectionMode="multiple">
+    <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+    <ComboBox.Option id="cat">Cat</ComboBox.Option>
+    <ComboBox.Option id="dog">Dog</ComboBox.Option>
+    <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+    <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+    <ComboBox.Option id="snake">Snake</ComboBox.Option>
+  </ComboBox>
+);

--- a/docs/content/components/form/combobox/index.mdx
+++ b/docs/content/components/form/combobox/index.mdx
@@ -17,7 +17,7 @@ Its purpose is to make interaction with software more intuitive by presenting op
 
 ### Controlled Usage with custom Filter
 
-If you want to listen or act while the user is typing into the `ComboBox` field, you can switch to controlled mode by adding an `onChange` handler and setting the `value` manually.
+If you want to listen or act while the user is typing into the `ComboBox` field, you can switch to controlled mode by adding an `onInputChange` handler and setting the `inputValue` manually.
 
 This is especially helpful if you need to customize the filtering. For example, you may only want to show suggestions when the user has typed at least two characters. Furthermore, you can improve the matching, as shown in the example below. In the demo, the user would not receive a suggestion if they typed "ssp" without the custom filter.
 
@@ -68,10 +68,10 @@ Note that the input itself is used to filter the list. To display the current se
 
 The `<ComboBox.Option>` component supports an `onAction` prop that triggers a callback when the user performs an action on an item. This is useful for triggering side effects such as navigating to a detail view or opening an edit modal.
 
-By combining controlled input (`value`/`onChange`) with `allowsCustomValue` and a conditional `<ComboBox.Option>`, you can offer a dynamic "Create new" option that reflects what the user has typed. This is a common pattern for comboboxes that allow creating new entries inline.
+By combining controlled input (`inputValue`/`onInputChange`) with `allowsCustomValue` and a conditional `<ComboBox.Option>`, you can offer a dynamic "Create new" option that reflects what the user has typed. This is a common pattern for comboboxes that allow creating new entries inline.
 
-<Callout title="`onAction` vs `onSelectionChange`" type="info">
-  The `onAction` prop on individual options differs from the `onSelectionChange` prop on the `<ComboBox>` itself. Use `onSelectionChange` when you need to track and manage the selected value. Use `onAction` when you need to perform a side effect when an item is activated, regardless of selection state. Note that `onAction` should not replace the primary selection behavior - it is intended for supplementary actions.
+<Callout title="`onAction` vs `onChange`" type="info">
+  The `onAction` prop on individual options differs from the `onChange` prop on the `<ComboBox>` itself. Use `onChange` when you need to track and manage the selected value. Use `onAction` when you need to perform a side effect when an item is activated, regardless of selection state. Note that `onAction` should not replace the primary selection behavior - it is intended for supplementary actions.
 </Callout>
 
 <ComponentDemo name="combobox-action" />

--- a/docs/content/components/form/combobox/index.mdx
+++ b/docs/content/components/form/combobox/index.mdx
@@ -56,6 +56,14 @@ The below examples will display the suggestions when the input field is focused.
 
 <ComponentDemo name="combobox-menu-trigger" />
 
+### Multiselection
+
+Sometimes you need to offer a way for users to filter and select multiple options from a list. By setting `selectionMode="multiple"` on the `<ComboBox>`, users can select more than one option from the filtered list. Selected options remain marked when the user keeps typing to refine the suggestions.
+
+Note that the input itself is used to filter the list. To display the current selection (e.g. as removable tags above the input), render `<ComboBox.Value>` or read the selected keys from your own state. On mobile, the trigger automatically shows a comma-separated list of selected items.
+
+<ComponentDemo name="combobox-multiple" />
+
 ### Item Actions
 
 The `<ComboBox.Option>` component supports an `onAction` prop that triggers a callback when the user performs an action on an item. This is useful for triggering side effects such as navigating to a detail view or opening an edit modal.

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -553,6 +553,66 @@ export const WithRenderValue: any = meta.story({
   },
 });
 
+export const MobileMultiple: any = meta.story({
+  tags: ['component-test'],
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  args: {
+    label: 'Animals',
+  },
+  render: args => {
+    const [selected, setSelected] = useState<Key | Key[] | null>([]);
+    return (
+      <Stack>
+        <ComboBox {...args} selectionMode="multiple" onChange={setSelected}>
+          <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+          <ComboBox.Option id="cat">Cat</ComboBox.Option>
+          <ComboBox.Option id="dog">Dog</ComboBox.Option>
+          <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+          <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+        </ComboBox>
+        <pre data-testid="selected">selected: {JSON.stringify(selected)}</pre>
+      </Stack>
+    );
+  },
+  play: async ({ canvas, step }: any) => {
+    const trigger = await canvas.findByRole('button');
+
+    await step('Open tray', async () => {
+      await userEvent.click(trigger);
+      await waitFor(() =>
+        expect(canvas.getByRole('dialog')).toBeInTheDocument()
+      );
+    });
+
+    await step('Pick first option and verify tray stays open', async () => {
+      await userEvent.click(await canvas.findByText('Dog'));
+      expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await step('Pick second option and verify tray stays open', async () => {
+      await userEvent.click(await canvas.findByText('Kangaroo'));
+      expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await step('Verify both selections persisted', async () => {
+      await waitFor(() =>
+        expect(canvas.getByTestId('selected')).toHaveTextContent(
+          'selected: ["dog","kangaroo"]'
+        )
+      );
+    });
+
+    await step('Dismiss tray so the story renders cleanly', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() =>
+        expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+      );
+    });
+  },
+});
+
 export const Mobile: any = meta.story({
   tags: ['component-test'],
   globals: {

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -171,7 +171,7 @@ export const Controlled: any = meta.story({
     const [id, setId] = useState<Key | Key[] | null>(null);
     return (
       <Stack>
-        <ComboBox {...args} onSelectionChange={setId} label="Animals">
+        <ComboBox {...args} onChange={setId} label="Animals">
           <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
           <ComboBox.Option id="cat">Cat</ComboBox.Option>
           <ComboBox.Option id="dog">Dog</ComboBox.Option>
@@ -227,8 +227,8 @@ export const AsyncLoading: any = meta.story({
     });
     return (
       <ComboBox
-        value={list.filterText}
-        onChange={list.setFilterText}
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
         items={list.items}
         label="Star Wars Character Lookup"
         {...args}
@@ -467,14 +467,14 @@ export const Multiple: any = meta.story({
     menuTrigger: 'focus',
   },
   render: args => {
-    const [selected, setSelected] = useState<Key[]>([]);
+    const [selected, setSelected] = useState<Key | Key[] | null>([]);
     return (
       <Stack>
         <ComboBox
           {...args}
           label="Animals"
           selectionMode="multiple"
-          onSelectionChange={value => setSelected(value as Key[])}
+          onChange={setSelected}
         >
           <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
           <ComboBox.Option id="cat">Cat</ComboBox.Option>

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -474,7 +474,7 @@ export const Multiple: any = meta.story({
           {...args}
           label="Animals"
           selectionMode="multiple"
-          onSelectionChange={(keys: any) => setSelected([...keys])}
+          onSelectionChange={value => setSelected(value as Key[])}
         >
           <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
           <ComboBox.Option id="cat">Cat</ComboBox.Option>

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -168,7 +168,7 @@ export const Basic: any = meta.story({
 export const Controlled: any = meta.story({
   tags: ['component-test'],
   render: args => {
-    const [id, setId] = useState<Key | null>(null);
+    const [id, setId] = useState<Key | Key[] | null>(null);
     return (
       <Stack>
         <ComboBox {...args} onSelectionChange={setId} label="Animals">
@@ -178,7 +178,7 @@ export const Controlled: any = meta.story({
           <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
           <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
         </ComboBox>
-        <pre data-testid="output">selected: {id?.toString()}</pre>
+        <pre data-testid="output">selected: {String(id ?? '')}</pre>
       </Stack>
     );
   },
@@ -458,6 +458,49 @@ export const LargeDataset: any = meta.story({
         expect(input).toHaveValue('Tenant 500 (item-500)');
       });
     });
+  },
+});
+
+export const Multiple: any = meta.story({
+  tags: ['component-test'],
+  args: {
+    menuTrigger: 'focus',
+  },
+  render: args => {
+    const [selected, setSelected] = useState<Key[]>([]);
+    return (
+      <Stack>
+        <ComboBox
+          {...args}
+          label="Animals"
+          selectionMode="multiple"
+          onSelectionChange={(keys: any) => setSelected([...keys])}
+        >
+          <ComboBox.Option id="red panda">Red Panda</ComboBox.Option>
+          <ComboBox.Option id="cat">Cat</ComboBox.Option>
+          <ComboBox.Option id="dog">Dog</ComboBox.Option>
+          <ComboBox.Option id="aardvark">Aardvark</ComboBox.Option>
+          <ComboBox.Option id="kangaroo">Kangaroo</ComboBox.Option>
+        </ComboBox>
+        <pre data-testid="selected">selected: {JSON.stringify(selected)}</pre>
+      </Stack>
+    );
+  },
+  play: async ({ canvas }: any) => {
+    const input = await canvas.findByRole('combobox', { name: 'Animals' });
+
+    await userEvent.click(input);
+    await userEvent.click(await canvas.findByRole('option', { name: 'Dog' }));
+    await userEvent.click(input);
+    await userEvent.click(
+      await canvas.findByRole('option', { name: 'Kangaroo' })
+    );
+
+    await waitFor(() =>
+      expect(canvas.getByTestId('selected')).toHaveTextContent(
+        'selected: ["dog","kangaroo"]'
+      )
+    );
   },
 });
 

--- a/packages/components/src/ComboBox/ComboBox.stories.tsx
+++ b/packages/components/src/ComboBox/ComboBox.stories.tsx
@@ -504,6 +504,55 @@ export const Multiple: any = meta.story({
   },
 });
 
+const people = [
+  { id: 'alice', name: 'Alice Johnson', role: 'Product Manager' },
+  { id: 'bob', name: 'Bob Smith', role: 'Senior Developer' },
+  { id: 'charlie', name: 'Charlie Davis', role: 'UX Designer' },
+] as const;
+
+type Person = (typeof people)[number];
+
+export const WithRenderValue: any = meta.story({
+  tags: ['component-test'],
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  args: {
+    label: 'Assignees',
+    placeholder: 'Select assignees',
+    menuTrigger: 'focus',
+  },
+  render: args => (
+    <ComboBox
+      {...args}
+      items={people}
+      selectionMode="multiple"
+      defaultValue={['alice', 'bob']}
+      renderValue={(selected: Person[]) => (
+        <span data-testid="custom-value">
+          {selected.length} selected: {selected.map(p => p.name).join(', ')}
+        </span>
+      )}
+    >
+      {(person: Person) => (
+        <ComboBox.Option id={person.id} textValue={person.name}>
+          <TextValue>{person.name}</TextValue>
+          <Description>{person.role}</Description>
+        </ComboBox.Option>
+      )}
+    </ComboBox>
+  ),
+  play: async ({ canvas }: any) => {
+    const trigger = await canvas.findByRole('button');
+
+    const customValue = await within(trigger).findByTestId('custom-value');
+
+    expect(customValue).toHaveTextContent(
+      '2 selected: Alice Johnson, Bob Smith'
+    );
+  },
+});
+
 export const Mobile: any = meta.story({
   tags: ['component-test'],
   globals: {

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -1,11 +1,13 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { theme } from '@marigold/theme-rui';
 import { mockMatchMedia, renderWithOverlay } from '../test.utils';
 import { ComboBox } from './ComboBox';
-import { Basic } from './ComboBox.stories';
+import { Basic, WithRenderValue } from './ComboBox.stories';
 
 const user = userEvent.setup();
+const smallScreenQuery = `(width < ${theme.screens!.sm})`;
 
 window.matchMedia = mockMatchMedia([]);
 
@@ -168,4 +170,15 @@ test('calls onChange with an array of keys in multiple mode', async () => {
 
 test('exposes ComboBoxValue as ComboBox.Value', () => {
   expect(ComboBox.Value).toBeDefined();
+});
+
+test('renderValue customizes the mobile trigger with selected items', () => {
+  window.matchMedia = mockMatchMedia([smallScreenQuery]);
+  renderWithOverlay(<WithRenderValue.Component />);
+
+  const trigger = screen.getByRole('button');
+
+  expect(within(trigger).getByTestId('custom-value')).toHaveTextContent(
+    '2 selected: Alice Johnson, Bob Smith'
+  );
 });

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { mockMatchMedia, renderWithOverlay } from '../test.utils';
+import { ComboBox } from './ComboBox';
 import { Basic } from './ComboBox.stories';
 
 const user = userEvent.setup();
@@ -132,4 +134,38 @@ test('supports specific empty state text', async () => {
 
   const emptyState = await screen.findByText('No vegetables found');
   expect(emptyState).toBeInTheDocument();
+});
+
+test('calls onSelectionChange with the selected key in single mode', async () => {
+  const onSelectionChange = vi.fn();
+  renderWithOverlay(<Basic.Component onSelectionChange={onSelectionChange} />);
+
+  const input = screen.getAllByLabelText(/Label/i)[0];
+  await user.type(input, 'dog');
+  await user.click(await screen.findByRole('option', { name: 'Dog' }));
+
+  expect(onSelectionChange).toHaveBeenCalledWith('dog');
+});
+
+test('calls onSelectionChange with an array of keys in multiple mode', async () => {
+  const onSelectionChange = vi.fn();
+  renderWithOverlay(
+    <Basic.Component
+      menuTrigger="focus"
+      selectionMode="multiple"
+      onSelectionChange={onSelectionChange}
+    />
+  );
+
+  const input = screen.getAllByLabelText(/Label/i)[0];
+  await user.click(input);
+  await user.click(await screen.findByRole('option', { name: 'Dog' }));
+  await user.click(input);
+  await user.click(await screen.findByRole('option', { name: 'Kangaroo' }));
+
+  expect(onSelectionChange).toHaveBeenLastCalledWith(['dog', 'kangaroo']);
+});
+
+test('exposes ComboBoxValue as ComboBox.Value', () => {
+  expect(ComboBox.Value).toBeDefined();
 });

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -173,12 +173,17 @@ test('exposes ComboBoxValue as ComboBox.Value', () => {
 });
 
 test('renderValue customizes the mobile trigger with selected items', () => {
+  const previousMatchMedia = window.matchMedia;
   window.matchMedia = mockMatchMedia([smallScreenQuery]);
-  renderWithOverlay(<WithRenderValue.Component />);
+  try {
+    renderWithOverlay(<WithRenderValue.Component />);
 
-  const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('button');
 
-  expect(within(trigger).getByTestId('custom-value')).toHaveTextContent(
-    '2 selected: Alice Johnson, Bob Smith'
-  );
+    expect(within(trigger).getByTestId('custom-value')).toHaveTextContent(
+      '2 selected: Alice Johnson, Bob Smith'
+    );
+  } finally {
+    window.matchMedia = previousMatchMedia;
+  }
 });

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -93,8 +93,8 @@ test('supporst showing an error', () => {
   expect(screen.getByText('Error!')).toBeInTheDocument();
 });
 
-test('supports default value', () => {
-  renderWithOverlay(<Basic.Component defaultValue="garlic" />);
+test('supports default input value', () => {
+  renderWithOverlay(<Basic.Component defaultInputValue="garlic" />);
 
   const textField = screen.getAllByLabelText(/Label/i)[0];
 
@@ -136,24 +136,24 @@ test('supports specific empty state text', async () => {
   expect(emptyState).toBeInTheDocument();
 });
 
-test('calls onSelectionChange with the selected key in single mode', async () => {
-  const onSelectionChange = vi.fn();
-  renderWithOverlay(<Basic.Component onSelectionChange={onSelectionChange} />);
+test('calls onChange with the selected key in single mode', async () => {
+  const onChange = vi.fn();
+  renderWithOverlay(<Basic.Component onChange={onChange} />);
 
   const input = screen.getAllByLabelText(/Label/i)[0];
   await user.type(input, 'dog');
   await user.click(await screen.findByRole('option', { name: 'Dog' }));
 
-  expect(onSelectionChange).toHaveBeenCalledWith('dog');
+  expect(onChange).toHaveBeenCalledWith('dog');
 });
 
-test('calls onSelectionChange with an array of keys in multiple mode', async () => {
-  const onSelectionChange = vi.fn();
+test('calls onChange with an array of keys in multiple mode', async () => {
+  const onChange = vi.fn();
   renderWithOverlay(
     <Basic.Component
       menuTrigger="focus"
       selectionMode="multiple"
-      onSelectionChange={onSelectionChange}
+      onChange={onChange}
     />
   );
 
@@ -163,7 +163,7 @@ test('calls onSelectionChange with an array of keys in multiple mode', async () 
   await user.click(input);
   await user.click(await screen.findByRole('option', { name: 'Kangaroo' }));
 
-  expect(onSelectionChange).toHaveBeenLastCalledWith(['dog', 'kangaroo']);
+  expect(onChange).toHaveBeenLastCalledWith(['dog', 'kangaroo']);
 });
 
 test('exposes ComboBoxValue as ComboBox.Value', () => {

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -20,8 +20,6 @@ import { MobileComboBox } from './MobileCombobox';
 
 export type SelectionMode = 'single' | 'multiple';
 
-// Props
-// ---------------
 type RemovedProps =
   | 'className'
   | 'style'
@@ -129,8 +127,6 @@ export interface ComboBoxProps<
   onSelectionChange?: (value: Key | Key[] | null) => void;
 }
 
-// Component
-// ---------------
 function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
   variant,
   size,

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -1,6 +1,9 @@
-import type { ReactNode, Ref } from 'react';
+import type { Key, ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
-import { ComboBox as RACComboBox } from 'react-aria-components/ComboBox';
+import {
+  ComboBoxValue,
+  ComboBox as RACComboBox,
+} from 'react-aria-components/ComboBox';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import type { WidthProp } from '@marigold/system';
 import { useClassNames, useSmallScreen } from '@marigold/system';
@@ -15,6 +18,8 @@ import { ChevronsVertical } from '../icons/ChevronsVertical';
 import { intlMessages } from '../intl/messages';
 import { MobileComboBox } from './MobileCombobox';
 
+export type SelectionMode = 'single' | 'multiple';
+
 // Props
 // ---------------
 type RemovedProps =
@@ -27,11 +32,18 @@ type RemovedProps =
   | 'isReadOnly'
   | 'defaultInputValue'
   | 'inputValue'
-  | 'onInputChange';
+  | 'onInputChange'
+  | 'onChange'
+  | 'onSelectionChange'
+  | 'value'
+  | 'defaultValue';
 
-export interface ComboBoxProps
+export interface ComboBoxProps<
+  T extends object,
+  M extends SelectionMode = 'single',
+>
   extends
-    Omit<RAC.ComboBoxProps<any>, RemovedProps>,
+    Omit<RAC.ComboBoxProps<T, M>, RemovedProps>,
     Pick<FieldBaseProps<'label'>, 'label' | 'description' | 'errorMessage'> {
   variant?: string;
   size?: string;
@@ -45,45 +57,45 @@ export interface ComboBoxProps
    * If `true`, the input is disabled.
    * @default false
    */
-  disabled?: RAC.ComboBoxProps<any>['isDisabled'];
+  disabled?: RAC.ComboBoxProps<T, M>['isDisabled'];
 
   /**
    * If `true`, the input is required.
    * @default false
    */
-  required?: RAC.ComboBoxProps<any>['isRequired'];
+  required?: RAC.ComboBoxProps<T, M>['isRequired'];
 
   /**
    * If `true`, the input is readOnly.
    * @default false
    */
-  readOnly?: RAC.ComboBoxProps<any>['isReadOnly'];
+  readOnly?: RAC.ComboBoxProps<T, M>['isReadOnly'];
 
   /**
    * If `true`, the field is considered invalid and if set the `errorMessage` is shown instead of the `description`.
    * @default false
    */
-  error?: RAC.ComboBoxProps<any>['isInvalid'];
+  error?: RAC.ComboBoxProps<T, M>['isInvalid'];
 
   /**
    * The value of the input (uncontrolled).
    */
-  defaultValue?: RAC.ComboBoxProps<any>['defaultInputValue'];
+  defaultValue?: RAC.ComboBoxProps<T, M>['defaultInputValue'];
 
   /**
    * The value of the input (controlled).
    */
-  value?: RAC.ComboBoxProps<any>['inputValue'];
+  value?: RAC.ComboBoxProps<T, M>['inputValue'];
 
   /**
    * Called when the input value changes.
    */
-  onChange?: RAC.ComboBoxProps<any>['onInputChange'];
+  onChange?: RAC.ComboBoxProps<T, M>['onInputChange'];
 
   /**
    * ReactNode or function to render the list of items.
    */
-  children?: ReactNode | ((item: any) => ReactNode);
+  children?: ReactNode | ((item: T) => ReactNode);
 
   /**
    * Set the placeholder for the select.
@@ -100,11 +112,26 @@ export interface ComboBoxProps
    * @default false
    */
   loading?: boolean;
+
+  /**
+   * Render the trigger value when one or more options are selected (mobile
+   * trigger only). Replaces the default trigger render. The placeholder still
+   * shows when nothing is selected. Must not contain focusable or interactive
+   * elements, since the trigger is itself a button.
+   */
+  renderValue?: (selectedItems: T[]) => ReactNode;
+
+  /**
+   * Handler that is called when the selection changes. In single selection
+   * mode the value is the selected key (or `null`). In multiple selection
+   * mode the value is an array of selected keys.
+   */
+  onSelectionChange?: (value: Key | Key[] | null) => void;
 }
 
 // Component
 // ---------------
-const ComboBoxBase = ({
+function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
   variant,
   size,
   required,
@@ -115,12 +142,14 @@ const ComboBoxBase = ({
   value,
   emptyState,
   onChange,
+  onSelectionChange,
   children,
   loading,
+  renderValue,
   ref,
   ...rest
-}: ComboBoxProps & { ref?: Ref<HTMLInputElement> }) => {
-  const props: RAC.ComboBoxProps<any> = {
+}: ComboBoxProps<T, M> & { ref?: Ref<HTMLInputElement> }) {
+  const props: RAC.ComboBoxProps<T, M> = {
     isDisabled: disabled,
     isReadOnly: readOnly,
     isRequired: required,
@@ -128,6 +157,7 @@ const ComboBoxBase = ({
     defaultInputValue: defaultValue,
     inputValue: value,
     onInputChange: onChange,
+    onChange: onSelectionChange as RAC.ComboBoxProps<T, M>['onChange'],
     ...rest,
   };
 
@@ -138,10 +168,11 @@ const ComboBoxBase = ({
   return (
     <FieldBase as={RACComboBox} ref={ref} {...props}>
       {isSmallScreen ? (
-        <MobileComboBox
+        <MobileComboBox<T>
           placeholder={rest.placeholder}
           label={rest.label}
           emptyState={emptyState}
+          renderValue={renderValue}
         >
           {children}
         </MobileComboBox>
@@ -163,15 +194,17 @@ const ComboBoxBase = ({
                 )
               }
             >
-              {children}
+              {children as any}
             </ListBox>
           </Popover>
         </>
       )}
     </FieldBase>
   );
-};
+}
+
 export const ComboBox = Object.assign(ComboBoxBase, {
   Option: ListBox.Item,
   Section: ListBox.Section,
+  Value: ComboBoxValue,
 });

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -190,7 +190,7 @@ function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
                 )
               }
             >
-              {children as any}
+              {children}
             </ListBox>
           </Popover>
         </>

--- a/packages/components/src/ComboBox/ComboBox.tsx
+++ b/packages/components/src/ComboBox/ComboBox.tsx
@@ -1,4 +1,4 @@
-import type { Key, ReactNode, Ref } from 'react';
+import type { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
 import {
   ComboBoxValue,
@@ -28,13 +28,7 @@ type RemovedProps =
   | 'isRequired'
   | 'isInvalid'
   | 'isReadOnly'
-  | 'defaultInputValue'
-  | 'inputValue'
-  | 'onInputChange'
-  | 'onChange'
-  | 'onSelectionChange'
-  | 'value'
-  | 'defaultValue';
+  | 'onSelectionChange';
 
 export interface ComboBoxProps<
   T extends object,
@@ -76,21 +70,6 @@ export interface ComboBoxProps<
   error?: RAC.ComboBoxProps<T, M>['isInvalid'];
 
   /**
-   * The value of the input (uncontrolled).
-   */
-  defaultValue?: RAC.ComboBoxProps<T, M>['defaultInputValue'];
-
-  /**
-   * The value of the input (controlled).
-   */
-  value?: RAC.ComboBoxProps<T, M>['inputValue'];
-
-  /**
-   * Called when the input value changes.
-   */
-  onChange?: RAC.ComboBoxProps<T, M>['onInputChange'];
-
-  /**
    * ReactNode or function to render the list of items.
    */
   children?: ReactNode | ((item: T) => ReactNode);
@@ -118,13 +97,6 @@ export interface ComboBoxProps<
    * elements, since the trigger is itself a button.
    */
   renderValue?: (selectedItems: T[]) => ReactNode;
-
-  /**
-   * Handler that is called when the selection changes. In single selection
-   * mode the value is the selected key (or `null`). In multiple selection
-   * mode the value is an array of selected keys.
-   */
-  onSelectionChange?: (value: Key | Key[] | null) => void;
 }
 
 function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
@@ -134,11 +106,7 @@ function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
   disabled,
   readOnly,
   error,
-  defaultValue,
-  value,
   emptyState,
-  onChange,
-  onSelectionChange,
   children,
   loading,
   renderValue,
@@ -150,10 +118,6 @@ function ComboBoxBase<T extends object, M extends SelectionMode = 'single'>({
     isReadOnly: readOnly,
     isRequired: required,
     isInvalid: error,
-    defaultInputValue: defaultValue,
-    inputValue: value,
-    onInputChange: onChange,
-    onChange: onSelectionChange as RAC.ComboBoxProps<T, M>['onChange'],
     ...rest,
   };
 

--- a/packages/components/src/ComboBox/MobileCombobox.tsx
+++ b/packages/components/src/ComboBox/MobileCombobox.tsx
@@ -11,8 +11,6 @@ import { Tray } from '../Tray/Tray';
 import { ChevronsVertical } from '../icons/ChevronsVertical';
 import { intlMessages } from '../intl/messages';
 
-// Props
-// ---------------
 interface MobileComboBoxTriggerProps<T extends object> {
   placeholder?: string;
   renderValue?: (selectedItems: T[]) => ReactNode;
@@ -26,8 +24,6 @@ interface MobileComboBoxProps<T extends object> {
   renderValue?: (selectedItems: T[]) => ReactNode;
 }
 
-// Trigger Display (for Mobile mode)
-// ---------------
 const MobileComboBoxTrigger = <T extends object>({
   placeholder,
   renderValue,
@@ -40,9 +36,7 @@ const MobileComboBoxTrigger = <T extends object>({
       <ComboBoxValue<T>
         className={cn(
           'w-full flex-1 truncate text-left text-nowrap',
-          // Error state: targets when parent FieldBase has data-error attribute
           'group-data-error/field:ui-state-error',
-          // Focus state: targets when parent Button has data-focus-visible attribute
           'group-data-focus-visible/trigger:ui-state-focus',
           inputClassNames.input
         )}
@@ -52,10 +46,7 @@ const MobileComboBoxTrigger = <T extends object>({
             return <span className="text-secondary">{placeholder}</span>;
           }
           if (renderValue) {
-            const items = selectedItems.filter(
-              (item): item is T => item != null
-            );
-            return renderValue(items);
+            return renderValue(selectedItems.filter((i): i is T => i != null));
           }
           return defaultChildren;
         }}
@@ -73,8 +64,6 @@ const MobileComboBoxTrigger = <T extends object>({
   );
 };
 
-// Component
-// ---------------
 const MobileComboBox = <T extends object>({
   placeholder,
   label,

--- a/packages/components/src/ComboBox/MobileCombobox.tsx
+++ b/packages/components/src/ComboBox/MobileCombobox.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
-import { use } from 'react';
 import { Button as RACButton } from 'react-aria-components/Button';
-import { ComboBoxStateContext } from 'react-aria-components/ComboBox';
+import { ComboBoxValue } from 'react-aria-components/ComboBox';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { cn, useClassNames } from '@marigold/system';
 import { Button } from '../Button/Button';
@@ -14,30 +13,33 @@ import { intlMessages } from '../intl/messages';
 
 // Props
 // ---------------
-interface MobileComboBoxTriggerProps {
+interface MobileComboBoxTriggerProps<T extends object> {
   placeholder?: string;
+  renderValue?: (selectedItems: T[]) => ReactNode;
 }
 
-interface MobileComboBoxProps {
+interface MobileComboBoxProps<T extends object> {
   placeholder?: string;
   label?: ReactNode;
   emptyState?: ReactNode;
-  children?: ReactNode | ((item: object) => ReactNode);
+  children?: ReactNode | ((item: T) => ReactNode);
+  renderValue?: (selectedItems: T[]) => ReactNode;
 }
 
 // Trigger Display (for Mobile mode)
 // ---------------
-const MobileComboBoxTrigger = ({ placeholder }: MobileComboBoxTriggerProps) => {
-  const state = use(ComboBoxStateContext);
+const MobileComboBoxTrigger = <T extends object>({
+  placeholder,
+  renderValue,
+}: MobileComboBoxTriggerProps<T>) => {
   const inputClassNames = useClassNames({ component: 'Input' });
   const comboBoxClassNames = useClassNames({ component: 'ComboBox' });
-  const displayText = state?.selectedItem?.textValue || '';
 
   return (
     <div className={comboBoxClassNames.mobileTrigger}>
-      <span
+      <ComboBoxValue<T>
         className={cn(
-          'w-full flex-1 text-left',
+          'w-full flex-1 truncate text-left text-nowrap',
           // Error state: targets when parent FieldBase has data-error attribute
           'group-data-error/field:ui-state-error',
           // Focus state: targets when parent Button has data-focus-visible attribute
@@ -45,8 +47,19 @@ const MobileComboBoxTrigger = ({ placeholder }: MobileComboBoxTriggerProps) => {
           inputClassNames.input
         )}
       >
-        {displayText || <span className="text-secondary">{placeholder}</span>}
-      </span>
+        {({ selectedItems, isPlaceholder, defaultChildren }) => {
+          if (isPlaceholder || selectedItems.length === 0) {
+            return <span className="text-secondary">{placeholder}</span>;
+          }
+          if (renderValue) {
+            const items = selectedItems.filter(
+              (item): item is T => item != null
+            );
+            return renderValue(items);
+          }
+          return defaultChildren;
+        }}
+      </ComboBoxValue>
       <span
         className={cn(
           'absolute right-2 cursor-pointer',
@@ -62,18 +75,22 @@ const MobileComboBoxTrigger = ({ placeholder }: MobileComboBoxTriggerProps) => {
 
 // Component
 // ---------------
-const MobileComboBox = ({
+const MobileComboBox = <T extends object>({
   placeholder,
   label,
   emptyState,
   children,
-}: MobileComboBoxProps) => {
+  renderValue,
+}: MobileComboBoxProps<T>) => {
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
 
   return (
     <Tray.Trigger>
       <RACButton className="group/trigger outline-none">
-        <MobileComboBoxTrigger placeholder={placeholder} />
+        <MobileComboBoxTrigger<T>
+          placeholder={placeholder}
+          renderValue={renderValue}
+        />
       </RACButton>
       <Tray>
         <Tray.Title>{label}</Tray.Title>
@@ -86,7 +103,7 @@ const MobileComboBox = ({
               )
             }
           >
-            {children}
+            {children as any}
           </ListBox>
         </Tray.Content>
         <Tray.Actions>

--- a/packages/components/src/ComboBox/MobileCombobox.tsx
+++ b/packages/components/src/ComboBox/MobileCombobox.tsx
@@ -16,12 +16,12 @@ interface MobileComboBoxTriggerProps<T extends object> {
   renderValue?: (selectedItems: T[]) => ReactNode;
 }
 
-interface MobileComboBoxProps<T extends object> {
-  placeholder?: string;
+interface MobileComboBoxProps<
+  T extends object,
+> extends MobileComboBoxTriggerProps<T> {
   label?: ReactNode;
   emptyState?: ReactNode;
   children?: ReactNode | ((item: T) => ReactNode);
-  renderValue?: (selectedItems: T[]) => ReactNode;
 }
 
 const MobileComboBoxTrigger = <T extends object>({
@@ -92,7 +92,7 @@ const MobileComboBox = <T extends object>({
               )
             }
           >
-            {children as any}
+            {children}
           </ListBox>
         </Tray.Content>
         <Tray.Actions>


### PR DESCRIPTION
## Summary

`<ComboBox>` now supports multi-select via `selectionMode="multiple"`, mirroring the API on `<Select>`. While at it, the props for selection vs. input filtering are renamed so both components stay consistent with React Aria Components.

- Generic signature: `ComboBoxProps<T, M extends SelectionMode>` with `M` defaulting to `'single'`.
- New `renderValue?: (selectedItems: T[]) => ReactNode` prop to customize the mobile trigger when items are selected.
- Mobile trigger now uses `<ComboBoxValue>` so a comma-separated list of selected items renders in both single and multi modes.
- Exposes `<ComboBox.Value>` (re-export of react-aria's `ComboBoxValue`) for rendering selected items in custom layouts.

## Breaking changes

Prop names on `<ComboBox>` now match React Aria Components and Marigold's `<Select>`:

| Before              | After               | Purpose                      |
| ------------------- | ------------------- | ---------------------------- |
| `value`             | `inputValue`        | Controlled input filter text |
| `defaultValue`      | `defaultInputValue` | Default input filter text    |
| `onChange`          | `onInputChange`     | Input filter change handler  |
| `onSelectionChange` | `onChange`          | Selection change handler     |

In multiple selection mode `onChange` receives `Key[]`; in single mode it receives `Key | null` (matching React Aria's `ChangeValueType<M>`).

## Docs & stories

- New `combobox-multiple` demo plus a Multiselection section in the ComboBox docs.
- Existing demos (`combobox-action`, `combobox-controlled`, `combobox-async`) and the MDX prose are migrated to the new prop names.
- New `Multiple` and `WithRenderValue` stories, both tagged `component-test`.

## Test plan

- [x] `pnpm typecheck:only` passes
- [x] `pnpm test:unit packages/components/src/ComboBox` — 17/17
- [x] `pnpm test:sb packages/components/src/ComboBox` — 12/12 (incl. `Multiple` and `WithRenderValue`)
- [ ] Manual smoke test in Storybook (`pnpm sb` → ComboBox → Multiple)
- [ ] Manual smoke test on mobile viewport (`WithRenderValue`)

Closes [DST-1462](https://reservix.atlassian.net/browse/DST-1462).


[DST-1462]: https://reservix.atlassian.net/browse/DST-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ