### PR TITLE
fix(DSTSUP-257): commit RangeCalendar month/year dropdown selection on touch

### DIFF
--- a/.changeset/dstsup-257-rangecalendar-touch-dropdown.md
+++ b/.changeset/dstsup-257-rangecalendar-touch-dropdown.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-257): commit RangeCalendar month/year dropdown selection on touch
+
+The dropdown overlay attached an unconditional `pointerup` `stopPropagation` listener to guard against react-aria's range-commit on overlay taps. On touch devices that also swallowed the event before react-aria's `usePress` click-completion fallback could run, so tapping a month or year never fired `onPress` and the selection was silently lost (the dropdown stayed open and the grid did not switch). The guard now skips `role="option"` targets, letting option taps bubble through while still protecting taps on empty overlay area. Desktop mouse behaviour is unchanged.

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -437,6 +437,46 @@ export const YearDropdown = meta.story({
   },
 });
 
+// Regression (DSTSUP-257): tapping a month option with touch input must commit
+// the selection. An unconditional `pointerup` stopPropagation on the dropdown
+// overlay used to swallow the event before react-aria's `usePress` touch
+// click-completion fallback could fire, so `onPress` never ran and the grid
+// never switched. We tap with touch pointer events (not a mouse click, which
+// always synthesizes a native click and therefore hides the bug).
+export const MonthDropdownTouch = meta.story({
+  tags: ['component-test'],
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ canvasElement, userEvent, step }) => {
+    const canvas = within(canvasElement);
+    const tap = (target: Element) =>
+      userEvent.pointer([{ keys: '[TouchA>]', target }, { keys: '[/TouchA]' }]);
+
+    await step('opens the month dropdown via touch', async () => {
+      await tap(canvas.getByRole('button', { name: 'Aug' }));
+      await expect(
+        canvas.getByRole('listbox', { name: 'monthOptions' })
+      ).toBeInTheDocument();
+    });
+
+    await step('commits a month selection via touch', async () => {
+      const monthOptions = canvas.getByRole('listbox', {
+        name: 'monthOptions',
+      });
+      const march = within(monthOptions).getByRole('option', { name: /Mar/i });
+
+      await tap(march);
+
+      // Dropdown closes and the grid switches to the tapped month.
+      await expect(
+        canvas.queryByRole('listbox', { name: 'monthOptions' })
+      ).not.toBeInTheDocument();
+      await expect(
+        canvas.getByRole('button', { name: 'Mar' })
+      ).toBeInTheDocument();
+    });
+  },
+});
+
 export const TwoMonthsRangeSelection = meta.story({
   tags: ['component-test'],
   args: {

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -140,18 +140,18 @@ const _RangeCalendar = <T extends DateValue>({
     ViewMapKeys | undefined
   >();
 
-  // react-aria's `useRangeCalendar` registers a window-level `pointerup`
-  // listener that commits the in-progress range when the click target is not
-  // a button. RAC's <ListBoxItem> renders with role="option", so picking a
-  // month or year would otherwise trip that commit and drop the user's first
-  // click. A native listener is required (not React's `onPointerUpCapture`)
-  // because react-aria's listener also runs on the native event, before any
-  // synthetic event would reach a React capture handler. Using a callback
-  // ref ensures the listener (re)attaches whenever the overlay node mounts,
-  // including when `visibleDuration` toggles single↔multi at runtime.
+  // react-aria's `useRangeCalendar` commits the range on any window `pointerup`
+  // whose target isn't a button, so a tap on the overlay would wrongly commit.
+  // We stop those pointerups — but must let `role="option"` taps through, or
+  // `usePress`'s touch fallback never fires and month/year selection silently
+  // fails on touch (DSTSUP-257). A native listener via callback ref is needed
+  // because react-aria also listens natively, before React's capture phase.
   const dropdownOverlayRef = useCallback((node: HTMLDivElement | null) => {
     if (!node) return;
-    const stop = (event: PointerEvent) => event.stopPropagation();
+    const stop = (event: PointerEvent) => {
+      if ((event.target as Element)?.closest('[role="option"]')) return;
+      event.stopPropagation();
+    };
     node.addEventListener('pointerup', stop);
     return () => node.removeEventListener('pointerup', stop);
   }, []);


### PR DESCRIPTION
# Description

Inside `<RangeCalendar>`, tapping a month or year option on a touch device failed to commit the selection — the dropdown stayed open and the calendar grid never switched. The dropdown overlay attached an unconditional `pointerup` `stopPropagation` listener (to stop react-aria's `useRangeCalendar` from committing the range when the overlay is tapped). On touch that also killed react-aria's `usePress` click-completion fallback, so `onPress` never fired.

The guard now skips `role="option"` targets, letting option taps bubble through to `usePress` while still protecting taps on the empty overlay area. Desktop mouse behaviour is unchanged; single-date `<Calendar>` was never affected (it doesn't install this listener).

Closes DSTSUP-257

## Screenshots / Preview

<!-- Touch-only interaction fix — best shown via Chrome DevTools mobile emulation on the RangeCalendar story. Paste a GIF if helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. `pnpm sb` → open `Components/RangeCalendar/Basic`.
2. Open Chrome DevTools, toggle Device Toolbar (e.g. iPhone 14 Pro) to switch the pointer type to `touch`.
3. Tap the month dropdown, then tap a different month → the grid switches and the dropdown closes.
4. Repeat for the year dropdown.
5. Automated: `pnpm test:sb --run RangeCalendar` (includes the new `MonthDropdownTouch` regression story).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with \`component-test\` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)