### PR TITLE
fix(DST-1480): guard Panel aria-labelledby on hasTitle

### DIFF
--- a/.changeset/dst-1480-panel-aria-labelledby-guard.md
+++ b/.changeset/dst-1480-panel-aria-labelledby-guard.md
@@ -1,0 +1,11 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1480): only set `aria-labelledby` on Panel when a Title is present
+
+`<Panel>` previously rendered `aria-labelledby={titleId}` whenever no `aria-label` was given, even if no `<Title>` was present. That left the `<section>` landmark pointing at an id no element carried, producing a broken/empty accessible name.
+
+The guard now also checks `hasTitle`, so `aria-labelledby` is only applied when a `<Title>` actually renders. This mirrors the stricter guard adopted by `Card` in DST-1373.
+
+[DST-1480](https://reservix.atlassian.net/browse/DST-1480)

--- a/packages/components/src/Panel/Panel.tsx
+++ b/packages/components/src/Panel/Panel.tsx
@@ -126,7 +126,7 @@ export const Panel = ({
     >
       <section
         data-panel
-        aria-labelledby={!ariaLabel ? titleId : undefined}
+        aria-labelledby={!ariaLabel && hasTitle ? titleId : undefined}
         aria-label={ariaLabel}
         className={cn(
           'flex flex-col gap-y-(--panel-gap) pt-(--panel-py) pb-(--panel-py) has-[[data-collapsible]:last-child]:pb-0',


### PR DESCRIPTION
# Description

`<Panel>` previously rendered `aria-labelledby={titleId}` whenever no `aria-label` was given — even when no `<Title>` was present. That left the `<section>` landmark referencing an `id` that no element carried, producing a broken/empty accessible name for title-less, label-less panels.

The guard now also checks `hasTitle` (already computed and threaded through context), so `aria-labelledby` is only applied when a `<Title>` actually renders:

```diff
- aria-labelledby={!ariaLabel ? titleId : undefined}
+ aria-labelledby={!ariaLabel && hasTitle ? titleId : undefined}
```

This backports the stricter guard adopted by `Card` in DST-1373 (#5461), where it was flagged in review that Panel's looser `!ariaLabel` check could dangle `aria-labelledby` at an absent title.

Closes DST-1480

## Test Instructions

1. Render a `<Panel>` with neither a `<Title>` nor an `aria-label`. Inspect the root `<section>` — it should **not** carry an `aria-labelledby` attribute (previously it pointed at a non-existent id).
2. Existing behaviour is unchanged: a Panel with a `<Title>` is still labelled via `aria-labelledby`; a Panel with `aria-label` still uses that as its accessible name and omits `aria-labelledby`.

## Breaking Changes

No

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

---

> [!NOTE]
> Single-token fix mirroring the Card precedent (`!ariaLabel && hasTitle`). No new story/test was added: covering the "neither Title nor aria-label" case would require introducing an intentionally **unnamed-landmark** story, which would also trip the a11y story-test run. The change is gated by `hasTitle` (already in scope) and leaves all existing Panel tests passing (Basic + TitleOnlyWithoutHeader have a Title; AriaLabeled is gated by `!ariaLabel`). Happy to add a dedicated regression test if preferred.
