### PR TITLE
test: add failing regression story for RangeCalendar mid-range dropdown commit

### DIFF
--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -477,6 +477,46 @@ export const MonthDropdownTouch = meta.story({
   },
 });
 
+// Regression: the touch fix in #5479 lets `role="option"` taps bubble past the
+// dropdown overlay so they reach react-aria's window-level `pointerup`. When a
+// range selection is already in progress (a start date picked, `anchorDate`
+// set), `useRangeCalendar`'s `endDragging` then commits the range as soon as the
+// user taps a month/year option — even though they only meant to navigate.
+// This story fails on `main`: picking a month mid-selection wrongly fires
+// `onChange`. Uses a plain mouse click, so it also proves the regression is not
+// touch-only (the merged PR claimed "desktop behaviour is unchanged").
+export const MidRangeMonthSwitchRegression = meta.story({
+  tags: ['component-test'],
+  args: {
+    onChange: fn(),
+    defaultFocusedValue: new CalendarDate(2025, 8, 15),
+  },
+  render: args => <RangeCalendar {...args} />,
+  play: async ({ args, canvasElement, userEvent, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('select a start date (range now in progress)', async () => {
+      await userEvent.click(canvas.getByLabelText(/August 15, 2025/i));
+      // the first click of a range must not commit anything yet
+      await expect(args.onChange).not.toHaveBeenCalled();
+    });
+
+    await step('open the month dropdown and pick a different month', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Aug' }));
+      const monthOptions = canvas.getByRole('listbox', {
+        name: 'monthOptions',
+      });
+      await userEvent.click(
+        within(monthOptions).getByRole('option', { name: /Mar/i })
+      );
+    });
+
+    await step('switching months must NOT commit the range', async () => {
+      await expect(args.onChange).not.toHaveBeenCalled();
+    });
+  },
+});
+
 export const TwoMonthsRangeSelection = meta.story({
   tags: ['component-test'],
   args: {


### PR DESCRIPTION
## What

Adds a `component-test` story `MidRangeMonthSwitchRegression` to `RangeCalendar` that reproduces a regression introduced in #5479.

⚠️ **This PR is intentionally red.** It contains only the failing test, no fix — it documents the bug so it can be confirmed and fixed separately.

## The regression

#5479 fixed touch month/year selection by letting `role="option"` pointerups bubble past the dropdown overlay. But when a range selection is already in progress (start date picked, react-aria's `anchorDate` set), those pointerups now reach `useRangeCalendar`'s window-level listener, which commits the in-progress range on the focused date as soon as the user taps a month/year option — even though they only meant to navigate.

The story picks a start date, opens the month dropdown, picks a different month, and asserts `onChange` was **not** called. It currently fails (`onChange` fires). It uses a plain **mouse click**, so the regression is not touch-only — #5479's "desktop behaviour is unchanged" doesn't hold once a range is in progress.

## Notes

- No changeset (test-only, nothing to release).
- A fix is straightforward (move the overlay's `stopPropagation` guard from the overlay node to `node.ownerDocument`, scoped with `node.contains(target)`, so `usePress` still completes on touch but `window`/`endDragging` never commits) but is deliberately left out of this PR.
