### PR TITLE
fix(DST-1482): make the width prop size field components again

### DIFF
--- a/.changeset/dst-1482-field-width-prop.md
+++ b/.changeset/dst-1482-field-width-prop.md
@@ -1,0 +1,13 @@
+---
+'@marigold/theme-rui': patch
+'@marigold/components': patch
+'@marigold/system': patch
+---
+
+fix(DST-1482): make the `width` prop size field components again
+
+Setting `width` on a field component (`<Select>`, `<TextField>`, `<NumberField>`, …) had no visible effect — the field sized to its content and consumers had to wrap it in an extra element. `FieldBase` sets the `--field-width` CSS variable for its child field element to consume via `w-(--field-width)`, but the variable was registered with `@property … { inherits: false }`, so it never reached the child and `width` fell back to `auto`.
+
+`--field-width` is now registered with `inherits: true`, restoring the intended parent→child handoff. The same-element layout variables (`--width`, `--max-width`, `--height`, `--container-width`) keep their non-inheriting leak protection.
+
+Also clarifies in the prop docs that numeric `width` values are spacing-scale tokens, not pixels: `width={64}` resolves to `calc(var(--spacing) * 64)` ≈ 16rem (256px).

--- a/docs/content/foundations/form-fields/index.mdx
+++ b/docs/content/foundations/form-fields/index.mdx
@@ -96,6 +96,15 @@ The width of form fields can be adjusted based on the context and design require
 
 Scale values may be passed either as a number or as the equivalent string — both `width={32}` and `width="32"` are valid and produce the same result. The same applies to spacing-scale props on layout components (`space`, `spaceX`, `spaceY`, `pl`, `pr`, `pt`, `pb`).
 
+Numeric values map to the spacing scale, **not** pixels: `width={64}` resolves to `calc(var(--spacing) * 64)`, roughly `16rem` (256px), not 64px. The `width` prop sizes the field element directly, so no wrapper element is needed.
+
+```tsx
+<TextField label="Name" width={64} />
+<Select label="Country" width="1/2">
+  {/* options */}
+</Select>
+```
+
 When using fixed/keywords widths the `label` and `description` won't be included in the width calculation and won't adapt to the width of the field. The text will not shrink if the field is too small to fit the text.
 
 For fraction values, the field will take up the specified fraction of the width of its parent container. This is particularly useful for creating responsive layouts where fields need to adjust based on the available space.

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -117,6 +117,9 @@ export interface AutocompleteProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default 'full'
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/Checkbox/CheckboxGroup.tsx
@@ -63,6 +63,9 @@ export interface CheckboxGroupProps
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
    *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
+   *
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/Checkbox/CheckboxGroup.tsx
@@ -65,7 +65,6 @@ export interface CheckboxGroupProps
    *
    * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
    * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
-   *
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/DateField/DateField.tsx
+++ b/packages/components/src/DateField/DateField.tsx
@@ -58,6 +58,9 @@ export interface DateFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default 'full'
    */
   width?: WidthProp['width'];

--- a/packages/components/src/DatePicker/DatePicker.tsx
+++ b/packages/components/src/DatePicker/DatePicker.tsx
@@ -73,6 +73,9 @@ export interface DatePickerProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    */
   width?: WidthProp['width'];
 }

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -24,6 +24,9 @@ export interface FileFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Multiselect/Multiselect.tsx
+++ b/packages/components/src/Multiselect/Multiselect.tsx
@@ -32,6 +32,9 @@ export interface MultipleSelectProps extends Pick<
 > {
   /**
    * Sets the width of the field.
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    */
   width?: WidthProp['width'];
   /**

--- a/packages/components/src/NumberField/NumberField.tsx
+++ b/packages/components/src/NumberField/NumberField.tsx
@@ -26,6 +26,9 @@ export interface NumberFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -17,6 +17,9 @@ export interface RadioProps extends Omit<RAC.RadioProps, RemovedProps> {
   size?: string;
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: string;

--- a/packages/components/src/SearchField/SearchField.tsx
+++ b/packages/components/src/SearchField/SearchField.tsx
@@ -32,6 +32,9 @@ export interface SearchFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -658,3 +658,37 @@ export const Mobile = meta.story({
     });
   },
 });
+
+/**
+ * Regression guard for DST-1482: a fixed `width` must size the field element
+ * itself (the trigger), not just the FieldBase wrapper. `width={64}` maps to the
+ * spacing scale, i.e. `calc(var(--spacing) * 64)` = 16rem (256px at default root
+ * font-size), and must drive the trigger's layout without an outer wrapper.
+ */
+export const FixedWidth = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Favorite',
+    width: 64,
+  },
+  render: args => (
+    <Select {...args} placeholder="Pick">
+      <Select.Option id="Star Wars">Star Wars</Select.Option>
+      <Select.Option id="Star Trek">Star Trek</Select.Option>
+    </Select>
+  ),
+  play: async ({ canvas, step }) => {
+    await step('Trigger width matches the requested scale value', async () => {
+      const button = canvas.getByRole('button', { name: /Favorite/i });
+      const rem = parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      );
+      // width={64} => calc(var(--spacing) * 64) = 64 * 0.25rem = 16rem
+      const expected = 16 * rem;
+      const { width } = button.getBoundingClientRect();
+
+      expect(width).toBeGreaterThan(rem * 12);
+      expect(Math.abs(width - expected)).toBeLessThanOrEqual(1);
+    });
+  },
+});

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -36,6 +36,12 @@ export interface SelectProps<
   variant?: string;
   size?: string;
 
+  /**
+   * Sets the width of the field.
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
+   */
   width?: WidthProp['width'];
   /**
    * Children of the select.

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -35,6 +35,9 @@ export interface SliderProps<T>
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -24,6 +24,9 @@ export interface SwitchProps extends Omit<RAC.SwitchProps, RemovedProps> {
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/TagGroup/TagGroup.tsx
+++ b/packages/components/src/TagGroup/TagGroup.tsx
@@ -19,6 +19,9 @@ export interface TagGroupProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/TextArea/TextArea.tsx
+++ b/packages/components/src/TextArea/TextArea.tsx
@@ -27,6 +27,9 @@ export interface TextAreaProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/TextField/TextField.stories.tsx
+++ b/packages/components/src/TextField/TextField.stories.tsx
@@ -219,14 +219,13 @@ export const FixedWidth = meta.story({
   tags: ['component-test'],
   args: {
     label: 'Name',
-    description: '',
     width: 64,
   },
   render: args => <TextField {...args} placeholder="Type" />,
   play: async ({ canvas, step }) => {
     await step('Input width matches the requested scale value', async () => {
       // The --field-width consumer is the `group/input` wrapper of the input.
-      const wrapper = canvas.getByRole('textbox').parentElement!;
+      const wrapper = canvas.getByRole('textbox').closest('.group\\/input')!;
       const rem = parseFloat(
         getComputedStyle(document.documentElement).fontSize
       );

--- a/packages/components/src/TextField/TextField.stories.tsx
+++ b/packages/components/src/TextField/TextField.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Form } from '../Form/Form';
@@ -206,4 +207,35 @@ export const WithFormValidation = meta.story({
       </Stack>
     </Form>
   ),
+});
+
+/**
+ * Regression guard for DST-1482: a fixed `width` must size the input element
+ * itself, not just the FieldBase wrapper. `width={64}` maps to the spacing
+ * scale, i.e. `calc(var(--spacing) * 64)` = 16rem (256px at default root
+ * font-size), and must drive the input's layout without an outer wrapper.
+ */
+export const FixedWidth = meta.story({
+  tags: ['component-test'],
+  args: {
+    label: 'Name',
+    description: '',
+    width: 64,
+  },
+  render: args => <TextField {...args} placeholder="Type" />,
+  play: async ({ canvas, step }) => {
+    await step('Input width matches the requested scale value', async () => {
+      // The --field-width consumer is the `group/input` wrapper of the input.
+      const wrapper = canvas.getByRole('textbox').parentElement!;
+      const rem = parseFloat(
+        getComputedStyle(document.documentElement).fontSize
+      );
+      // width={64} => calc(var(--spacing) * 64) = 64 * 0.25rem = 16rem
+      const expected = 16 * rem;
+      const { width } = wrapper.getBoundingClientRect();
+
+      expect(width).toBeGreaterThan(rem * 12);
+      expect(Math.abs(width - expected)).toBeLessThanOrEqual(1);
+    });
+  },
 });

--- a/packages/components/src/TextField/TextField.tsx
+++ b/packages/components/src/TextField/TextField.tsx
@@ -28,6 +28,9 @@ export interface TextFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/components/src/TimeField/TimeField.tsx
+++ b/packages/components/src/TimeField/TimeField.tsx
@@ -32,6 +32,9 @@ export interface TimeFieldProps
 
   /**
    * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
    * @default full
    */
   width?: WidthProp['width'];

--- a/packages/system/src/style-props.tsx
+++ b/packages/system/src/style-props.tsx
@@ -375,6 +375,9 @@ export type WidthProp = {
    *
    * Accepts spacing-scale values as either numbers (`4`) or their string
    * equivalents (`"4"`), fractions (`"1/2"`), and keywords (`"full"`, `"fit"`, ...).
+   *
+   * Numeric/scale values are **spacing-scale tokens, not pixels**: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ≈ 16rem (256px), not 64px.
    */
   width?: WidthValue;
 };

--- a/themes/theme-rui/src/theme.css
+++ b/themes/theme-rui/src/theme.css
@@ -440,7 +440,8 @@
   syntax: '*';
   inherits: false;
 }
+/* Intentionally inherits: FieldBase sets --field-width for its child field element to consume. */
 @property --field-width {
   syntax: '*';
-  inherits: false;
+  inherits: true;
 }


### PR DESCRIPTION
# Description

Setting the `width` prop on Marigold field components (`<Select>`, `<TextField>`, `<NumberField>`, …) had no visible effect in `18.0.0-beta.2` — the field shrink-wrapped to its content, so consumers had to wrap it in an extra fixed-width `div`.

`FieldBase` sets the `--field-width` CSS variable for its child field element to consume via `w-(--field-width)`, but DST-901 registered the variable with `@property { inherits: false }`. With inheritance off, the value set on `FieldBase` never reached the child, so `w-(--field-width)` resolved to its guaranteed-invalid initial value and `width` fell back to `auto`. This PR registers `--field-width` with `inherits: true`, restoring the intended **parent→child handoff**. The same-element layout vars (`--width`, `--max-width`, `--height`, `--container-width`) keep their non-inheriting leak protection. A single CSS change fixes every affected field component (Select, TextField, TextArea, NumberField, SearchField, ComboBox, Autocomplete, …).

**Behavior change:** fields that previously sized to their content now honor a fixed/keyword `width` directly — no wrapper needed. Fractions (`width="1/2"`) and the full-width default are unchanged.

Also documents that numeric `width` values are spacing-scale **tokens, not pixels** (`width={64}` → `calc(var(--spacing) * 64)` ≈ 16rem/256px) on the prop JSDoc and the Form Fields foundations page, and adds computed-width regression guards.

Closes DST-1482

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. `pnpm build:themes`, then `pnpm sb`.
2. Render `<Select width={64}>` — confirm the trigger is ~256px (16rem) and no longer content-sized; no wrapper required.
3. Spot-check `TextField`, `TextArea`, `NumberField`, `SearchField`, `ComboBox`, `Autocomplete` with a fixed `width`, with `width="1/2"` (still responsive), and with no width (full-width default).
4. `pnpm test:sb` — the new `FixedWidth` play stories on Select/TextField assert the rendered field width equals 16rem.
5. `pnpm test:unit` — existing class-based assertions still pass.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [x] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)