### PR TITLE
docs(DST-1362): add loading, layout-children, no-table-layout and action-hierarchy guidance

### DIFF
--- a/docs/content/components/actions/button/index.mdx
+++ b/docs/content/components/actions/button/index.mdx
@@ -58,6 +58,8 @@ It is essential that the label and context around the button clearly set expecta
 
 This primary button should represent the most crucial action within that section. Having multiple primary buttons in one section can create confusion and visual clutter, as they compete for the user's attention and detract from the clarity of the intended action.
 
+For how this hierarchy applies to a form's actions, see [Action hierarchy](/patterns/user-input/forms#action-hierarchy) in the Forms pattern.
+
 <GuidelineTiles>
   <Do>
     <DoFigure>
@@ -244,6 +246,28 @@ When the loading state is activated, the label becomes hidden. To ensure accessi
 The `loading` property must be added manually to a Button, and is intended for processes that typically last more than 1 second.
 
 <ComponentDemo name="button-loading" />
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Use the `loading` prop on the action button to show progress, so the
+      indicator stays on the button that triggered the action.
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't place a separate `<Loader>` next to a button or swap the label for a
+      loader manually. Use the built-in `loading` prop instead.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
+<Callout title="Pending state from async actions">
+  When the loading state comes from a React 19 action, let `useActionState`
+  manage the pending flag and pass it to the button. See [Async forms and
+  useActionState
+  hook](/patterns/user-input/form-implementation#async-forms-and-useactionstate-hook).
+</Callout>
 
 ### Full-width
 

--- a/docs/content/components/collection/table/index.mdx
+++ b/docs/content/components/collection/table/index.mdx
@@ -455,5 +455,26 @@ Is there still not the right alternative for you please [get in touch](/resource
         </svg>
       ),
     },
+    {
+      title: 'Layouts',
+      href: '/foundations/layouts',
+      caption: 'Use a layout component, not a Table, to arrange UI.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6A2.25 2.25 0 0 1 6 3.75h12A2.25 2.25 0 0 1 20.25 6v12A2.25 2.25 0 0 1 18 20.25H6A2.25 2.25 0 0 1 3.75 18V6Zm0 4.5h16.5m-9-6.75v16.5"
+          />
+        </svg>
+      ),
+    },
   ]}
 />

--- a/docs/content/foundations/layouts/index.mdx
+++ b/docs/content/foundations/layouts/index.mdx
@@ -48,3 +48,40 @@ The components listed below can be nested within each other any number of times 
 - [Split](../components/layout/split)
 - [Stack](../components/layout/stack)
 - [Tiles](../components/layout/tiles)
+
+## Reach for a layout component only with two or more children
+
+A layout component's whole job is to _arrange_ elements in relation to one another. Just like `Inline` and `Stack` express the named intent "lay these out horizontally" or "stack these vertically", that intent only exists once there is more than one thing to arrange. A layout component therefore earns its place only when it arranges **two or more children**. With a single child there is nothing to arrange, so render the element directly instead of wrapping it.
+
+```tsx
+// Don't: a layout component around a single child adds no intent
+<Stack>
+  <Card>…</Card>
+</Stack>
+
+// Do: render the element directly
+<Card>…</Card>
+```
+
+This keeps the JSX tree honest: every layout component in the markup signals a real arrangement decision, not incidental nesting.
+
+<Callout title="Padding and centering wrappers are different">
+  Components whose intent is to wrap a _single_ element — `Inset` for padding
+  and `Center` for centering — legitimately take one child. The two-or-more rule
+  applies to arrangement components like `Stack`, `Inline`, `Columns`, `Grid`
+  and `Tiles`, where a single child carries no arrangement.
+</Callout>
+
+<Callout title="Table is for data, not layout" type="warning">
+  `Table` must never be used as a layout grid. It expresses tabular _data_ with
+  rows and columns of related values — not a way to align arbitrary elements.
+
+For arranging UI, reach for a layout component instead. In particular,
+**form fields belong in `Stack`, `Inline` or `Columns`, never in
+`Table.Cell`** — putting inputs in table cells to line them up breaks the
+named-intent model and harms accessibility.
+
+See the [Table](/components/collection/table) component for its legitimate use,
+and the [Forms](/patterns/user-input/forms) pattern for laying out fields.
+
+</Callout>

--- a/docs/content/foundations/layouts/index.mdx
+++ b/docs/content/foundations/layouts/index.mdx
@@ -74,14 +74,11 @@ This keeps the JSX tree honest: every layout component in the markup signals a r
 
 <Callout title="Table is for data, not layout" type="warning">
   `Table` must never be used as a layout grid. It expresses tabular _data_ with
-  rows and columns of related values — not a way to align arbitrary elements.
-
-For arranging UI, reach for a layout component instead. In particular,
-**form fields belong in `Stack`, `Inline` or `Columns`, never in
-`Table.Cell`** — putting inputs in table cells to line them up breaks the
-named-intent model and harms accessibility.
-
-See the [Table](/components/collection/table) component for its legitimate use,
-and the [Forms](/patterns/user-input/forms) pattern for laying out fields.
-
+  rows and columns of related values, not a way to align arbitrary elements. For
+  arranging UI, reach for a layout component instead: **form fields belong in
+  `Stack`, `Inline` or `Columns`, never in `Table.Cell`**, since putting inputs
+  in table cells to line them up breaks the named-intent model and harms
+  accessibility. See the [Table](/components/collection/table) component for its
+  legitimate use, and the [Forms](/patterns/user-input/forms) pattern for laying
+  out fields.
 </Callout>

--- a/docs/content/patterns/user-input/forms/index.mdx
+++ b/docs/content/patterns/user-input/forms/index.mdx
@@ -115,14 +115,15 @@ A normal form has exactly **one** primary action: the submit. Everything else st
 
 Map each action to a Button variant by its role:
 
-| Action role                                           | Use                     |
-| ----------------------------------------------------- | ----------------------- |
-| Submit the form (the one primary action)              | `primary`               |
-| Supporting form operation ("Save as Draft", "Reset")  | `secondary`             |
-| Low-emphasis action that should stay quiet            | `ghost`                 |
-| Navigation away from the form (terms, privacy policy) | `<Link>`/`<LinkButton>` |
+| Action role                                           | Use                               |
+| ----------------------------------------------------- | --------------------------------- |
+| Submit the form (the one primary action)              | `primary`                         |
+| Supporting form operation ("Save as Draft", "Reset")  | `secondary`                       |
+| Low-emphasis action that should stay quiet            | `ghost`                           |
+| Destructive form action ("Delete account")            | `destructive`/`destructive-ghost` |
+| Navigation away from the form (terms, privacy policy) | `<Link>`/`<LinkButton>`           |
 
-This is the same cascade the Button component describes. See [Visual hierarchy](/components/actions/button#visual-hierarchy) for why a section gets only one primary action, and [Placement and order](/components/actions/button#placement-and-order) for how the `primary → secondary → ghost` variants line up.
+This is the same cascade the Button component describes. See [Visual hierarchy](/components/actions/button#visual-hierarchy) for why a section gets only one primary action, [Placement and order](/components/actions/button#placement-and-order) for how the `primary → secondary → ghost` variants line up, and [Destructive buttons](/components/actions/button#destructive-buttons) for when a form action carries irreversible consequences.
 
 <Callout title="Settings pages are the exception">
   Settings pages are the one place where a single page carries more than one

--- a/docs/content/patterns/user-input/forms/index.mdx
+++ b/docs/content/patterns/user-input/forms/index.mdx
@@ -48,7 +48,7 @@ See the [Form Fields](../../foundations/form-fields) page for a full guide on in
 
 Beyond those, you'll likely need some of these to put a form together:
 
-- **Layout components**: [`<Stack>`](../../components/layout/stack/) and [`<Inset>`](../../components/layout/inset/) to organize fields and sections.
+- **Layout components**: [`<Stack>`](../../components/layout/stack/) and [`<Inset>`](../../components/layout/inset/) to organize fields and sections. See [Layouts](/foundations/layouts) for choosing the right layout component (and why fields never belong in a `<Table>`).
 - **Accordion**: Group fields with an [accordion](../../components/navigation/accordion/) for lengthy forms or optional fields. Use accordions for sections that can be collapsed to save space and reduce cognitive load.
 - **Buttons**: Use primary [buttons](../../components/actions/button/) for form submission, secondary for additional actions like "View PDF".
 - **Links**: Use [links](../../components/navigation/link/) for navigation to privacy policies or terms of service, not for form actions.
@@ -108,6 +108,31 @@ Accordions can also be used _within_ a section to group content. This lets users
 ## Actions
 
 Forms usually need more than just a submit button. Links, secondary buttons, and other controls handle everything from navigation to drafts. The key is making each action easy to find and hard to confuse with the primary submit.
+
+### Action hierarchy
+
+A normal form has exactly **one** primary action: the submit. Everything else steps down the hierarchy so the primary action stays unmistakable. Giving two actions the `primary` variant makes them compete for attention and leaves people unsure which one completes the form.
+
+Map each action to a Button variant by its role:
+
+| Action role                                           | Use                     |
+| ----------------------------------------------------- | ----------------------- |
+| Submit the form (the one primary action)              | `primary`               |
+| Supporting form operation ("Save as Draft", "Reset")  | `secondary`             |
+| Low-emphasis action that should stay quiet            | `ghost`                 |
+| Navigation away from the form (terms, privacy policy) | `<Link>`/`<LinkButton>` |
+
+This is the same cascade the Button component describes. See [Visual hierarchy](/components/actions/button#visual-hierarchy) for why a section gets only one primary action, and [Placement and order](/components/actions/button#placement-and-order) for how the `primary → secondary → ghost` variants line up.
+
+<Callout title="Settings pages are the exception">
+  Settings pages are the one place where a single page carries more than one
+  primary action. When a page is split into independently-saving `<Panel>`s,
+  each panel is its own form and owns its own primary save button — so a
+  multi-panel settings page has one primary action _per panel_, not per page.
+  Never share one submit across panels: a save in one panel must not commit the
+  fields of another. Outside of this case, keep it to one primary action per
+  form.
+</Callout>
 
 ### Inline actions
 


### PR DESCRIPTION
## What

Adds human-facing guidance for four recurring pattern drifts (internal ticket DST-1362):

- **Button** (`components/actions/button`): Do/Don't tiles for the `loading` prop ("use this, not a separate `<Loader>`"), callout linking pending state to `useActionState`, cross-link from Visual hierarchy to the forms action-hierarchy section
- **Layouts foundation** (`foundations/layouts`): new section "Reach for a layout component only with two or more children" with Do/Don't snippet, callout exempting padding/centering wrappers (`Inset`/`Center`), warning callout "Table is for data, not layout" with a form-specific note
- **Forms pattern** (`patterns/user-input/forms`): new "Action hierarchy" section — one primary action per form, role→variant table, settings-pages exception (one primary save per independently-saving panel), cross-links to Button Visual hierarchy / Placement and order
- **Table** (`components/collection/table`): Related entry pointing to the layouts guidance

All edits are additive; prettier passes; all anchors verified against the target headings.

## Why

AI-assisted and human work had drifted toward ad-hoc spinners next to buttons, single-child layout wrappers, Tables used to align form fields, and forms with several primary buttons. The equivalent machine-facing rules land in our internal AI-suite skill in a companion MR; this PR makes the docs say the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)