### PR TITLE
feat(DST-1488): enable Shiki line highlighting in docs code examples

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@react-aria/i18n": "3.13.1",
     "@react-types/shared": "3.35.0",
+    "@shikijs/transformers": "^4.0.0",
     "@tanstack/react-query": "^5.62.0",
     "@upstash/redis": "1.37.0",
     "@vercel/analytics": "2.0.1",

--- a/docs/ui/ComponentDemo.tsx
+++ b/docs/ui/ComponentDemo.tsx
@@ -2,6 +2,7 @@
 
 import { type RegistryKey, registry } from '@/.registry/demos';
 import { cn } from '@/lib/cn';
+import { transformerNotationHighlight } from '@shikijs/transformers';
 import { track } from '@vercel/analytics';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
@@ -49,6 +50,16 @@ function fileToRegistryKey(file: string): string {
   const match = normalized.match(/([^/]+)\.demo\.tsx$/);
   return match ? match[1] : normalized;
 }
+
+// Shiki options for the Code tab. Passing `options` replaces fumadocs'
+// default, so the themes are repeated here. `transformerNotationHighlight`
+// lets a demo emphasise lines with a `{/* [!code highlight] */}` marker in
+// the source itself, so the highlight tracks the line through future edits
+// (and the marker is stripped from both the rendered code and the preview).
+const codeOptions = {
+  themes: { light: 'github-light', dark: 'github-dark' },
+  transformers: [transformerNotationHighlight()],
+};
 
 // Preview wrapper component
 // ---------------
@@ -119,17 +130,19 @@ export const ComponentDemo = ({
 
   // Code only mode
   if (mode === 'code') {
-    return <DynamicCodeBlock lang="tsx" code={codeString} />;
+    return (
+      <DynamicCodeBlock lang="tsx" code={codeString} options={codeOptions} />
+    );
   }
 
   // Full mode with Preview + Code tabs
   return (
-    <DemoTabs demoKey={key}>
+    <DemoTabs>
       <Tab value="Preview" className="p-0">
         <Preview name={key} background={background} />
       </Tab>
       <Tab value="Code">
-        <DynamicCodeBlock lang="tsx" code={codeString} />
+        <DynamicCodeBlock lang="tsx" code={codeString} options={codeOptions} />
       </Tab>
     </DemoTabs>
   );
@@ -137,13 +150,7 @@ export const ComponentDemo = ({
 
 // Tracked Tabs wrapper
 // ---------------
-const DemoTabs = ({
-  demoKey,
-  children,
-}: {
-  demoKey: string;
-  children: ReactNode;
-}) => (
+const DemoTabs = ({ children }: { children: ReactNode }) => (
   <Tabs
     items={['Preview', 'Code']}
     defaultIndex={0}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       '@react-types/shared':
         specifier: 3.35.0
         version: 3.35.0(react@19.2.6)
+      '@shikijs/transformers':
+        specifier: ^4.0.0
+        version: 4.2.0
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.90.21(react@19.2.6)
@@ -3298,6 +3301,10 @@ packages:
     resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
     engines: {node: '>=20'}
 
+  '@shikijs/core@4.2.0':
+    resolution: {integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==}
+    engines: {node: '>=20'}
+
   '@shikijs/engine-javascript@4.1.0':
     resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
     engines: {node: '>=20'}
@@ -3314,12 +3321,24 @@ packages:
     resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
     engines: {node: '>=20'}
 
+  '@shikijs/primitive@4.2.0':
+    resolution: {integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==}
+    engines: {node: '>=20'}
+
   '@shikijs/themes@4.1.0':
     resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
     engines: {node: '>=20'}
 
+  '@shikijs/transformers@4.2.0':
+    resolution: {integrity: sha512-pKrYVNUr1oPjJvs76gkPPirDySx3GKG9O88P2Y3AQ+7AjSFws9Y+Ry/Q/6Yg6QpyigzjdQ6H5JAMNAvLXZ63dw==}
+    engines: {node: '>=20'}
+
   '@shikijs/types@4.1.0':
     resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.2.0':
+    resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -11232,6 +11251,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@4.2.0':
+    dependencies:
+      '@shikijs/primitive': 4.2.0
+      '@shikijs/types': 4.2.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@4.1.0':
     dependencies:
       '@shikijs/types': 4.1.0
@@ -11253,11 +11280,27 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/primitive@4.2.0':
+    dependencies:
+      '@shikijs/types': 4.2.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   '@shikijs/themes@4.1.0':
     dependencies:
       '@shikijs/types': 4.1.0
 
+  '@shikijs/transformers@4.2.0':
+    dependencies:
+      '@shikijs/core': 4.2.0
+      '@shikijs/types': 4.2.0
+
   '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.2.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4


### PR DESCRIPTION
# Description

The **Code** tab of every `<ComponentDemo>` had no way to draw the reader's eye to the line that actually embodies the concept the surrounding prose describes. fumadocs' `DynamicCodeBlock` highlights with Shiki and accepts Shiki `transformers`, but none were wired up for the demo Code tab.

This enables Shiki line highlighting for demo code examples:

- Wires `transformerNotationHighlight()` into `ComponentDemo`'s `DynamicCodeBlock` options (both the code-only and full tab modes).
- Adds `@shikijs/transformers` as a `docs` dependency. It is vendored inside fumadocs but not resolvable on its own.
- Drops a pre-existing unused `demoKey` prop on `DemoTabs` (touched the file anyway).

A demo author marks an important line with an own-line marker **above** it:

```tsx
{/* [!code highlight] */}
<Button variant="secondary" size="default">
```

This form is JSX-safe and prettier-stable. The `v3` algorithm removes the marker line and shifts the highlight to the next line, so the marker is stripped from the rendered Code tab, renders nothing in the live preview, and tracks the line through future edits (no brittle absolute line numbers). The same `transformers` array can later carry diff (`[!code ++]` / `[!code --]`), focus, and word-highlight notations.

The first real usage of the marker ships separately on the DST-1483 (slot-aware Button) branch, so this PR is the enabling infrastructure only.

Closes DST-1488

## Screenshots / Preview

_Infrastructure only; no visual change until a demo adds a marker. Preview a marked-up demo by checking out DST-1483 on top of this branch._

## Test Instructions

1. `pnpm install` then `pnpm build` (components + themes).
2. `pnpm --filter @marigold/docs types:check` — passes.
3. Add `{/* [!code highlight] */}` on its own line above any line in a `*.demo.tsx`, run `pnpm start`, open that component page, switch to the **Code** tab: the next line is highlighted, the marker is gone, and the **Preview** is unchanged.

## Breaking Changes

No

## Checklist

- [x] Component documentation added/updated (if it exists) — docs tooling (`ComponentDemo`)
- [ ] Stories added/updated (with `component-test` tag where applicable) — n/a (docs-app tooling)
- [ ] Unit tests added/updated — n/a (docs-app tooling)
- [ ] Visual regression tests updated (for UI changes) — n/a (no component UI change)
- [ ] Changeset added (`pnpm changeset`) — n/a (`@marigold/docs` is private, not a published package)
