### PR TITLE
🐛 fix(DSTSUP-256): show cursor-not-allowed on disabled TagField

### DIFF
--- a/.changeset/dstsup-256-tagfield-disabled-cursor.md
+++ b/.changeset/dstsup-256-tagfield-disabled-cursor.md
@@ -1,0 +1,10 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-256): show `cursor-not-allowed` on disabled TagField
+
+The hidden trigger button inside TagField had `cursor-pointer` hardcoded, so hovering a
+disabled TagField showed the text/caret cursor instead of `not-allowed` — inconsistent with
+Select and ComboBox. Added `disabled:cursor-not-allowed` to the trigger button so the cursor
+now matches the rest of the form components.

--- a/packages/components/src/TagField/TagField.stories.tsx
+++ b/packages/components/src/TagField/TagField.stories.tsx
@@ -221,6 +221,7 @@ export const Disabled = Basic.extend({
 Disabled.test('shows not-allowed cursor when disabled', async ({ canvas }) => {
   const trigger = canvas.getByRole('button');
   const style = window.getComputedStyle(trigger);
+
   await expect(style.cursor).toBe('not-allowed');
 });
 

--- a/packages/components/src/TagField/TagField.stories.tsx
+++ b/packages/components/src/TagField/TagField.stories.tsx
@@ -211,6 +211,19 @@ LargeDataset.test(
   }
 );
 
+export const Disabled = Basic.extend({
+  tags: ['component-test'],
+  args: {
+    disabled: true,
+  },
+});
+
+Disabled.test('shows not-allowed cursor when disabled', async ({ canvas }) => {
+  const trigger = canvas.getByRole('button');
+  const style = window.getComputedStyle(trigger);
+  await expect(style.cursor).toBe('not-allowed');
+});
+
 export const DisabledItems = Basic.extend({
   args: {
     disabledKeys: ['classical', 'electronic'],

--- a/packages/components/src/TagField/TagField.tsx
+++ b/packages/components/src/TagField/TagField.tsx
@@ -261,7 +261,7 @@ function TagFieldBase<T extends object>({
           classNames.trigger
         )}
       >
-        <RACButton className="col-start-1 row-start-1 h-full w-full cursor-pointer opacity-0" />
+        <RACButton className="col-start-1 row-start-1 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed" />
         <div className="pointer-events-none col-start-1 row-start-1 flex flex-1 items-center justify-between gap-1 **:[[role=row]]:pointer-events-auto">
           <TagDisplay
             placeholder={placeholder}


### PR DESCRIPTION
## Summary
- Disabled `TagField` showed a text/caret cursor on hover instead of `not-allowed`, unlike `Select` and `ComboBox`
- Root cause: the hidden `RACButton` overlay inside the trigger had `cursor-pointer` hardcoded, winning over the disabled styles on the wrapper
- Fix: added `disabled:cursor-not-allowed` to the trigger button

## Changes
- `packages/components/src/TagField/TagField.tsx` — add `disabled:cursor-not-allowed` to `RACButton`
- `packages/components/src/TagField/TagField.stories.tsx` — add `Disabled` story with cursor assertion
- `.changeset/dstsup-256-tagfield-disabled-cursor.md` — patch changeset

Fixes [DSTSUP-256](https://reservix.atlassian.net/browse/DSTSUP-256)

[DSTSUP-256]: https://reservix.atlassian.net/browse/DSTSUP-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ