### PR TITLE
fix(DST-1501): apply padding for numeric `<Panel p={n}>`

### DIFF
--- a/.changeset/dst-1501-panel-numeric-padding.md
+++ b/.changeset/dst-1501-panel-numeric-padding.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1501): `<Panel p={number}>` now applies padding
+
+A numeric `p` (e.g. `p={4}`) silently produced no padding: the value was suffixed with `-x`/`-y` and resolved to a non-existent `var(--spacing-4-x)`. A scale value is now applied directly (`calc(var(--spacing) * 4)`) on both axes, matching `px`/`py` and `<Page>`. Named inset tokens are unchanged.

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -108,6 +108,21 @@ describe('Panel', () => {
       );
     });
 
+    test('numeric `p` resolves through the tailwind spacing scale on both axes', () => {
+      render(<Basic.Component p={4} />);
+
+      const region = screen.getByRole('region', { name: 'Organizer Profile' });
+
+      // A numeric `p` must not build a non-existent `var(--spacing-4-x)`; it is
+      // applied directly as a scale value to both axes.
+      expect(region.style.getPropertyValue('--panel-px')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+      expect(region.style.getPropertyValue('--panel-py')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+    });
+
     test('`p` recipe drives both --panel-px and --panel-py', () => {
       render(<CustomPadding.Component />);
 

--- a/packages/components/src/Panel/Panel.tsx
+++ b/packages/components/src/Panel/Panel.tsx
@@ -7,7 +7,7 @@ import type {
   SpaceProp,
   SpacingTokens,
 } from '@marigold/system';
-import { cn, createSpacingVar, useClassNames } from '@marigold/system';
+import { cn, createSpacingVar, isScale, useClassNames } from '@marigold/system';
 import { useSlot } from '../utils/useSlot';
 import { PanelContext } from './Context';
 import { PanelCollapsible } from './PanelCollapsible';
@@ -91,9 +91,10 @@ export const Panel = ({
   const classNames = useClassNames({ component: 'Panel', variant, size });
   const [titleSlotRef, hasTitle] = useSlot(!ariaLabel);
 
-  const inset = p ?? 'square-regular';
-  const resolvedPx = px ?? `${inset}-x`;
-  const resolvedPy = py ?? `${inset}-y`;
+  const inset = `${p ?? 'square-regular'}`;
+  const isScaleInset = isScale(inset);
+  const resolvedPx = px ?? (isScaleInset ? inset : `${inset}-x`);
+  const resolvedPy = py ?? (isScaleInset ? inset : `${inset}-y`);
 
   const rootHeadingProps = useMemo(
     () => ({


### PR DESCRIPTION
# Description

`<Panel p={number}>` silently produced no padding. `p` accepts the numeric `Scale`, so `p={4}` type-checks, but the value was suffixed with `-x`/`-y` and resolved to a non-existent `var(--spacing-4-x)` — so nothing was applied. The inset now branches on `isScale`: a numeric `p` is used directly (`calc(var(--spacing) * 4)`) on both axes, matching `px`/`py` and the `<Page>` fix. Named inset tokens are unchanged.

Closes DST-1501

## Test Instructions

1. Render `<Panel p={4}><Panel.Content>…</Panel.Content></Panel>` and confirm padding is now applied (previously none).
2. Confirm named tokens still work: `<Panel p="square-loose">` is unchanged.
3. `pnpm test:unit packages/components/src/Panel/Panel.test.tsx` — 36 pass, incl. the new numeric-`p` case.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)