### PR TITLE
feat(DST-1500): default auto-dismiss timeout for toasts

### DIFF
--- a/.changeset/toast-default-timeout.md
+++ b/.changeset/toast-default-timeout.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': minor
+---
+
+feat(DST-1500): default auto-dismiss timeout for toasts
+
+`addToast` now applies a default `timeout` based on `variant` when none is given: `success`, `info` and the default variant auto-dismiss after 5000ms, while `warning` and `error` stay until dismissed. Pass an explicit `timeout` to override it (values are clamped up to a 5000ms minimum), or `timeout: 0` to keep a toast on screen until it is manually dismissed.
+
+Behavior change: `success`, `info` and default toasts that previously stayed until dismissed now auto-dismiss after 5 seconds. Pass `timeout: 0` to restore the old behavior.

--- a/docs/content/components/overlay/toast/index.mdx
+++ b/docs/content/components/overlay/toast/index.mdx
@@ -37,14 +37,24 @@ The `<ToastProvider>` Component should be in the root of your application, so it
 
 ### Simple toast
 
-A Toast should be used when you want to give users quick, non-intrusive feedback after an action, such as saving, deleting, or uploading data. It appears on the edge of the screen and should remain visible for at least 5 seconds or until the user manually dismisses it. Because it doesn't interrupt the user's workflow, a Toast is ideal for success messages, notifications, or error alerts that don't need immediate interaction. The message should be clear, concise, and easy to read.
+A Toast should be used when you want to give users quick, non-intrusive feedback after an action, such as saving, deleting, or uploading data. It appears on the edge of the screen. Because it doesn't interrupt the user's workflow, a Toast is ideal for success messages, notifications, or error alerts that don't need immediate interaction. The message should be clear, concise, and easy to read.
 
 <ComponentDemo name="toast-simple" />
 
+### Default timeouts
+
+`addToast` picks a timeout based on `variant` when you don't pass one. Low-severity, reassuring toasts auto-dismiss, while higher-severity or actionable ones stay until the user dismisses them.
+
+| Variant                    | Default behavior          |
+| -------------------------- | ------------------------- |
+| `success`, `info`, default | Auto-dismiss after 5000ms |
+| `warning`, `error`         | Stay until dismissed      |
+
+To override the default, pass `timeout`. An explicit value is honored and clamped up to the 5000ms minimum, and `timeout: 0` keeps any toast on screen until it is dismissed.
+
 ### Auto dismiss
 
-This Toast will automatically dismiss itself after a specified duration.
-This is useful for notifications that do not require user interaction and should disappear after a short time. The time is in milliseconds.
+Set `timeout` (in milliseconds) to override the per-variant default and dismiss a Toast after a specific duration. This is useful to make a `warning` or `error` clear on its own, or to extend a success toast. Values below the 5000ms minimum are clamped up.
 
 <ComponentDemo name="toast-auto-dismiss" />
 

--- a/docs/content/components/overlay/toast/toast-close-all.demo.tsx
+++ b/docs/content/components/overlay/toast/toast-close-all.demo.tsx
@@ -10,6 +10,8 @@ export default () => {
           addToast({
             title: 'Updated Settings',
             variant: 'success',
+            // Keep toasts until cleared so this demo can stack a few.
+            timeout: 0,
           })
         }
       >

--- a/packages/components/src/Toast/Toast.test.tsx
+++ b/packages/components/src/Toast/Toast.test.tsx
@@ -136,3 +136,66 @@ describe('Toast', () => {
     expect(results[0].removeToast).toBe(results[1].removeToast);
   });
 });
+
+describe('addToast timeout resolution', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addSpy = vi.spyOn(queue, 'add');
+  });
+  afterEach(() => {
+    addSpy.mockRestore();
+  });
+
+  const lastTimeout = () =>
+    (addSpy.mock.calls.at(-1)?.[1] as { timeout?: number } | undefined)
+      ?.timeout;
+
+  it.each([
+    ['success', 5000],
+    ['info', 5000],
+    ['warning', undefined],
+    ['error', undefined],
+  ] as const)(
+    'uses the %s default when no timeout is passed',
+    async (variant, expected) => {
+      const { addToast } = setupToastHook();
+      await act(async () => {
+        addToast({ title: 'x', variant });
+      });
+      expect(lastTimeout()).toBe(expected);
+    }
+  );
+
+  test('defaults to 5000ms when no variant is given', async () => {
+    const { addToast } = setupToastHook();
+    await act(async () => {
+      addToast({ title: 'x' });
+    });
+    expect(lastTimeout()).toBe(5000);
+  });
+
+  test('honors an explicit timeout above the minimum', async () => {
+    const { addToast } = setupToastHook();
+    await act(async () => {
+      addToast({ title: 'x', variant: 'success', timeout: 8000 });
+    });
+    expect(lastTimeout()).toBe(8000);
+  });
+
+  test('clamps an explicit timeout up to the 5000ms minimum', async () => {
+    const { addToast } = setupToastHook();
+    await act(async () => {
+      addToast({ title: 'x', variant: 'success', timeout: 1000 });
+    });
+    expect(lastTimeout()).toBe(5000);
+  });
+
+  test('treats timeout 0 as persist (no auto-dismiss)', async () => {
+    const { addToast } = setupToastHook();
+    await act(async () => {
+      addToast({ title: 'x', variant: 'success', timeout: 0 });
+    });
+    expect(lastTimeout()).toBeUndefined();
+  });
+});

--- a/packages/components/src/Toast/ToastQueue.ts
+++ b/packages/components/src/Toast/ToastQueue.ts
@@ -1,20 +1,55 @@
 import { ReactNode, useCallback } from 'react';
 import { queue } from './ToastProvider';
 
+export type ToastVariant = 'info' | 'success' | 'error' | 'warning';
+
+export type ToastOptions = {
+  title: string;
+  description?: ReactNode;
+  variant?: ToastVariant;
+  /**
+   * Time in milliseconds before the toast auto-dismisses.
+   *
+   * When omitted, the default is derived from `variant`: `success`, `info` and
+   * the default (no variant) auto-dismiss after 5000ms, while `warning` and
+   * `error` persist until dismissed. Pass `0` to force a toast to persist
+   * regardless of variant. Explicit values are clamped up to a 5000ms minimum.
+   */
+  timeout?: number;
+  action?: ReactNode;
+};
+
+const MINIMUM_TIMEOUT_MS = 5000;
+
+// Per-variant default timeout used when the caller does not pass one. Low
+// severity / reassurance toasts auto-dismiss, while high-severity / actionable
+// ones persist until dismissed (WCAG 2.1 SC 1.4.13 "Content on Hover or Focus").
+const DEFAULT_TIMEOUT_BY_VARIANT: Record<ToastVariant, number | undefined> = {
+  success: MINIMUM_TIMEOUT_MS,
+  info: MINIMUM_TIMEOUT_MS,
+  warning: undefined,
+  error: undefined,
+};
+
+const resolveTimeout = (
+  timeout: number | undefined,
+  variant?: ToastVariant
+) => {
+  // No explicit timeout: use the per-variant default (no variant = default).
+  if (timeout === undefined) {
+    return variant ? DEFAULT_TIMEOUT_BY_VARIANT[variant] : MINIMUM_TIMEOUT_MS;
+  }
+  // Explicit opt-out: keep the toast until it is manually dismissed.
+  if (timeout <= 0) {
+    return undefined;
+  }
+  // Honor explicit values, clamped up to the minimum.
+  return Math.max(timeout, MINIMUM_TIMEOUT_MS);
+};
+
 export function useToast() {
-  type ToastOptions = {
-    title: string;
-    description?: ReactNode;
-    variant?: 'info' | 'success' | 'error' | 'warning';
-    timeout?: number;
-    action?: ReactNode;
-  };
-  const MINIMUM_TIMEOUT_MS = 5000;
   const addToast = useCallback((options: ToastOptions) => {
-    let { title, description, variant, timeout, action } = options;
-    if (timeout && timeout < MINIMUM_TIMEOUT_MS) {
-      timeout = MINIMUM_TIMEOUT_MS; // Ensure a minimum timeout of 5000ms
-    }
+    const { title, description, variant, timeout, action } = options;
     return queue.add(
       {
         title,
@@ -22,7 +57,7 @@ export function useToast() {
         variant,
         action,
       },
-      { timeout }
+      { timeout: resolveTimeout(timeout, variant) }
     );
   }, []);
 

--- a/packages/components/src/Toast/ToastQueue.ts
+++ b/packages/components/src/Toast/ToastQueue.ts
@@ -21,25 +21,18 @@ export type ToastOptions = {
 
 const MINIMUM_TIMEOUT_MS = 5000;
 
-// Per-variant default timeout used when the caller does not pass one. Low
-// severity / reassurance toasts auto-dismiss, while high-severity / actionable
-// ones persist until dismissed (WCAG 2.1 SC 1.4.13 "Content on Hover or Focus").
-const DEFAULT_TIMEOUT_BY_VARIANT: Record<ToastVariant, number | undefined> = {
-  success: MINIMUM_TIMEOUT_MS,
-  info: MINIMUM_TIMEOUT_MS,
-  warning: undefined,
-  error: undefined,
-};
-
+// Only warning and error persist until dismissed (higher severity, per WCAG
+// 2.1 SC 1.4.13). Everything else auto-dismisses after the minimum.
 const resolveTimeout = (
   timeout: number | undefined,
   variant?: ToastVariant
 ) => {
-  // No explicit timeout: use the per-variant default (no variant = default).
   if (timeout === undefined) {
-    return variant ? DEFAULT_TIMEOUT_BY_VARIANT[variant] : MINIMUM_TIMEOUT_MS;
+    return variant === 'warning' || variant === 'error'
+      ? undefined
+      : MINIMUM_TIMEOUT_MS;
   }
-  // Explicit opt-out: keep the toast until it is manually dismissed.
+  // `0` or less keeps the toast until it is manually dismissed.
   if (timeout <= 0) {
     return undefined;
   }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`addToast` previously applied no default timeout, so unless the caller passed `timeout`, every toast stayed on screen until manually dismissed. This adds sensible per-variant defaults: `success`, `info`, and the default variant auto-dismiss after 5000ms, while `warning` and `error` persist until dismissed (WCAG 2.1 SC 1.4.13). An explicit `timeout` still wins (clamped up to the 5000ms minimum), and `timeout: 0` forces a toast to persist.

Surfaced while building the DST-1198 "Fetching and Mutations" docs, where a delete success toast never disappeared.

**Behavior change:** `success`, `info`, and default toasts that previously stayed now auto-dismiss after 5 seconds. Pass `timeout: 0` to restore the old behavior. The `toast-close-all` demo was updated accordingly. No visual change (timing only), so no screenshots or VRT.

Closes DST-1500

## Test Instructions

1. `pnpm install && pnpm build`
2. Unit tests: `pnpm vitest run --config vite.config.ts --project=unit-tests packages/components/src/Toast/Toast.test.tsx` (16 pass).
3. `pnpm sb` -> Components/Toast: a `success` toast auto-dismisses after ~5s; `error` persists; `timeout: 0` persists; explicit `8000` lasts ~8s; `1000` is clamped to ~5s.
4. `pnpm start` -> /components/overlay/toast: the new "Default timeouts" table renders, and the "Close all toasts" demo can stack toasts (they no longer auto-vanish).

## Breaking Changes

No. Minor behavior change (documented above); `timeout: 0` restores prior persistence.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)