### PR TITLE
fix: build CLI before publish so dist/ ships to npm

### DIFF
--- a/.changeset/cli-dist-publish.md
+++ b/.changeset/cli-dist-publish.md
@@ -1,0 +1,5 @@
+---
+"@marigold/cli": patch
+---
+
+Fix `@marigold/cli` publishing without its `dist/` output. The release build filter excluded the CLI package, so the published tarball shipped without compiled files and the `marigold` bin pointed to a missing entry. The CLI is now built before publish.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "start": "pnpm --filter @marigold/docs dev",
     "sb": "FOLDERS=packages/components/src,packages/system/src storybook dev -p 6006 -c ./.storybook",
-    "build": "turbo run --filter \"@marigold/components...\" --filter \"@marigold/theme*...\" build",
+    "build": "turbo run --filter \"@marigold/components...\" --filter \"@marigold/theme*...\" --filter \"@marigold/cli\" build",
     "build:docs": "turbo run --filter @marigold/docs... build",
     "build:sb": "storybook build --disable-telemetry -c ./.storybook -o storybook-static --stats-json",
     "build:themes": "turbo run --filter \"@marigold/theme*...\" build",


### PR DESCRIPTION
# Description

`@marigold/cli` was published to npm without its `dist/` output — the `0.2.0` tarball contained only `LICENSE`, `README.md`, and `package.json`, so the `marigold` bin pointed to a missing `./dist/bin/marigold.mjs` and broke on install.

Root cause: the release job (`.github/workflows/release.yml`) builds with `pnpm build`, whose Turbo filter only matched `@marigold/components` and `@marigold/theme*` (plus their dependency graphs). Nothing depends on `@marigold/cli`, so it was never built in CI, and since `packages/cli/dist` is gitignored, `files: ["dist"]` matched nothing at publish time.

This adds `@marigold/cli` to the build filter so it is built before `changeset publish`. The included changeset bumps the CLI (patch) to republish a working version, since `0.2.0` is immutable on npm.

## Test Instructions

1. From the repo root, run `pnpm build`.
2. Confirm `packages/cli/dist/bin/marigold.mjs` and the other `dist/` entries are produced.
3. Optionally verify packaging: `cd packages/cli && npm pack --dry-run` and confirm the tarball now lists the `dist/` files (not just LICENSE/README/package.json).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with \`component-test\` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no UI changes
- [x] Changeset added (\`pnpm changeset\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)