### PR TITLE
docs(DST-1377): expand "Usage with AI" page with prompting tips, helpers, and limitations

### DIFF
--- a/.changeset/dst-1377-usage-with-ai.md
+++ b/.changeset/dst-1377-usage-with-ai.md
@@ -1,0 +1,7 @@
+---
+'@marigold/docs': patch
+---
+
+docs(DST-1377): expand "Usage with AI" page with prompting tips, helpers, and limitations
+
+The "Usage with AI" page now covers three ways to feed Marigold docs to an AI agent (the marigold-docs MCP server, the public `manifest.json` / per-page `.md` endpoints, and the `@marigold/cli`), alongside a new Prompting tips section (the renamed-prop gotcha, naming Marigold, nudging the MCP, referencing component names), a Reservix AI helpers section surfacing rx-ai-suite (`frontend-dev`, `design-system`, `create-marigold-app`), and a Limitations section setting honest expectations plus a Slack feedback footer.

--- a/docs/content/getting-started/usage-with-ai/index.mdx
+++ b/docs/content/getting-started/usage-with-ai/index.mdx
@@ -4,11 +4,6 @@ description: Connect AI coding assistants to the Marigold documentation.
 badge: updated
 ---
 
-<Callout title="Internal use only">
-  The marigold-docs MCP server and the Reservix AI helpers described below are
-  intended for internal Reservix usage only.
-</Callout>
-
 Marigold can feed its documentation directly to AI coding assistants, so agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview) can look up component APIs, usage guidelines, and code examples instead of guessing. There are three ways to give a model access to the docs: the [MCP server](#mcp-server), the [public manifest and markdown endpoints](#manifest-and-direct-ingestion), and the [CLI](#cli). On top of that, a set of [Reservix AI helpers](#reservix-ai-helpers) wrap Marigold-specific workflows. This page also covers [prompting tips](#prompting-tips) and the [limitations](#limitations) of the integration.
 
 ## Setup
@@ -138,4 +133,4 @@ A few things the integration can't do:
 2. **The index is a build-time snapshot.** Both the MCP index and the manifest / `.md` assets are generated when the docs are built and refresh on each docs deploy. Edits to the docs won't show up until the site redeploys.
 3. **It's search, not generation.** The MCP returns relevant documentation chunks, and the agent writes the code from them. Treat its output like any AI-generated code and review it.
 
-If something looks wrong or you have suggestions, ping `#design-system` or `#cop_ai_coding` in Slack.
+If something looks wrong or you have suggestions, ping [`#design-system`](https://reservix.slack.com/archives/C02727BNZ3J) or [`#cop_ai_coding`](https://reservix.slack.com/archives/C09MLTYQSS2) in Slack.

--- a/docs/content/getting-started/usage-with-ai/index.mdx
+++ b/docs/content/getting-started/usage-with-ai/index.mdx
@@ -1,16 +1,21 @@
 ---
 title: Usage with AI
-description: How to connect AI coding assistants to the Marigold documentation using MCP.
-badge: new
+description: Connect AI coding assistants to the Marigold documentation.
+badge: updated
 ---
 
 <Callout title="Internal use only">
-  This MCP server is intended for internal Reservix usage only.
+  The marigold-docs MCP server and the Reservix AI helpers described below are
+  intended for internal Reservix usage only.
 </Callout>
 
-Marigold offers an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that lets AI coding assistants search the design system documentation on their own. When you build something with Marigold and use an AI coding agent like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview), the agent can automatically look up component APIs, usage guidelines, and code examples from the Marigold docs to give you accurate answers.
+Marigold can feed its documentation directly to AI coding assistants, so agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview) can look up component APIs, usage guidelines, and code examples instead of guessing. There are three ways to give a model access to the docs: the [MCP server](#mcp-server), the [public manifest and markdown endpoints](#manifest-and-direct-ingestion), and the [CLI](#cli). On top of that, a set of [Reservix AI helpers](#reservix-ai-helpers) wrap Marigold-specific workflows. This page also covers [prompting tips](#prompting-tips) and the [limitations](#limitations) of the integration.
 
 ## Setup
+
+Pick whichever access path fits your tool. The MCP server gives an agent semantic search. The manifest and markdown endpoints work in any tool with no setup or auth. The CLI is handy from the terminal and in agent workflows.
+
+### MCP server
 
 The **marigold-docs** MCP server provides semantic search over the full Marigold documentation. To connect it to your AI coding assistant, follow the instructions for your editor.
 
@@ -74,13 +79,63 @@ The **marigold-docs** MCP server provides semantic search over the full Marigold
 </Tabs>
 {/* prettier-ignore-end */}
 
-## How to use it
+Once connected, the agent searches the docs on its own when you ask a question or instruct it while coding. You can ask direct questions like "What props does Select accept?" or steer it, for example: "Use the marigold-docs MCP to check how I should implement this DatePicker."
 
-Once the server is connected, your AI agent can query the Marigold documentation automatically. When you ask a question, the agent searches the docs via the MCP server and uses the results to answer you. You can ask direct questions like "What props does Select accept?" or instruct the agent while coding, for example: "Use the marigold-docs MCP to check how I should implement this DatePicker."
+### Manifest and direct ingestion
 
-This is especially useful during development. Instead of switching to the docs, you can tell your agent to look up the right way to use a component, check which props are available, or find code examples.
+The docs are also published as plain, public assets that work in any AI agent (Cursor, ChatGPT on the web, and so on). No setup, no authentication.
 
-<Callout title="Best results">
-  Be specific in your questions. "How do I add validation to a TextField?" will
-  return better results than just "TextField".
-</Callout>
+- **Manifest**: [`https://www.marigold-ui.io/manifest.json`](https://www.marigold-ui.io/manifest.json) is a machine-readable index of every component and guide page, with each entry's `name`, `slug`, `category`, `description`, and markdown `url`. Drop the manifest URL into a chat to give a model the full doc index in one shot, then let it pull the pages it needs.
+- **Single page as markdown**: append `.md` to any docs URL to get the raw markdown for that page. For example, [`https://www.marigold-ui.io/components/actions/button.md`](https://www.marigold-ui.io/components/actions/button.md) returns the full Button documentation as plain text. Each manifest entry's `url` already points at the `.md` path, relative to the manifest's `baseUrl`.
+
+### CLI
+
+The **`@marigold/cli`** package pulls the same documentation into your terminal. It is useful on its own and inside AI agent workflows. Install it globally, add it as a dev dependency, or run it one-off with `npx`:
+
+```bash
+npm install -g @marigold/cli   # global
+pnpm add -D @marigold/cli       # dev dep
+npx @marigold/cli docs Button   # one-off
+```
+
+Requires Node 22 or newer.
+
+```bash
+# Structured prop data (recommended for AI agents)
+marigold docs Select --section props --format json
+
+# Discover components
+marigold list --category form
+marigold list --search date
+```
+
+`marigold docs <Component>`, `marigold list`, and `marigold init` (set up Marigold in an existing project) are the core commands. For AI use, prefer `--format json` with `--section props`, which returns a structured payload instead of formatted markdown. The CLI caches responses for 24h and works offline with `--offline`. See the [CLI README](https://github.com/marigold-ui/marigold/blob/main/packages/cli/README.md) for the full command reference.
+
+## Prompting tips
+
+A few habits get noticeably better results when working with Marigold specifically:
+
+1. **Say "Marigold".** Mention "Marigold" or `@marigold/components` by name. Without it, models default to MUI, Chakra, or shadcn patterns that don't apply here.
+2. **Nudge the MCP when it's quiet.** If the agent isn't searching the docs on its own, tell it to: "use the marigold-docs MCP to look this up." Most agents auto-invoke it, but an explicit hint reliably triggers a lookup.
+3. **Name the component.** Reference components directly (`Select`, `TextField`, `DatePicker`) rather than describing them. Exact names produce sharper documentation hits.
+4. **Don't trust default prop names.** Marigold renames several react-aria props: `isDisabled` becomes `disabled`, `isPending` becomes `loading`, and `className` / `style` are intentionally not exposed (theming goes through `variant` and `size`). This is the single thing AI gets wrong most often, so verify props against the docs.
+
+## Reservix AI helpers
+
+**rx-ai-suite** is the internal Claude Code plugin marketplace. Once installed, it adds agents and skills that already know about Marigold, so you don't have to spell out the conventions each time. The design-system-relevant helpers live in the `rx-frontend` plugin:
+
+- **`frontend-dev` agent**: builds React/TypeScript UI and keeps it compliant with Marigold (and RUI) conventions. Example: _"Verify this component matches Marigold conventions."_
+- **`design-system` skill**: Marigold and RUI guidance for migrating and modernizing UI. Examples: _"Migrate this legacy CSS / inline-styled component to Marigold."_ or _"Apply RUI styling and spacing conventions to this TWIG page."_
+- **`create-marigold-app` skill**: scaffolds a fresh Marigold app from the starter template. Example: _"Scaffold a new prototype app."_
+
+The `rx-baseline` plugin offers adjacent general-purpose helpers (planning, refactoring) that pair well with the design-system ones.
+
+## Limitations
+
+A few things the integration can't do:
+
+1. **It searches docs, not source code.** The MCP indexes the documentation site, not the component source. Implementation details that aren't documented won't surface.
+2. **The index is a build-time snapshot.** Both the MCP index and the manifest / `.md` assets are generated when the docs are built and refresh on each docs deploy. Edits to the docs won't show up until the site redeploys.
+3. **It's search, not generation.** The MCP returns relevant documentation chunks, and the agent writes the code from them. Treat its output like any AI-generated code and review it.
+
+If something looks wrong or you have suggestions, ping `#design-system` or `#cop_ai_coding` in Slack.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

Expands the "Usage with AI" page beyond the single MCP-server section into a full guide. It now documents three ways to feed Marigold docs to an AI agent — the marigold-docs MCP server, the public `manifest.json` / per-page `.md` endpoints, and the `@marigold/cli` — plus new Prompting tips, Reservix AI helpers (rx-ai-suite), and Limitations sections, with a Slack feedback footer. The page badge changes from `new` to `updated`.

Docs only — no code or component changes.

Closes DST-1377

## Test Instructions

1. Run `pnpm start`, navigate to Getting Started → Usage with AI.
2. Confirm the new sections render (MCP server, Manifest and direct ingestion, CLI, Prompting tips, Reservix AI helpers, Limitations) and the in-page anchor links resolve.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)