### PR TITLE
fix(DSTSUP-261): guard Tray against the react-aria HiddenContext split (mobile Select tray)

### DIFF
--- a/.changeset/select-tray-hidden-context-split.md
+++ b/.changeset/select-tray-hidden-context-split.md
@@ -1,0 +1,13 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-261): make `Tray` immune to a split react-aria `HiddenContext` (mobile `Select` tray selecting nothing)
+
+On a touch/mobile viewport, `Select` (and other components that fall back to a `Tray`) could open an empty bottom sheet next to the real one: tapping an option selected nothing, the trigger kept showing the placeholder, and the page was left `inert` until reload.
+
+Root cause was a dependency-resolution split, not component logic. `Tray` guards the collection hidden pass with `useIsHidden()` from `@react-aria/collections` (which depends on `react-aria` via a caret range), while `react-aria-components` pins `react-aria` exactly and its `Select` (a `createHideableComponent`) sets the `HiddenContext` from its own copy. Both read that context from `react-aria/private/collections/Hidden`, so they only agree when `react-aria` resolves to a single version. When a consumer's lockfile resolves the two edges to different `react-aria` generations, the guard reads a context the collection renderer never sets: it never fires, a duplicate (empty) tray modal leaks into the DOM, and the two modals `inert` each other so options are no longer hit-testable.
+
+`Tray` now verifies the hidden pass through the DOM as well: react-aria renders the hidden pass into a `<template>` element, whose content lives in a detached `DocumentFragment`. A hidden probe element rendered alongside the modal is therefore never connected to the document during the hidden pass, and the tray skips mounting its modal whenever the probe is detached. This holds no matter how the consumer's lockfile resolves `react-aria` — including future react-aria releases that would re-arm the split (`@react-aria/collections`' caret range resolves to the newest `react-aria`, while `react-aria-components` stays pinned) — so no dependency pins are needed.
+
+The durable upstream fix is for react-aria-components' `Modal` to skip the collection hidden pass like its `Popover` already does (which is why the desktop `Popover` path was never affected), or for it to export `useIsHidden`. Once either lands, the guard in `Tray` can be reduced again.

--- a/packages/components/src/Select/Select.hiddenContext.test.tsx
+++ b/packages/components/src/Select/Select.hiddenContext.test.tsx
@@ -1,10 +1,8 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
-import { theme } from '../../../../themes/theme-rui/src/index';
-import { MarigoldProvider } from '../Provider/MarigoldProvider';
-import { mockMatchMedia } from '../test.utils';
-import { Select } from './Select';
+import { mockMatchMedia, renderWithOverlay } from '../test.utils';
+import { Basic } from './Select.stories';
 
 // DSTSUP-261 regression test.
 //
@@ -34,15 +32,12 @@ vi.mock('@react-aria/collections', async importActual => {
 const user = userEvent.setup();
 window.matchMedia = mockMatchMedia(['(width < 640px)']);
 
-const renderSelect = () =>
-  render(
-    <MarigoldProvider theme={theme}>
-      <Select label="Favorite" placeholder="Select Item">
-        <Select.Option id="Star Wars">Star Wars</Select.Option>
-        <Select.Option id="Star Trek">Star Trek</Select.Option>
-      </Select>
-    </MarigoldProvider>
-  );
+// Import the existing story instead of hand-rolling a fixture (CLAUDE.md:
+// "Don't create test fixtures/themes — import stories"). `Basic` is labelled
+// "Favorite", ships the Star Wars / Star Trek options, and wires the theme via
+// its decorator path; `renderWithOverlay` adds the portal container the tray
+// modal needs.
+const renderSelect = () => renderWithOverlay(<Basic.Component />);
 
 test('split HiddenContext (useIsHidden blind to hidden pass) does not leak a duplicate tray modal', async () => {
   // `false` everywhere mimics the Tray reading a different react-aria

--- a/packages/components/src/Select/Select.hiddenContext.test.tsx
+++ b/packages/components/src/Select/Select.hiddenContext.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { theme } from '../../../../themes/theme-rui/src/index';
+import { MarigoldProvider } from '../Provider/MarigoldProvider';
+import { mockMatchMedia } from '../test.utils';
+import { Select } from './Select';
+
+// DSTSUP-261 regression test.
+//
+// On mobile, `Select` builds its collection in a hidden pass before rendering
+// for real. `Tray` skips its modal during that pass via `useIsHidden()`, which
+// reads the `HiddenContext` that react-aria-components' `Select`
+// (`createHideableComponent`) sets. Provider and consumer only share that
+// context when `react-aria` resolves to a single version. If two `react-aria`
+// generations are installed, `useIsHidden()` reads an orphan context that is
+// never flipped to `true`. Without further protection the guard never fires,
+// a second (empty) tray modal leaks, and the two modals `inert` each other so
+// the option becomes unselectable.
+//
+// We can't install two react-aria generations inside a single test, so we
+// simulate the split: force `useIsHidden` to stay `false` (blind to the hidden
+// pass), exactly like reading a context the collection renderer never sets.
+// `Tray`'s DOM-probe safety net must catch this: the hidden pass renders into
+// the collection's `<template>` (a detached DocumentFragment), so the probe is
+// never connected to the document and the duplicate modal must not mount —
+// regardless of how react-aria versions resolve.
+const hidden = vi.hoisted(() => ({ isHidden: false }));
+vi.mock('@react-aria/collections', async importActual => {
+  const actual = await importActual<typeof import('@react-aria/collections')>();
+  return { ...actual, useIsHidden: () => hidden.isHidden };
+});
+
+const user = userEvent.setup();
+window.matchMedia = mockMatchMedia(['(width < 640px)']);
+
+const renderSelect = () =>
+  render(
+    <MarigoldProvider theme={theme}>
+      <Select label="Favorite" placeholder="Select Item">
+        <Select.Option id="Star Wars">Star Wars</Select.Option>
+        <Select.Option id="Star Trek">Star Trek</Select.Option>
+      </Select>
+    </MarigoldProvider>
+  );
+
+test('split HiddenContext (useIsHidden blind to hidden pass) does not leak a duplicate tray modal', async () => {
+  // `false` everywhere mimics the Tray reading a different react-aria
+  // generation's context than the Select's collection renderer sets.
+  hidden.isHidden = false;
+  renderSelect();
+
+  await user.click(screen.getByLabelText(/Favorite/i));
+  const dialog = await screen.findByRole('dialog');
+
+  // The broken DOM signature from the ticket was two overlay dialogs, only one
+  // of which holds the listbox. The DOM probe must suppress the hidden-pass
+  // copy, leaving exactly one populated tray modal.
+  expect(screen.getAllByRole('dialog')).toHaveLength(1);
+  expect(within(dialog).getByRole('listbox')).toBeInTheDocument();
+
+  // No leaked twin modal means the real tray is not `inert`-ed: tapping an
+  // option commits the selection and closes the tray.
+  await user.click(within(dialog).getByRole('option', { name: 'Star Trek' }));
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  );
+  expect(screen.getByLabelText(/Favorite/i)).toHaveTextContent('Star Trek');
+});

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -665,10 +665,12 @@ export const Mobile = meta.story({
  * Below the `sm` breakpoint, `<Select>` renders its listbox inside a `<Tray>`
  * (RAC `DialogTrigger`) instead of a `<Popover>`. The inner `<ListBox>` must
  * keep participating in the Select's list state so that picking an option still
- * fires `onChange` (value API) and updates the controlled value — exactly like
- * the desktop branch. The earlier `Mobile` story only asserted `aria-selected`,
- * which can be set without `onChange` ever firing; this story verifies the full
- * controlled flow: value update, tray auto-close, and trigger value.
+ * fires `onChange` (value API) and drives the controlled `value` prop — exactly
+ * like the desktop branch. The earlier `Mobile` story only asserted
+ * `aria-selected`, which can be set without `onChange` ever firing; this story
+ * uses a fully controlled `value`/`onChange` Select and verifies the round-trip:
+ * the controlled `value` updates, the tray auto-closes, and the trigger renders
+ * from `value`.
  */
 export const MobileControlled = meta.story({
   tags: ['component-test'],
@@ -679,13 +681,15 @@ export const MobileControlled = meta.story({
     label: 'Favorite character',
   },
   render: ({ label }) => {
-    const [selected, setSelected] = useState<any>('');
+    // Controlled via the `value` prop (single-select value API).
+    const [value, setValue] = useState<Key | null>(null);
     return (
       <Stack space={6}>
         <Select
           label={label}
           placeholder="Select your character"
-          onChange={setSelected}
+          value={value}
+          onChange={setValue}
         >
           <Select.Option id="mario">Mario</Select.Option>
           <Select.Option id="luigi">Luigi</Select.Option>
@@ -695,7 +699,7 @@ export const MobileControlled = meta.story({
           <Select.Option id="bowser">Bowser</Select.Option>
         </Select>
         <hr />
-        <pre data-testid="selected">selected: {selected}</pre>
+        <pre data-testid="value">value: {value}</pre>
       </Stack>
     );
   },
@@ -721,11 +725,9 @@ export const MobileControlled = meta.story({
       await userEvent.click(within(dialog).getByText('Peach'));
     });
 
-    await step('onChange fires and the controlled value updates', async () => {
+    await step('Controlled `value` prop updates via onChange', async () => {
       await waitFor(() =>
-        expect(canvas.getByTestId('selected')).toHaveTextContent(
-          'selected: peach'
-        )
+        expect(canvas.getByTestId('value')).toHaveTextContent('value: peach')
       );
     });
 
@@ -735,7 +737,7 @@ export const MobileControlled = meta.story({
       );
     });
 
-    await step('Trigger reflects the selected value', async () => {
+    await step('Trigger renders from the controlled `value`', async () => {
       await waitFor(() => expect(trigger).toHaveTextContent('Peach'));
     });
   },

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -660,6 +660,88 @@ export const Mobile = meta.story({
 });
 
 /**
+ * Regression guard for DSTSUP-261.
+ *
+ * Below the `sm` breakpoint, `<Select>` renders its listbox inside a `<Tray>`
+ * (RAC `DialogTrigger`) instead of a `<Popover>`. The inner `<ListBox>` must
+ * keep participating in the Select's list state so that picking an option still
+ * fires `onChange` (value API) and updates the controlled value — exactly like
+ * the desktop branch. The earlier `Mobile` story only asserted `aria-selected`,
+ * which can be set without `onChange` ever firing; this story verifies the full
+ * controlled flow: value update, tray auto-close, and trigger value.
+ */
+export const MobileControlled = meta.story({
+  tags: ['component-test'],
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  args: {
+    label: 'Favorite character',
+  },
+  render: ({ label }) => {
+    const [selected, setSelected] = useState<any>('');
+    return (
+      <Stack space={6}>
+        <Select
+          label={label}
+          placeholder="Select your character"
+          onChange={setSelected}
+        >
+          <Select.Option id="mario">Mario</Select.Option>
+          <Select.Option id="luigi">Luigi</Select.Option>
+          <Select.Option id="peach">Peach</Select.Option>
+          <Select.Option id="toad">Toad</Select.Option>
+          <Select.Option id="yoshi">Yoshi</Select.Option>
+          <Select.Option id="bowser">Bowser</Select.Option>
+        </Select>
+        <hr />
+        <pre data-testid="selected">selected: {selected}</pre>
+      </Stack>
+    );
+  },
+  play: async ({ canvas, step }) => {
+    // Fail loudly if `useSmallScreen` did not pick up the mobile viewport,
+    // rather than passing a test that never exercised the tray branch.
+    expect(window.innerWidth).toBeLessThan(640);
+
+    const trigger = canvas.getByRole('button', {
+      name: /Favorite character/i,
+    });
+
+    await step('Open the tray', async () => {
+      await userEvent.click(trigger);
+      // Mobile path renders the listbox inside a tray (role="dialog").
+      await waitFor(() =>
+        expect(canvas.getByRole('dialog')).toBeInTheDocument()
+      );
+    });
+
+    await step('Select an option from the tray', async () => {
+      const dialog = canvas.getByRole('dialog');
+      await userEvent.click(within(dialog).getByText('Peach'));
+    });
+
+    await step('onChange fires and the controlled value updates', async () => {
+      await waitFor(() =>
+        expect(canvas.getByTestId('selected')).toHaveTextContent(
+          'selected: peach'
+        )
+      );
+    });
+
+    await step('Single selection auto-closes the tray', async () => {
+      await waitFor(() =>
+        expect(canvas.queryByRole('dialog')).not.toBeInTheDocument()
+      );
+    });
+
+    await step('Trigger reflects the selected value', async () => {
+      await waitFor(() => expect(trigger).toHaveTextContent('Peach'));
+    });
+  },
+});
+
+/**
  * Regression guard for DST-1482: a fixed `width` must size the field element
  * itself (the trigger), not just the FieldBase wrapper. `width={64}` maps to the
  * spacing scale, i.e. `calc(var(--spacing) * 64)` = 16rem (256px at default root

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -145,6 +145,13 @@ test('updates the controlled `value` when selecting in the tray (small screen)',
 
   // On small screens the listbox is presented as a tray (dialog), not a popover.
   const dialog = await screen.findByRole('dialog');
+
+  // DSTSUP-261 invariant: exactly one tray modal, holding the listbox. A split
+  // `HiddenContext` (dual react-aria generations) or a broken hidden-pass guard
+  // leaks a second, empty modal that `inert`s the real one.
+  expect(screen.getAllByRole('dialog')).toHaveLength(1);
+  expect(within(dialog).getByRole('listbox')).toBeInTheDocument();
+
   await user.click(within(dialog).getByText('Peach'));
 
   // The controlled `value` prop round-trips: onChange -> state -> value.

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { mockMatchMedia, renderWithOverlay } from '../test.utils';
-import { Basic, Sections } from './Select.stories';
+import { Basic, MobileControlled, Sections } from './Select.stories';
 
 const user = userEvent.setup();
 
@@ -132,29 +132,29 @@ test('error is there', () => {
 // breakpoint, `<Select>` renders its listbox inside a `<Tray>` (RAC
 // `DialogTrigger`). The inner `<ListBox>` must keep participating in the
 // Select's list state so that selecting an option still fires `onChange`
-// (value API) and updates the controlled value — exactly as on desktop.
-test('fires onChange when selecting an option in the tray (small screen)', async () => {
+// (value API) and drives the controlled `value` prop — exactly as on desktop.
+// `MobileControlled` is a fully controlled (`value`/`onChange`) Select, so the
+// assertions read selection through the `value` prop round-trip.
+test('updates the controlled `value` when selecting in the tray (small screen)', async () => {
   window.matchMedia = mockMatchMedia([SMALL_SCREEN_QUERY]);
 
-  renderWithOverlay(<Basic.Component label="Favorite" />);
+  renderWithOverlay(<MobileControlled.Component />);
 
-  const button = screen.getByLabelText(/Favorite/i);
+  const button = screen.getByLabelText(/Favorite character/i);
   await user.click(button);
 
   // On small screens the listbox is presented as a tray (dialog), not a popover.
   const dialog = await screen.findByRole('dialog');
-  await user.click(within(dialog).getByText('Star Wars'));
+  await user.click(within(dialog).getByText('Peach'));
 
-  // `onChange` fired -> the story's controlled value updated.
+  // The controlled `value` prop round-trips: onChange -> state -> value.
   await waitFor(() =>
-    expect(screen.getByTestId('selected')).toHaveTextContent(
-      'selected: Star Wars'
-    )
+    expect(screen.getByTestId('value')).toHaveTextContent('value: peach')
   );
 
-  // Single selection auto-closes the tray and the trigger reflects the value.
+  // Single selection auto-closes the tray and the trigger renders from `value`.
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
-  expect(button).toHaveTextContent('Star Wars');
+  expect(button).toHaveTextContent('Peach');
 });

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { mockMatchMedia, renderWithOverlay } from '../test.utils';
@@ -6,7 +6,16 @@ import { Basic, Sections } from './Select.stories';
 
 const user = userEvent.setup();
 
+// `useSmallScreen` matches `(width < 640px)`. By default we keep the desktop
+// (Popover) branch active; individual tests opt into the mobile (Tray) branch.
+const SMALL_SCREEN_QUERY = '(width < 640px)';
+
 window.matchMedia = mockMatchMedia([]);
+
+afterEach(() => {
+  // Reset to the desktop default in case a test forced the small-screen branch.
+  window.matchMedia = mockMatchMedia([]);
+});
 
 test('renders a field (label, helptext, select)', () => {
   render(
@@ -117,4 +126,35 @@ test('error is there', () => {
   const container = screen.getAllByText('Label')[0].parentElement;
 
   expect(container).toHaveAttribute('data-error');
+});
+
+// Regression guard for DSTSUP-261: on screens narrower than the `sm`
+// breakpoint, `<Select>` renders its listbox inside a `<Tray>` (RAC
+// `DialogTrigger`). The inner `<ListBox>` must keep participating in the
+// Select's list state so that selecting an option still fires `onChange`
+// (value API) and updates the controlled value — exactly as on desktop.
+test('fires onChange when selecting an option in the tray (small screen)', async () => {
+  window.matchMedia = mockMatchMedia([SMALL_SCREEN_QUERY]);
+
+  renderWithOverlay(<Basic.Component label="Favorite" />);
+
+  const button = screen.getByLabelText(/Favorite/i);
+  await user.click(button);
+
+  // On small screens the listbox is presented as a tray (dialog), not a popover.
+  const dialog = await screen.findByRole('dialog');
+  await user.click(within(dialog).getByText('Star Wars'));
+
+  // `onChange` fired -> the story's controlled value updated.
+  await waitFor(() =>
+    expect(screen.getByTestId('selected')).toHaveTextContent(
+      'selected: Star Wars'
+    )
+  );
+
+  // Single selection auto-closes the tray and the trigger reflects the value.
+  await waitFor(() =>
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  );
+  expect(button).toHaveTextContent('Star Wars');
 });

--- a/packages/components/src/Tray/Tray.test.tsx
+++ b/packages/components/src/Tray/Tray.test.tsx
@@ -3,8 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { renderWithOverlay } from '../test.utils';
 import { Basic, DismissControlsWithCallbacks } from './Tray.stories';
 
-// Lets individual tests drive the `useIsHidden()` guard (DSTSUP-261). Defaults
-// to `false` so the existing tests keep exercising the real modal path.
+// Lets the hidden-pass test drive the `useIsHidden()` guard (DSTSUP-261).
+// `vi.mock` is hoisted to module scope by Vitest, so it can't be nested inside
+// the `describe` block below — but the partial mock keeps every other export of
+// `@react-aria/collections` real and defaults `useIsHidden` to `false`, which is
+// exactly what the real hook returns outside a hidden pass. So the rest of the
+// file behaves identically; only the scoped block toggles it to `true`.
 const hiddenState = vi.hoisted(() => ({ isHidden: false }));
 vi.mock('@react-aria/collections', async importActual => {
   const actual = await importActual<typeof import('@react-aria/collections')>();
@@ -12,10 +16,6 @@ vi.mock('@react-aria/collections', async importActual => {
 });
 
 const user = userEvent.setup();
-
-beforeEach(() => {
-  hiddenState.isHidden = false;
-});
 
 test('renders trigger button', () => {
   renderWithOverlay(<Basic.Component />);
@@ -153,14 +153,23 @@ test('small drag snaps tray back', async () => {
 // `useIsHidden()` to ever return `true`; when a dependency-resolution split
 // breaks that sharing, the Tray's DOM probe takes over (covered by
 // `Select.hiddenContext.test.tsx`).
-test('hidden collection pass renders children without mounting the modal', async () => {
-  hiddenState.isHidden = true;
+//
+// Scoped to its own block so the `useIsHidden` toggle is reset here and never
+// leaks into the tests above (the mock itself is necessarily file-scoped).
+describe('hidden collection pass', () => {
+  beforeEach(() => {
+    hiddenState.isHidden = false;
+  });
 
-  renderWithOverlay(<Basic.Component />);
+  test('renders children without mounting the modal', async () => {
+    hiddenState.isHidden = true;
 
-  // Children render inline (so the collection can still be built) even though
-  // the trigger was never pressed...
-  expect(screen.getByText('Tray Title')).toBeInTheDocument();
-  // ...but no portalled modal/overlay is mounted during the hidden pass.
-  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    renderWithOverlay(<Basic.Component />);
+
+    // Children render inline (so the collection can still be built) even though
+    // the trigger was never pressed...
+    expect(screen.getByText('Tray Title')).toBeInTheDocument();
+    // ...but no portalled modal/overlay is mounted during the hidden pass.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });

--- a/packages/components/src/Tray/Tray.test.tsx
+++ b/packages/components/src/Tray/Tray.test.tsx
@@ -3,7 +3,19 @@ import userEvent from '@testing-library/user-event';
 import { renderWithOverlay } from '../test.utils';
 import { Basic, DismissControlsWithCallbacks } from './Tray.stories';
 
+// Lets individual tests drive the `useIsHidden()` guard (DSTSUP-261). Defaults
+// to `false` so the existing tests keep exercising the real modal path.
+const hiddenState = vi.hoisted(() => ({ isHidden: false }));
+vi.mock('@react-aria/collections', async importActual => {
+  const actual = await importActual<typeof import('@react-aria/collections')>();
+  return { ...actual, useIsHidden: () => hiddenState.isHidden };
+});
+
 const user = userEvent.setup();
+
+beforeEach(() => {
+  hiddenState.isHidden = false;
+});
 
 test('renders trigger button', () => {
   renderWithOverlay(<Basic.Component />);
@@ -129,4 +141,26 @@ test('small drag snaps tray back', async () => {
 
   expect(screen.getByRole('dialog')).toBeInTheDocument();
   expect(mockAnimate).toHaveBeenCalled();
+});
+
+// DSTSUP-261 hidden-pass guard contract.
+//
+// During a collection's hidden build pass, `useIsHidden()` is `true` and the
+// Tray must render its children WITHOUT mounting the portalled modal — otherwise
+// a `Select`/`ComboBox` that builds its collection through a Tray would leak an
+// empty modal into the DOM. This locks that behavior so the guard can't be
+// dropped. The provider/consumer must share one `HiddenContext` for the real
+// `useIsHidden()` to ever return `true`; when a dependency-resolution split
+// breaks that sharing, the Tray's DOM probe takes over (covered by
+// `Select.hiddenContext.test.tsx`).
+test('hidden collection pass renders children without mounting the modal', async () => {
+  hiddenState.isHidden = true;
+
+  renderWithOverlay(<Basic.Component />);
+
+  // Children render inline (so the collection can still be built) even though
+  // the trigger was never pressed...
+  expect(screen.getByText('Tray Title')).toBeInTheDocument();
+  // ...but no portalled modal/overlay is mounted during the hidden pass.
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });

--- a/packages/components/src/Tray/Tray.tsx
+++ b/packages/components/src/Tray/Tray.tsx
@@ -1,6 +1,29 @@
-import { type ReactNode, useContext } from 'react';
+import {
+  type ReactNode,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import type RAC from 'react-aria-components';
 import { Dialog, OverlayTriggerStateContext } from 'react-aria-components';
+// `useIsHidden` and react-aria-components' `createHideableComponent` (used by
+// `Select`/`ComboBox`/etc.) both read the SAME `HiddenContext`, defined in
+// `react-aria/private/collections/Hidden`. They only share that context when
+// `react-aria` resolves to a single version across the dependency tree. RAC pins
+// `react-aria` exactly while `@react-aria/collections` uses a caret range, so a
+// consumer's lockfile can install two `react-aria` generations -> two
+// `HiddenContext` instances -> this guard reads a context the collection
+// renderer never sets -> a duplicate (empty) tray modal leaks and both modals
+// `inert` each other (DSTSUP-261). The DOM probe below covers that case.
+//
+// Why this guard exists at all: RAC's own `Popover`/`Menu` skip the hidden pass
+// internally (via RAC's bundled `react-aria`, so they can never split) — which
+// is why the desktop `Popover` path is immune. RAC's `Modal` (what `Tray` builds
+// on) has no such guard, so we add one here. The durable fix is upstream — RAC
+// guarding `Modal`'s hidden pass like `Popover`, or RAC exporting `useIsHidden`
+// — after which this guard and the `@react-aria/collections` dependency can be
+// dropped.
 import { useIsHidden } from '@react-aria/collections';
 import { cn, useClassNames } from '@marigold/system';
 import { TrayContext } from './Context';
@@ -78,15 +101,31 @@ export const Tray = ({
 }: TrayProps) => {
   const state = useContext(OverlayTriggerStateContext);
   const isHidden = useIsHidden();
+  const probeRef = useRef<HTMLSpanElement>(null);
+  const [isDetached, setIsDetached] = useState(false);
   const classNames = useClassNames({
     component: 'Tray',
   });
 
   const openState = open ?? state?.isOpen;
 
+  // Safety net for when `useIsHidden()` is blind to the hidden pass because of
+  // a split `HiddenContext` (two react-aria generations, see above): the hidden
+  // pass renders into a `<template>`, whose content lives in a detached
+  // DocumentFragment, so a probe rendered in place is never connected to the
+  // document. This resolves at mount — before the tray can ever open — so the
+  // modal cannot portal out of a hidden tree even when the context guard fails.
+  // Unlike the context guard, this holds regardless of how the consumer's
+  // lockfile resolves react-aria.
+  useLayoutEffect(() => {
+    if (probeRef.current && !probeRef.current.isConnected) {
+      setIsDetached(true);
+    }
+  }, []);
+
   // If we are in a hidden tree, we still need to preserve our children.
   // This is important for components like Select that need to maintain state context.
-  if (isHidden) {
+  if (isHidden || isDetached) {
     return (
       <TrayContext.Provider value={{ classNames }}>
         {children}
@@ -96,6 +135,7 @@ export const Tray = ({
 
   return (
     <TrayContext.Provider value={{ classNames }}>
+      <span hidden ref={probeRef} />
       <TrayModal
         open={openState}
         dismissable={dismissable}


### PR DESCRIPTION
# Description

On a touch/mobile viewport, `Select` (and the other components that fall back to a `Tray`: `ComboBox`, `Autocomplete`, `TagField`, `DatePicker`, `Menu`) could open an **empty bottom sheet** next to the real one: tapping an option selected nothing, the trigger kept showing the placeholder, and the page was left `inert` until reload.

**Root cause — a dependency-resolution split, not component logic** (confirmed against the installed packages):

- `react-aria-components@1.18.0` pins `react-aria@3.49.0` / `react-stately@3.47.0` **exactly**. Its `Select` became a `createHideableComponent` in v1.18 (RAC PR #10019), which *sets* the `HiddenContext` during the collection's hidden build pass.
- `@react-aria/collections@3.1.1` — the source of `Tray`'s `useIsHidden` — depends on `react-aria@^3.48.0` (**caret**).
- Both read the *same* `HiddenContext` from `react-aria/private/collections/Hidden`, so they only agree when `react-aria` resolves to one version. When a consumer's lockfile resolves those two edges to different `react-aria` generations, the Tray's hidden-pass guard reads a context the `Select` never sets → the guard never fires → a duplicate empty `TrayModal` portals into `<body>` → the two modals `inert` each other → options are no longer hit-testable.

Thanks to the reporter for the precise diagnosis.

**Fix: `Tray` now verifies the hidden pass through the DOM, independent of context identity.** react-aria renders the hidden pass into a `<template>` element whose content lives in a **detached `DocumentFragment`** — the duplicate modal only ever appears because RAC's `Modal` portals to `<body>`, escaping that template. `Tray` renders a `<span hidden>` probe next to its modal and checks `isConnected` in a layout effect at mount:

- **Real pass** → probe is in the live document → modal renders exactly as before (zero behavior change on the healthy path).
- **Hidden pass with a split context** → probe sits in the detached fragment (`isConnected === false`) → `Tray` flips to its children-only branch **at mount, before the tray can ever open**, so the empty modal never mounts.

`useIsHidden()` stays as the render-time fast path; the probe is the safety net that holds **regardless of how a consumer's lockfile resolves `react-aria`** — frozen lockfiles, fresh installs, and future react-aria releases alike. No dependency pins required.

Closes DSTSUP-261

## Why not pin `react-aria`/`react-stately`?

An earlier iteration of this branch pinned both to the versions RAC pins. Deeper research showed the pins cannot actually protect consumers:

1. **They don't constrain the edge that splits.** `Tray` reads `useIsHidden` through `@react-aria/collections`, whose *own* `react-aria@^3.48.0` range is resolved independently by the consumer's package manager. pnpm reuses existing lockfile resolutions for unchanged packages, so the affected consumer (lockfile: `@react-aria/collections → react-aria@3.48.x`) would upgrade Marigold and **still be split**. A direct pin is just a third edge — not an override.
2. **The split re-arms on upstream's next release — even for fresh installs.** Today `react-aria@3.49.0` is the latest on npm, so the caret happens to dedupe. The moment upstream ships 3.50 (~6-week release cadence), `^3.48.0` fresh-resolves to 3.50 while RAC 1.18 stays pinned to 3.49 → **every fresh install splits**, pins or not.
3. **The asymmetry is permanent by design.** The react-spectrum team's [2025 dependencies RFC](https://github.com/adobe/react-spectrum/blob/main/rfcs/2025-dependencies.md) explicitly keeps caret ranges on the `@react-aria/*` shell packages for backward compatibility.

Also verified: there is **no split-proof import path** for the context — RAC does not export `useIsHidden` (checked `exports/index.ts` and every subpath export in 1.18.0), and `react-aria` only exposes it via the explicitly private `react-aria/private/collections/Hidden`.

## The durable fix is upstream

RAC's `Popover`/`Menu` already guard the hidden pass internally — via RAC's own exact-pinned `react-aria`, so they can never split — which is why the desktop `Popover` path was never affected. RAC's `Modal` (what `Tray` builds on) has no such guard. A small upstream PR mirroring `Popover`'s `useIsHidden` guard in `ModalOverlay`/`Modal` is split-proof by construction (both ends live inside RAC's dependency closure). Once that lands, `Tray`'s guard and the `@react-aria/collections` dependency can be dropped entirely. Related upstream context: [#6021](https://github.com/adobe/react-spectrum/issues/6021) (ListBox empty inside a Modal — same missing-guard family), [#8777](https://github.com/adobe/react-spectrum/issues/8777) (context singletons vs version ranges).

Follow-up (separate ticket): `packages/components/src/index.ts` re-exports `I18nProvider` from `@react-aria/i18n` — the same split class. RAC re-exports `I18nProvider`, so switching that import to `react-aria-components` makes it split-proof for free.

## Test Instructions

1. `pnpm test:unit packages/components/src/Select/Select.test.tsx packages/components/src/Select/Select.hiddenContext.test.tsx packages/components/src/Tray/Tray.test.tsx` — all pass.
2. `Select.hiddenContext.test.tsx` is the regression test for the split itself: it blinds `useIsHidden` (mocked to `false` — exactly what reading an orphan context does) and asserts the probe keeps it to **one** dialog, the selection commits, and the tray closes. Before the fix, the same mock produced the two-dialog leak.
3. `pnpm test:sb` — the `Components/Select` `MobileControlled` story test passes.
4. All Tray consumers pass: `pnpm test:unit packages/components/src/ComboBox packages/components/src/Autocomplete packages/components/src/DatePicker packages/components/src/Menu packages/components/src/TagField packages/components/src/Tray` (75 tests).
5. Manual (mobile viewport): open a `Select`, tap an option → it commits, the trigger updates, the tray closes, exactly one overlay exists.

## Breaking Changes

No

## What changed

- `packages/components/src/Tray/Tray.tsx` — DOM-probe safety net (`<span hidden>` + `isConnected` layout-effect check) alongside the existing `useIsHidden()` guard; comments document the `HiddenContext` coupling, why the guard exists (RAC `Modal` lacks the `Popover`/`Menu` guard), and the upstream path that lets us drop it.
- `packages/components/package.json` / `pnpm-lock.yaml` — net-unchanged vs `main` (the interim `react-aria`/`react-stately` pins were removed again; see "Why not pin").
- **Tests:**
  - `Select.hiddenContext.test.tsx` — simulates the split and asserts the probe prevents the duplicate modal and the selection commits (was: executable documentation of the leak).
  - `Select.test.tsx` — mobile tray invariant: exactly one dialog, holding the listbox; controlled `value` round-trips.
  - `Tray.test.tsx` — locks the hidden-pass guard contract (`isHidden` → children render without a mounted modal).
  - `Select.stories.tsx` — `MobileControlled` story (`component-test`) verifies `onChange`/`value` selection on the tray.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
