### PR TITLE
fix(DST-1505): re-export I18nProvider from react-aria-components to prevent locale context splits

### DIFF
--- a/.changeset/i18nprovider-rac-reexport.md
+++ b/.changeset/i18nprovider-rac-reexport.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1505): re-export `I18nProvider` from `react-aria-components` to prevent locale context splits
+
+`I18nProvider` was re-exported from `@react-aria/i18n`, which resolves `react-aria` via a caret range while `react-aria-components` pins it exactly. A consumer's lockfile can therefore install two `react-aria` copies, splitting the `I18nContext`: the locale set through Marigold's `I18nProvider` landed in one copy's context while the react-aria-components rendering Marigold's UI read the other — silently falling back to the default locale for aria labels, date/number formatting, and RTL detection.
+
+Re-exporting `I18nProvider` from `react-aria-components` makes provider and consumers share one context by construction, regardless of how the lockfile resolves `react-aria`. Same failure class as the mobile `Select` tray bug (DSTSUP-261).

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -182,7 +182,14 @@ export type { PaginationProps } from './Pagination/Pagination';
 export { ProgressCircle } from './ProgressCircle/ProgressCircle';
 export type { ProgressCircleProps } from './ProgressCircle/ProgressCircle';
 
-export { I18nProvider } from '@react-aria/i18n';
+// Re-exported from react-aria-components (NOT `@react-aria/i18n`) so the
+// provider writes the same `I18nContext` instance that RAC-based components
+// read. The `@react-aria/*` shell packages resolve `react-aria` via caret
+// ranges while RAC pins it exactly, so a consumer's lockfile can install two
+// `react-aria` copies — a provider from `@react-aria/i18n` would then set a
+// context RAC never reads and the locale would be silently ignored. Same
+// failure class as DSTSUP-261; see DST-1505.
+export { I18nProvider } from 'react-aria-components';
 export { useTheme, ThemeProvider } from '@marigold/system';
 export { MarigoldProvider } from './Provider/MarigoldProvider';
 export type { MarigoldProviderProps } from './Provider/MarigoldProvider';


### PR DESCRIPTION
# Description

`@marigold/components` re-exported `I18nProvider` from `@react-aria/i18n`. That shell package resolves `react-aria` through a **caret range** (`^3.48.0`), while `react-aria-components` pins `react-aria` **exactly** — so a consumer's lockfile can resolve them to two different `react-aria` copies. The `I18nContext` is then split: the locale a consumer sets via Marigold's `I18nProvider` is written into one copy's context, while the react-aria-components that render Marigold's UI read the other copy — and **silently fall back to the default locale** (aria labels, date/number formatting, RTL detection).

`react-aria-components@1.18` re-exports `I18nProvider` through its own exact-pinned closure (verified against the installed package). Switching the re-export makes provider and consumers share one context **by construction**, regardless of how the consumer's lockfile resolves `react-aria`.

This is the same failure class as the mobile `Select` tray bug (DSTSUP-261 / #5514), found during that investigation. General principle established there: whenever `react-aria-components` re-exports an API, import it from there — it is the only package whose internal consistency upstream guarantees. The `@react-aria/*` shell packages keep caret ranges permanently by design ([react-spectrum 2025 dependencies RFC](https://github.com/adobe/react-spectrum/blob/main/rfcs/2025-dependencies.md)).

**Known limitation:** Marigold-internal `useLocalizedStringFormatter` calls still read through `@react-aria/i18n`, which RAC does not re-export — that residual edge can only be fixed upstream.

Closes DST-1505

## Test Instructions

1. No behavior change when `react-aria` is deduped (the overwhelmingly common case): `pnpm test:unit packages/components/src/Provider` passes; i18n-driven stories (Calendar, DatePicker, Pagination) behave as before.
2. API surface unchanged: `import { I18nProvider } from '@marigold/components'` resolves to the same component signature (`locale` + `children`).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
