### PR TITLE
fix(DSTSUP-260): make Pagination follow the controlled page prop

### DIFF
--- a/.changeset/dstsup-260-pagination-controlled-page.md
+++ b/.changeset/dstsup-260-pagination-controlled-page.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-260): `Pagination` follows the controlled `page` prop after mount
+
+Previously the `page` prop only seeded internal state, so external updates (e.g. resetting to page 1 on a filter change) were ignored — the page indicator and the accessible `<nav>` label kept showing the stale page. `Pagination` now uses `useControlledState` from react-stately: when `page` is set, it is the single source of truth and `onChange` reports requested page changes; `defaultPage` remains the uncontrolled initial value. As part of this, `onChange` no longer fires when the active page is selected again, and the reset-to-page-1 behavior on `pageSize` changes only triggers when `pageSize` actually changed.

--- a/docs/app/(examples)/examples/inventory/Inventory.tsx
+++ b/docs/app/(examples)/examples/inventory/Inventory.tsx
@@ -220,7 +220,7 @@ export const Inventory = () => (
         <Switch label="Gift Wrap" defaultSelected />
       </Stack>
       <Stack space={6}>
-        <Pagination page={2} pageSize={1} totalItems={4} />
+        <Pagination defaultPage={2} pageSize={1} totalItems={4} />
         <Tag.Group label="Venue types" onRemove={() => {}}>
           {venueTypes.map(type => (
             <Tag key={type} id={type}>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,6 +67,7 @@
     "@react-stately/overlays": "^3.7.1",
     "@react-stately/table": "^3.16.1",
     "@react-stately/tree": "^3.10.1",
+    "@react-stately/utils": "^3.12.1",
     "@react-types/button": "~3.15.0",
     "@react-types/checkbox": "~3.10.0",
     "@react-types/grid": "~3.3.0",

--- a/packages/components/src/Pagination/Pagination.stories.tsx
+++ b/packages/components/src/Pagination/Pagination.stories.tsx
@@ -115,6 +115,7 @@ export const Basic = meta.story({
 });
 
 export const Controlled = meta.story({
+  tags: ['component-test'],
   render: ({ totalItems, pageSize, ...rest }: Partial<PaginationProps>) => {
     const [basicPage, setBasicPage] = useState(1);
 
@@ -122,6 +123,7 @@ export const Controlled = meta.story({
       <div>
         <h1>Pagination Example</h1>
         <p>Selected Page: {basicPage}</p>
+        <button onClick={() => setBasicPage(1)}>Reset to first page</button>
         <Pagination
           {...rest}
           totalItems={totalItems!}
@@ -130,6 +132,34 @@ export const Controlled = meta.story({
           onChange={setBasicPage}
         />
       </div>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Selecting a page updates the parent state', async () => {
+      await userEvent.click(canvas.getByLabelText('Page 3'));
+
+      await expect(canvas.getByText('Selected Page: 3')).toBeInTheDocument();
+      await expect(canvas.getByLabelText('Page 3')).toHaveAttribute(
+        'data-selected',
+        'true'
+      );
+    });
+
+    await step(
+      'An external change to the page prop updates the active page',
+      async () => {
+        await userEvent.click(
+          canvas.getByRole('button', { name: 'Reset to first page' })
+        );
+
+        await expect(canvas.getByLabelText('Page 1')).toHaveAttribute(
+          'data-selected',
+          'true'
+        );
+        await expect(canvas.getByText('Selected Page: 1')).toBeInTheDocument();
+      }
     );
   },
 });

--- a/packages/components/src/Pagination/Pagination.test.tsx
+++ b/packages/components/src/Pagination/Pagination.test.tsx
@@ -195,6 +195,40 @@ describe('Pagination tests', () => {
     );
   });
 
+  test('controlled: a pageSize change reports the reset via onChange(1) while the page prop stays the source of truth', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Basic.Component
+        totalItems={100}
+        pageSize={10}
+        page={3}
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.getByLabelText('Page 3')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+
+    rerender(
+      <Basic.Component
+        totalItems={100}
+        pageSize={20}
+        page={3}
+        onChange={onChange}
+      />
+    );
+
+    // In controlled mode the reset is requested via onChange(1); the parent owns
+    // `page`, so the active page stays 3 until the parent updates the prop.
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(screen.getByLabelText('Page 3')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+  });
+
   test('use control labels', async () => {
     render(<WithButtonLabels.Component />);
 

--- a/packages/components/src/Pagination/Pagination.test.tsx
+++ b/packages/components/src/Pagination/Pagination.test.tsx
@@ -99,6 +99,102 @@ describe('Pagination tests', () => {
     }
   );
 
+  test('follows the controlled page prop after mount', () => {
+    const { rerender } = render(
+      <Basic.Component totalItems={100} pageSize={10} page={3} />
+    );
+
+    expect(screen.getByLabelText('Page 3')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+
+    // Parent resets the page externally, e.g. when a filter changes
+    rerender(<Basic.Component totalItems={100} pageSize={10} page={1} />);
+
+    expect(screen.getByLabelText('Page 1')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+    expect(screen.getByRole('navigation')).toHaveAttribute(
+      'aria-label',
+      'Page 1 of 10'
+    );
+  });
+
+  test('controlled: clicking a page calls onChange but the page prop stays the source of truth', async () => {
+    const onChange = vi.fn();
+    render(
+      <Basic.Component
+        totalItems={100}
+        pageSize={10}
+        page={1}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Page 2'));
+
+    expect(onChange).toHaveBeenCalledWith(2);
+    // The parent did not update the page prop, so page 1 stays active
+    expect(screen.getByLabelText('Page 1')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+  });
+
+  test('uncontrolled: navigation updates the active page and calls onChange', async () => {
+    const onChange = vi.fn();
+    render(
+      <Basic.Component
+        totalItems={100}
+        pageSize={10}
+        defaultPage={2}
+        onChange={onChange}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Page 4'));
+
+    expect(onChange).toHaveBeenCalledWith(4);
+    expect(screen.getByLabelText('Page 4')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+  });
+
+  test('resets to the first page when pageSize changes', async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Basic.Component
+        totalItems={100}
+        pageSize={10}
+        defaultPage={5}
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.getByLabelText('Page 5')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+
+    rerender(
+      <Basic.Component
+        totalItems={100}
+        pageSize={20}
+        defaultPage={5}
+        onChange={onChange}
+      />
+    );
+
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(screen.getByLabelText('Page 1')).toHaveAttribute(
+      'data-selected',
+      'true'
+    );
+  });
+
   test('use control labels', async () => {
     render(<WithButtonLabels.Component />);
 

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
-import { KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, useEffect, useRef } from 'react';
 import { FocusScope, useFocusManager } from '@react-aria/focus';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { useControlledState } from '@react-stately/utils';
 import { cn, useClassNames } from '@marigold/system';
 import { ChevronLeft } from '../icons/ChevronLeft';
 import { ChevronRight } from '../icons/ChevronRight';
@@ -42,7 +43,10 @@ export interface PaginationProps {
   controlLabels?: [string, string];
 }
 
-interface InnerPaginationProps extends Omit<PaginationProps, 'totalItems'> {
+interface InnerPaginationProps extends Pick<
+  PaginationProps,
+  'pageSize' | 'controlLabels'
+> {
   currentPage: number;
   totalPages: number;
   pageRange: (number | 'ellipsis')[];
@@ -55,7 +59,6 @@ const InnerPagination = ({
   totalPages,
   pageRange,
   setCurrentPage,
-  onChange,
   controlLabels,
 }: InnerPaginationProps) => {
   const focusManager = useFocusManager();
@@ -63,27 +66,17 @@ const InnerPagination = ({
 
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage === totalPages || totalPages === 0;
-  const isFirstRender = useRef(true);
-
-  const handlePageChange = useCallback(
-    (newPage: number) => {
-      setCurrentPage(newPage);
-      if (onChange) {
-        onChange(newPage);
-      }
-    },
-    [setCurrentPage, onChange]
-  );
+  const prevPageSize = useRef(pageSize);
 
   useEffect(() => {
-    /* avoid setting page 1 on first render, 
-    e.g. necessary when using page prop */
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
+    /* Only reset to page 1 when the page size actually changed, so neither
+    mounting (e.g. with the page prop) nor an unstable setter triggers it */
+    if (prevPageSize.current === pageSize) {
       return;
     }
-    handlePageChange(1);
-  }, [pageSize, handlePageChange]);
+    prevPageSize.current = pageSize;
+    setCurrentPage(1);
+  }, [pageSize, setCurrentPage]);
 
   const { icon, container } = useClassNames({
     component: 'Pagination',
@@ -107,12 +100,12 @@ const InnerPagination = ({
   return (
     <>
       <NavigationButton
-        onClick={() => handlePageChange(Math.max(1, currentPage - 1))}
+        onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
         aria-label={stringFormatter.format('pagePrevious')}
         isDisabled={isFirstPage}
         controlLabel={controlLabels?.[0]}
         position="left"
-        onKeyDown={handleKeyDown(() => handlePageChange(currentPage - 1))}
+        onKeyDown={handleKeyDown(() => setCurrentPage(currentPage - 1))}
       >
         <ChevronLeft className={icon} />
       </NavigationButton>
@@ -127,8 +120,8 @@ const InnerPagination = ({
                 key={pageNumber}
                 page={pageNumber}
                 selected={pageNumber === currentPage}
-                onClick={() => handlePageChange(pageNumber)}
-                onKeyDown={handleKeyDown(() => handlePageChange(pageNumber))}
+                onClick={() => setCurrentPage(pageNumber)}
+                onKeyDown={handleKeyDown(() => setCurrentPage(pageNumber))}
               />
             )
           )
@@ -138,12 +131,12 @@ const InnerPagination = ({
       </div>
 
       <NavigationButton
-        onClick={() => handlePageChange(Math.min(totalPages, currentPage + 1))}
+        onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
         aria-label={stringFormatter.format('pageNext')}
         isDisabled={isLastPage}
         controlLabel={controlLabels?.[1]}
         position="right"
-        onKeyDown={handleKeyDown(() => handlePageChange(currentPage + 1))}
+        onKeyDown={handleKeyDown(() => setCurrentPage(currentPage + 1))}
       >
         <ChevronRight className={icon} />
       </NavigationButton>
@@ -156,9 +149,14 @@ const _Pagination = ({
   page,
   totalItems,
   pageSize,
+  onChange,
   ...props
 }: PaginationProps) => {
-  const [currentPage, setCurrentPage] = useState(page ?? defaultPage);
+  const [currentPage, setCurrentPage] = useControlledState(
+    page,
+    defaultPage,
+    onChange
+  );
   const totalPages = Math.ceil(totalItems / pageSize);
   const pageRange = usePageRange({ currentPage, totalPages });
   const { container } = useClassNames({ component: 'Pagination' });

--- a/packages/components/src/Pagination/Pagination.tsx
+++ b/packages/components/src/Pagination/Pagination.tsx
@@ -105,7 +105,9 @@ const InnerPagination = ({
         isDisabled={isFirstPage}
         controlLabel={controlLabels?.[0]}
         position="left"
-        onKeyDown={handleKeyDown(() => setCurrentPage(currentPage - 1))}
+        onKeyDown={handleKeyDown(() =>
+          setCurrentPage(Math.max(1, currentPage - 1))
+        )}
       >
         <ChevronLeft className={icon} />
       </NavigationButton>
@@ -136,7 +138,9 @@ const InnerPagination = ({
         isDisabled={isLastPage}
         controlLabel={controlLabels?.[1]}
         position="right"
-        onKeyDown={handleKeyDown(() => setCurrentPage(currentPage + 1))}
+        onKeyDown={handleKeyDown(() =>
+          setCurrentPage(Math.min(totalPages, currentPage + 1))
+        )}
       >
         <ChevronRight className={icon} />
       </NavigationButton>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@react-stately/tree':
         specifier: ^3.10.1
         version: 3.10.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-stately/utils':
+        specifier: ^3.12.1
+        version: 3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/button':
         specifier: ~3.15.0
         version: 3.15.1(react@19.2.6)
@@ -2817,6 +2820,12 @@ packages:
 
   '@react-stately/tree@3.10.1':
     resolution: {integrity: sha512-npdJ+hQGR1J+yi+LOWX7zGS0B9U2SYVbvS31ZCwSMfVUUo4eV+bvLtsiocYUn3bX/EgowFI/ZYJChrIKBpROJA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-stately/utils@3.12.1':
+    resolution: {integrity: sha512-NqKfzrknpfwiewx7R2vk1P+CneClInPDsIhw15+jOcUYSEfej0nta4cJywuKQJ2gsPwqX/ojDNixedCve9FWGw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -10745,6 +10754,13 @@ snapshots:
       react-stately: 3.47.0(react@19.2.6)
 
   '@react-stately/tree@3.10.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@swc/helpers': 0.5.23
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-stately: 3.47.0(react@19.2.6)
+
+  '@react-stately/utils@3.12.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@swc/helpers': 0.5.23
       react: 19.2.6


### PR DESCRIPTION
# Description

The `page` prop of `Pagination` is documented as controlled, but it was only used to seed internal `useState`. After mount, external updates to `page` (e.g. resetting to page 1 when a filter changes) were silently ignored — the page indicator and the `<nav>` `aria-label` kept announcing the stale page.

`Pagination` now uses `useControlledState` from `@react-stately/utils` (added as a direct dependency, already in the tree transitively): when `page` is provided it is the single source of truth and `onChange` reports requested page changes; `defaultPage` keeps covering the uncontrolled case. Two deliberate behavior refinements come with this:

- `onChange` no longer fires when the already-active page is selected again (matches react-aria conventions).
- The reset-to-page-1 effect now guards on an actual `pageSize` change instead of a first-render flag, so an unstable `onChange` identity can no longer retrigger it.

The inventory example in the docs passed `page={2}` without `onChange` (relying on the old broken seeding behavior) and was switched to `defaultPage={2}`.

No visual changes — Before/After screenshots are not applicable.

Closes DSTSUP-260

## Test Instructions

1. Run `pnpm sb` and open `Components/Pagination` → `Controlled`.
2. Click "Page 3" — the parent state ("Selected Page: 3") and the indicator update.
3. Click "Reset to first page" — the indicator must move back to page 1 (previously it stayed on page 3).
4. Run `pnpm vitest run --config vite.config.ts --project=unit-tests packages/components/src/Pagination/` and `pnpm vitest run --config vite.config.ts --project=storybook-tests packages/components/src/Pagination/Pagination.stories.tsx`.

## Breaking Changes

No — this restores the documented contract. Consumers that passed `page` without ever updating it (as a pseudo-initial value) should switch to `defaultPage`.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)