### PR TITLE
feat(DST-1506): add clientOnly option to ComponentDemo

### DIFF
--- a/docs/ui/ComponentDemo.tsx
+++ b/docs/ui/ComponentDemo.tsx
@@ -6,7 +6,7 @@ import { transformerNotationHighlight } from '@shikijs/transformers';
 import { track } from '@vercel/analytics';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
-import { type ComponentType, type ReactNode } from 'react';
+import { type ComponentType, type ReactNode, useEffect, useState } from 'react';
 import {
   MarigoldProvider,
   OverlayContainerProvider,
@@ -36,6 +36,15 @@ export interface ComponentDemoProps {
    * 'surface' uses white, 'page' uses the theme's background color.
    */
   background?: 'surface' | 'page';
+  /**
+   * Render the demo only on the client, after mount. Use this for demos whose
+   * interactivity relies on overlays inside a `<Panel>` (for example a `<Table>`
+   * with editable cells), which can fail to attach their handlers under the
+   * Next.js dev server's hydration. The demo works either way in a production
+   * build; this keeps it working in local development too.
+   * @default false
+   */
+  clientOnly?: boolean;
   children?: ReactNode;
 }
 
@@ -66,11 +75,19 @@ const codeOptions = {
 const Preview = ({
   name,
   background = 'surface',
+  clientOnly = false,
 }: {
   name: RegistryKey;
   background?: 'surface' | 'page';
+  clientOnly?: boolean;
 }) => {
   const Demo: ComponentType<any> = registry[name].demo;
+
+  // When `clientOnly` is set, defer rendering the demo until after mount so the
+  // server and the first client render agree (both render nothing), avoiding the
+  // hydration path that can leave overlay handlers detached under `next dev`.
+  const [mounted, setMounted] = useState(!clientOnly);
+  useEffect(() => setMounted(true), []);
 
   return (
     <div
@@ -86,7 +103,7 @@ const Preview = ({
           )}
         >
           <div className="not-prose w-full overflow-x-auto p-4">
-            <Demo />
+            {mounted ? <Demo /> : null}
           </div>
         </MarigoldProvider>
       </OverlayContainerProvider>
@@ -101,6 +118,7 @@ export const ComponentDemo = ({
   file,
   mode = 'full',
   background,
+  clientOnly,
 }: ComponentDemoProps) => {
   // Resolve the registry key from either name or file prop
   const registryKey = name ?? (file ? fileToRegistryKey(file) : undefined);
@@ -123,7 +141,7 @@ export const ComponentDemo = ({
   if (mode === 'preview') {
     return (
       <div className="overflow-hidden rounded-xl border">
-        <Preview name={key} background={background} />
+        <Preview name={key} background={background} clientOnly={clientOnly} />
       </div>
     );
   }
@@ -139,7 +157,7 @@ export const ComponentDemo = ({
   return (
     <DemoTabs>
       <Tab value="Preview" className="p-0">
-        <Preview name={key} background={background} />
+        <Preview name={key} background={background} clientOnly={clientOnly} />
       </Tab>
       <Tab value="Code">
         <DynamicCodeBlock lang="tsx" code={codeString} options={codeOptions} />


### PR DESCRIPTION
# Description

Adds an optional `clientOnly` prop to the docs `ComponentDemo` wrapper. When set, the demo renders only on the client after mount, so the server render and the first client render agree (both render nothing) and the demo skips the hydration path.

This fixes interactive demos whose overlays live inside a `<Panel>` (for example a `<Table>` with `<Table.EditableCell>`), which fail to attach their press handlers under the local `next dev` server. The demos already work in a production build (`next build` + `next start`) and the components pass their Storybook tests inside a Panel — this is a `next dev`-only SSR/hydration artifact. `clientOnly` defaults to `false`, so every existing demo is unaffected; opt in per demo with `<ComponentDemo file="..." clientOnly />`.

Found while building the Table Record Management pattern (DST-1288), which is the first consumer.

> **Base branch:** targets `beta-release` because `ComponentDemo.tsx` on `beta-release` already carries the `background` / code-options changes this builds on, which are not yet on `main`.

Closes DST-1506

## Test Instructions

1. `pnpm start`, open a page with a demo wrapped in `<ComponentDemo ... clientOnly />` (e.g. the Table Record Management pattern's inline-edit demo on the DST-1288 branch).
2. Confirm the demo renders after mount and its interactions work in `next dev`.
3. Confirm demos without the prop are unchanged (still server-rendered).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable) — N/A (docs tooling)
- [ ] Unit tests added/updated — N/A
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components) — N/A
- [ ] Visual regression tests updated (for UI changes) — N/A (no component or theme changes)
- [ ] Changeset added (`pnpm changeset`) — N/A (docs-only, no published package)