### PR TITLE
feat(DSTSUP-262): add `large` size to Dialog for wider layouts

### DIFF
--- a/.changeset/dstsup-262-dialog-large-size.md
+++ b/.changeset/dstsup-262-dialog-large-size.md
@@ -1,0 +1,8 @@
+---
+'@marigold/theme-rui': minor
+'@marigold/components': minor
+---
+
+feat(DSTSUP-262): add `large` size to Dialog for wider layouts
+
+`Dialog` (and `ConfirmationDialog`, which inherits the prop) now accepts `size="large"`, which sets the dialog width to `1024px` — matching the Tailwind `lg` breakpoint. Use it for content that doesn't fit the previous `medium` cap of `768px`, e.g. multi-month calendars or wider forms. The existing `min()` width formula keeps the dialog viewport-safe on smaller screens.

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -26,7 +26,7 @@ const meta = preview.meta({
         type: 'radio',
       },
       description: 'Size of the dialog',
-      options: ['default', 'xsmall', 'small', 'medium'],
+      options: ['default', 'xsmall', 'small', 'medium', 'large'],
       table: {
         type: { summary: 'string' },
       },

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -75,7 +75,7 @@ export interface DialogProps
     Omit<RAC.DialogProps, 'className' | 'style' | 'render'>,
     Pick<ModalProps, 'open' | 'onOpenChange'> {
   variant?: string;
-  size?: 'xsmall' | 'small' | 'medium' | (string & {});
+  size?: 'xsmall' | 'small' | 'medium' | 'large' | (string & {});
   /**
    * Show the close button.
    */

--- a/themes/theme-rui/src/components/Dialog.styles.ts
+++ b/themes/theme-rui/src/components/Dialog.styles.ts
@@ -14,6 +14,7 @@ export const Dialog: ThemeComponent<'Dialog'> = {
         xsmall: '',
         small: '',
         medium: '',
+        large: '',
       },
     },
   }),

--- a/themes/theme-rui/src/components/Modal.styles.ts
+++ b/themes/theme-rui/src/components/Modal.styles.ts
@@ -11,6 +11,7 @@ export const Modal: ThemeComponent<'Modal'> = cva({
       xsmall: '[--dialog-width:480px]', // "xs" breakpoint
       small: '[--dialog-width:640px]', // sm breakpoint
       medium: '[--dialog-width:768px]', // md breakpoint
+      large: '[--dialog-width:1024px]', // lg breakpoint
     },
   },
   defaultVariants: {


### PR DESCRIPTION
# Description

Adds a new `large` size option to `Dialog` (and `ConfirmationDialog`, which inherits the prop via `Pick<DialogProps, 'size'>`). `size="large"` sets the dialog width to **1024px** — matching the Tailwind `lg` breakpoint — so consumers can fit content that doesn't comfortably sit inside the previous `medium` cap of `768px`, e.g. multi-month calendars or wider forms.

The size scale is now `xsmall` (480) → `small` (640, default) → `medium` (768) → `large` (1024). The existing `w-[min(100% - 1rem, --dialog-width - 1rem)]` formula on `Modal` keeps the dialog viewport-safe on smaller screens — a `large` dialog on a 375px phone still clamps to the viewport, not 1024px.

Closes DSTSUP-262

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. `pnpm sb` and open Storybook → `Components/Dialog`.
2. In the Controls panel, set `size` to `large` and open the dialog — it should render at 1024px wide on a desktop viewport.
3. Resize the browser narrower than ~1138px — the dialog should clamp gracefully (via `max-w-[90vw]` on the inner Dialog and the `min()` width formula on Modal), never overflow.
4. Confirm existing sizes (`xsmall`, `small`, `medium`) still render at their previous widths.
5. `pnpm typecheck:only` — passes locally.

## Breaking Changes

No — purely additive. Existing `size` values are unchanged.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)