### PR TITLE
chore(DST-1512): apply RAC-first import principle to remaining I18nProvider usages

### DIFF
--- a/.changeset/dst-1512-rac-first-i18nprovider.md
+++ b/.changeset/dst-1512-rac-first-i18nprovider.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+chore(DST-1512): import `I18nProvider` from `react-aria-components` in remaining stories/tests/demos
+
+Follow-up to DST-1505. Migrates the remaining `I18nProvider` imports off the `@react-aria/i18n` shell package to stay consistent with the RAC-first principle (import an API from `react-aria-components` whenever it re-exports it, so provider and consumers share one `I18nContext`). Component stories/tests now import from `react-aria-components/I18nProvider`, and docs demos use the public `@marigold/components` export. The `packages/system` formatter tests intentionally stay on `@react-aria/i18n`, because the formatters under test read locale from that package directly and `packages/system` does not depend on `react-aria-components`.

--- a/docs/content/components/collection/table/table-formatters.demo.tsx
+++ b/docs/content/components/collection/table/table-formatters.demo.tsx
@@ -1,5 +1,4 @@
-import { I18nProvider } from '@react-aria/i18n';
-import { Table } from '@marigold/components';
+import { I18nProvider, Table } from '@marigold/components';
 import { DateFormat, NumericFormat } from '@marigold/system';
 
 export default () => (

--- a/docs/content/components/formatters/dateformat/dateformat-common-format.demo.tsx
+++ b/docs/content/components/formatters/dateformat/dateformat-common-format.demo.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
-import { I18nProvider } from '@react-aria/i18n';
-import { Columns, DateFormat, Radio, Stack } from '@marigold/components';
+import {
+  Columns,
+  DateFormat,
+  I18nProvider,
+  Radio,
+  Stack,
+} from '@marigold/components';
 
 interface Locale {
   [key: string]: string;

--- a/docs/content/components/formatters/numericformat/numericformat-common-format.demo.tsx
+++ b/docs/content/components/formatters/numericformat/numericformat-common-format.demo.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
-import { I18nProvider } from '@react-aria/i18n';
-import { Columns, NumericFormat, Radio, Stack } from '@marigold/components';
+import {
+  Columns,
+  I18nProvider,
+  NumericFormat,
+  Radio,
+  Stack,
+} from '@marigold/components';
 
 interface Locale {
   [key: string]: string;

--- a/packages/components/src/DateField/DateField.stories.tsx
+++ b/packages/components/src/DateField/DateField.stories.tsx
@@ -1,8 +1,8 @@
 import { CalendarDate, DateValue } from '@internationalized/date';
 import { useState } from 'react';
+import { I18nProvider } from 'react-aria-components/I18nProvider';
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
-import { I18nProvider } from '@react-aria/i18n';
 import { DateField } from './DateField';
 
 const meta = preview.meta({

--- a/packages/components/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/DatePicker/DatePicker.stories.tsx
@@ -1,9 +1,9 @@
 import { CalendarDate } from '@internationalized/date';
 import { useState } from 'react';
 import type { DateValue } from 'react-aria-components';
+import { I18nProvider } from 'react-aria-components/I18nProvider';
 import { expect, spyOn, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
-import { I18nProvider } from '@react-aria/i18n';
 import { Stack } from '../Stack/Stack';
 import { DatePicker } from './DatePicker';
 

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import { I18nProvider } from 'react-aria-components/I18nProvider';
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
-import { I18nProvider } from '@react-aria/i18n';
 import { Button } from '../Button/Button';
 import { Form } from '../Form/Form';
 import { makeFile } from './../test.utils';

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/no-node-access */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { I18nProvider } from '@react-aria/i18n';
+import { I18nProvider } from 'react-aria-components/I18nProvider';
 import { makeFile } from './../test.utils';
 import { Basic, MultipleFileUpload } from './FileField.stories';
 

--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -25,6 +25,10 @@ export const browserDeps = [
   // App deps used in decorators/stories
   '@tanstack/react-query',
   'react-select',
+  // RAC subpath import used in stories/tests (see DST-1512). Without
+  // pre-bundling, the unit-tests project discovers it at runtime and
+  // re-optimizes mid-run, cascading "error loading dynamically imported module".
+  'react-aria-components/I18nProvider',
   // Virtualizer deps (reference process.env in source)
   '@react-aria/virtualizer',
   '@react-stately/layout',


### PR DESCRIPTION
# Description

Follow-up to **DST-1505 / #5516**, which swapped the runtime re-export of `I18nProvider` in `packages/components/src/index.ts` from `@react-aria/i18n` to `react-aria-components` to prevent a split `I18nContext` when a consumer's lockfile resolves two `react-aria` copies.

This PR finishes the migration for the remaining stories/tests/demos, so the RAC-first principle (import an API from `react-aria-components` whenever it re-exports one) is applied consistently and the risky `@react-aria/i18n` pattern doesn't get copy-pasted into new code.

The correct target differs per package:

- **`packages/components`** (depends on `react-aria-components`) → import from `react-aria-components/I18nProvider`, matching existing siblings (`Calendar.stories`, `Radio.stories`, `Table.stories`):
  - `DatePicker/DatePicker.stories.tsx`
  - `DateField/DateField.stories.tsx`
  - `FileField/FileField.stories.tsx`
  - `FileField/FileField.test.tsx`
- **`docs`** (does not depend on RAC directly) → import from the public `@marigold/components` export, matching existing demos (`table-badge`, `table-numeric`, `calendar-localization`). This also inherits whatever the re-export points at — `@react-aria/i18n` today, `react-aria-components` automatically once #5516 merges:
  - `collection/table/table-formatters.demo.tsx`
  - `formatters/numericformat/numericformat-common-format.demo.tsx`
  - `formatters/dateformat/dateformat-common-format.demo.tsx`

### Deliberately out of scope

`packages/system/src/components/Formatters/DateFormat.test.tsx` and `NumericFormat.test.tsx` were in the original review list but are **intentionally left on `@react-aria/i18n`**. The formatters under test (`useDateFormatter` / `useNumberFormatter`) read locale directly from `@react-aria/i18n`, and `packages/system` does not depend on `react-aria-components`. The test provider must write to the same context the formatter reads — migrating these to RAC would deliberately split provider/consumer across packages (only works due to dedupe), which is conceptually backwards.

### Independence from #5516

These files are disjoint from #5516 (which only touches `index.ts` + its changeset), so the two PRs merge in any order with no conflict. Nothing here depends on #5516 being merged first.

Closes DST-1512

## Test Instructions

Pure import-source swap — no behavior change when `react-aria` is deduped (the common case). `I18nProvider` resolves to the same component signature from all three sources.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)