### PR TITLE
feat(DST-1514): add agent-example sidecars for settings-form and auto-save-settings

### DIFF
--- a/docs/app/(examples)/examples/auto-save-settings/auto-save-settings.marigold-pattern.yaml
+++ b/docs/app/(examples)/examples/auto-save-settings/auto-save-settings.marigold-pattern.yaml
@@ -1,0 +1,17 @@
+title: Auto-saving settings with optimistic toggles
+brief: >-
+  An account-preferences screen where each Switch saves the moment it is
+  toggled, with no save button. Toggles update optimistically and a shared hook
+  rolls the value back and raises an error Toast (with a retry action) when the
+  save fails, keeping concurrent saves race-safe.
+patterns:
+  - user-input/forms
+  - feedback/feedback-messages
+mock_data: []
+key_files:
+  - notifications.tsx
+  - privacy.tsx
+  - useAutoSaveSwitch.tsx
+scaffolding_files:
+  - page.tsx
+peer_deps: []

--- a/docs/app/(examples)/examples/settings-form/settings-form.marigold-pattern.yaml
+++ b/docs/app/(examples)/examples/settings-form/settings-form.marigold-pattern.yaml
@@ -1,0 +1,27 @@
+title: Tabbed event-settings form
+brief: >-
+  An organization-level settings screen that groups related forms under Tabs
+  (general info, registration & capacity, notifications). Each tab is its own
+  Form that saves independently with a success Toast, and a Danger Zone uses
+  ConfirmationDialog to gate destructive actions (reset defaults, delete).
+patterns:
+  - user-input/forms
+mock_data:
+  - alias: '@/lib/data/eventTypes'
+    shape: |
+      // Populates the default event-type Select on the General tab. Swap for
+      // the consumer's own option source.
+      export const eventTypes: Array<{
+        id: string;
+        label: string;
+        description: string;
+      }>;
+key_files:
+  - generalSettings.tsx
+  - registrationCapacity.tsx
+  - notifications.tsx
+  - dangerZone.tsx
+  - useSavedToast.ts
+scaffolding_files:
+  - page.tsx
+peer_deps: []


### PR DESCRIPTION
# Description

Adds `*.marigold-pattern.yaml` sidecars for the `settings-form` and `auto-save-settings` examples under `docs/app/(examples)/examples/`. Both live in the "Form" group of the `(examples)` app-shell navigation alongside the already-documented `event-form`, but lacked a sidecar — so the `build:examples` validator skipped them and the `marigold examples` CLI / `/mcp/examples.json` registry never surfaced them.

- **settings-form** — tabbed event-settings form (general / registration / notifications) plus a `ConfirmationDialog`-gated Danger Zone.
- **auto-save-settings** — `Switch` toggles that save optimistically with rollback + error toast on failure.

The remaining sidecar-less folders (`analytics`, `billing`, `general`, `security`, `teams`, `users`) are App-Shell placeholder/nav pages and stay excluded by design. After this change `build:examples` builds 5 examples (filter, event-form, inventory, settings-form, auto-save-settings).

This surfaced while merging `main` (DST-1421/1445 agent-example sidecar system) into `beta-release`; these two beta-only examples needed sidecars to match.

Closes DST-1514

## Test Instructions

1. From the repo root run `pnpm --filter @marigold/docs build:examples`.
2. Confirm it reports **5 examples** built and skips only the 6 App-Shell folders (analytics, billing, general, security, teams, users) — no `❌ Sidecar … references files that do not exist` errors.
3. Optionally inspect `docs/public/mcp/examples.json` and `docs/public/mcp/examples/{settings-form,auto-save-settings}.json` to verify the payloads.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no UI changes
- [ ] Changeset added (`pnpm changeset`) — N/A, docs registry metadata only