### PR TITLE
chore(DST-1517): HelpText renders the shared Description component

### DIFF
--- a/.changeset/dst-1517-helptext-uses-description.md
+++ b/.changeset/dst-1517-helptext-uses-description.md
@@ -1,0 +1,12 @@
+---
+'@marigold/components': patch
+---
+
+chore(DST-1517): HelpText renders the shared Description component
+
+`HelpText` now renders the description through the shared `Description` component
+instead of react-aria's raw `<Text slot="description">`. `Description` is just
+`<Text slot="description">`, so the rendered output and `aria-describedby` wiring
+are unchanged. The win is a single `Description` building block shared by both the
+slot-configuration containers and the form fields, so the two cannot drift apart.
+No names, output, or behaviour change.

--- a/packages/components/src/HelpText/HelpText.tsx
+++ b/packages/components/src/HelpText/HelpText.tsx
@@ -4,9 +4,9 @@ import {
   FieldError,
   FieldErrorContext,
 } from 'react-aria-components/FieldError';
-import { Text } from 'react-aria-components/Text';
 import type { ValidationResult } from '@react-types/shared';
 import { cn, useClassNames } from '@marigold/system';
+import { Description } from '../Description/Description';
 import { TriangleAlert } from '../icons/TriangleAlert';
 
 // Props
@@ -80,9 +80,7 @@ export const HelpText = ({
           );
         }}
       </FieldError>
-      {ctx && ctx.isInvalid ? null : (
-        <Text slot="description">{description}</Text>
-      )}
+      {ctx && ctx.isInvalid ? null : <Description>{description}</Description>}
     </div>
   );
 };


### PR DESCRIPTION
# Description

`HelpText` now renders the description through the shared `Description` component instead of react-aria's raw `<Text slot="description">`. `Description` is just `<Text slot="description">`, so the rendered DOM and `aria-describedby` wiring are unchanged. The win is a single `Description` building block shared by both the slot-configuration containers and the form fields, so the two cannot drift apart. No names, output, or behaviour change.

This is the single follow-up from the spike DST-1371 (RFC: Distinct Vocabulary for Field Family and Slot-Configuration Pattern).

Closes DST-1517

## Test Instructions

1. `pnpm install && pnpm typecheck:only`
2. `pnpm test:unit packages/components/src/HelpText packages/components/src/Description` — 8/8 pass
3. Confirm field descriptions and error messages still render identically (no visual change).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated — N/A, output-neutral change, beta-release target
- [x] Changeset added (\`pnpm changeset\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)