### PR TITLE
refa([DST-1502]): 🧹 Extract shared `resolveInsetAxes` helper for inset padding (fixes `<Card p={number}>`)

### DIFF
--- a/.changeset/dst-1502-inset-padding-helper.md
+++ b/.changeset/dst-1502-inset-padding-helper.md
@@ -1,5 +1,5 @@
 ---
-'@marigold/system': patch
+'@marigold/system': minor
 '@marigold/components': patch
 ---
 

--- a/.changeset/dst-1502-inset-padding-helper.md
+++ b/.changeset/dst-1502-inset-padding-helper.md
@@ -1,0 +1,12 @@
+---
+'@marigold/system': patch
+'@marigold/components': patch
+---
+
+Extract `resolveInsetAxes` helper to centralise inset-padding axis resolution.
+
+The `p` → `px`/`py` resolution logic (branching on whether the value is a numeric scale or a named token) was copy-pasted across `Page`, `Panel`, and `Card`. This duplication caused the `<Card p={number}>` silent bug (resolving to a non-existent `var(--spacing-4-x)`), the same class of bug that had already been fixed independently in `Panel` (DST-1501) and `Page` (DST-1360).
+
+- Adds `resolveInsetAxes({ p, px, py, defaultInset })` to `@marigold/system` alongside `createSpacingVar`.
+- Adopts the helper in `Card`, `Panel`, and `Page`, fixing the live `<Card p={number}>` bug as part of the refactor.
+- Fixes the same numeric-`p` bug in `SelectList` (inline, since its conditional-axis pattern differs).

--- a/packages/components/src/Card/Card.stories.tsx
+++ b/packages/components/src/Card/Card.stories.tsx
@@ -222,6 +222,37 @@ export const WithPaddingProp = meta.story({
   ),
 });
 
+export const WithNumericPadding = meta.story({
+  tags: ['component-test'],
+  args: { p: 4 },
+  render: args => (
+    <Card {...args}>
+      <Card.Header>
+        <Title>Numeric Padding</Title>
+      </Card.Header>
+      <Card.Body>
+        <Text>
+          This card uses a numeric scale value (<code>p=&#123;4&#125;</code>)
+          for inset padding. Both axes should have equal spacing.
+        </Text>
+      </Card.Body>
+    </Card>
+  ),
+});
+
+WithNumericPadding.test(
+  'applies equal horizontal and vertical padding from a numeric scale value',
+  async ({ canvas }) => {
+    const article = canvas.getByRole('article');
+    const style = getComputedStyle(article);
+    expect(style.getPropertyValue('--card-px')).toBeTruthy();
+    expect(style.getPropertyValue('--card-py')).toBeTruthy();
+    expect(style.getPropertyValue('--card-px')).toBe(
+      style.getPropertyValue('--card-py')
+    );
+  }
+);
+
 export const WithBleedBody = meta.story({
   render: args => (
     <Card {...args}>

--- a/packages/components/src/Card/Card.test.tsx
+++ b/packages/components/src/Card/Card.test.tsx
@@ -97,6 +97,19 @@ describe('Card', () => {
       );
     });
 
+    test('numeric `p` drives both --card-px and --card-py as scale values', () => {
+      render(<Basic.Component p={4} data-testid="card" />);
+
+      const card = screen.getByTestId('card');
+
+      expect(card.style.getPropertyValue('--card-px')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+      expect(card.style.getPropertyValue('--card-py')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+    });
+
     test('`p` recipe drives both --card-px and --card-py', () => {
       render(<Basic.Component p="square-relaxed" data-testid="card" />);
 

--- a/packages/components/src/Card/Card.tsx
+++ b/packages/components/src/Card/Card.tsx
@@ -7,7 +7,12 @@ import type {
   SpaceProp,
   SpacingTokens,
 } from '@marigold/system';
-import { cn, createSpacingVar, useClassNames } from '@marigold/system';
+import {
+  cn,
+  createSpacingVar,
+  resolveInsetAxes,
+  useClassNames,
+} from '@marigold/system';
 import { useSlot } from '../utils/useSlot';
 import { CardBody } from './CardBody';
 import { CardContext } from './CardContext';
@@ -101,9 +106,12 @@ export const Card = ({
     );
   }
 
-  const inset = p ?? 'square-regular';
-  const resolvedPx = px ?? `${inset}-x`;
-  const resolvedPy = py ?? `${inset}-y`;
+  const { px: resolvedPx, py: resolvedPy } = resolveInsetAxes({
+    p,
+    px,
+    py,
+    defaultInset: 'square-regular',
+  });
 
   const rootHeadingProps = useMemo(
     () => ({

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -7,7 +7,12 @@ import type {
   SpaceProp,
   SpacingTokens,
 } from '@marigold/system';
-import { cn, createSpacingVar, isScale, useClassNames } from '@marigold/system';
+import {
+  cn,
+  createSpacingVar,
+  resolveInsetAxes,
+  useClassNames,
+} from '@marigold/system';
 import { useSlot } from '../utils/useSlot';
 import { PageContext } from './Context';
 import { PageContent } from './PageContent';
@@ -87,10 +92,12 @@ export const Page = ({
   const classNames = useClassNames({ component: 'Page' });
   const [titleSlotRef, hasTitle] = useSlot(!ariaLabel);
 
-  const inset = `${p ?? 'square-relaxed'}`;
-  const isScaleInset = isScale(inset);
-  const resolvedPx = px ?? (isScaleInset ? inset : `${inset}-x`);
-  const resolvedPy = py ?? (isScaleInset ? inset : `${inset}-y`);
+  const { px: resolvedPx, py: resolvedPy } = resolveInsetAxes({
+    p,
+    px,
+    py,
+    defaultInset: 'square-relaxed',
+  });
 
   const rootHeadingProps = useMemo(
     () => ({

--- a/packages/components/src/Panel/Panel.tsx
+++ b/packages/components/src/Panel/Panel.tsx
@@ -7,7 +7,12 @@ import type {
   SpaceProp,
   SpacingTokens,
 } from '@marigold/system';
-import { cn, createSpacingVar, isScale, useClassNames } from '@marigold/system';
+import {
+  cn,
+  createSpacingVar,
+  resolveInsetAxes,
+  useClassNames,
+} from '@marigold/system';
 import { useSlot } from '../utils/useSlot';
 import { PanelContext } from './Context';
 import { PanelCollapsible } from './PanelCollapsible';
@@ -91,10 +96,12 @@ export const Panel = ({
   const classNames = useClassNames({ component: 'Panel', variant, size });
   const [titleSlotRef, hasTitle] = useSlot(!ariaLabel);
 
-  const inset = `${p ?? 'square-regular'}`;
-  const isScaleInset = isScale(inset);
-  const resolvedPx = px ?? (isScaleInset ? inset : `${inset}-x`);
-  const resolvedPy = py ?? (isScaleInset ? inset : `${inset}-y`);
+  const { px: resolvedPx, py: resolvedPy } = resolveInsetAxes({
+    p,
+    px,
+    py,
+    defaultInset: 'square-regular',
+  });
 
   const rootHeadingProps = useMemo(
     () => ({

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -339,6 +339,19 @@ describe('SelectList', () => {
       expect(grid.style.getPropertyValue('--selectlist-item-py')).toBe('');
     });
 
+    test('numeric `p` writes both axis vars as scale values (not -x/-y suffixed)', () => {
+      render(<Basic.Component p={4} />);
+
+      const grid = screen.getByRole('grid') as HTMLElement;
+
+      expect(grid.style.getPropertyValue('--selectlist-item-px')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+      expect(grid.style.getPropertyValue('--selectlist-item-py')).toBe(
+        'calc(var(--spacing) * 4)'
+      );
+    });
+
     test('uniform `p` writes both axis vars inline, deriving from the inset token', () => {
       render(<Basic.Component p="square-loose" />);
 

--- a/packages/components/src/SelectList/SelectList.tsx
+++ b/packages/components/src/SelectList/SelectList.tsx
@@ -21,7 +21,7 @@ import type {
   SpaceProp,
   WidthProp,
 } from '@marigold/system';
-import { cn, createSpacingVar, useClassNames } from '@marigold/system';
+import { cn, createSpacingVar, isScale, useClassNames } from '@marigold/system';
 import { FieldBase } from '../FieldBase/FieldBase';
 import { HiddenSelection } from '../HiddenSelection/HiddenSelection';
 import { SelectListContext } from './Context';
@@ -242,9 +242,15 @@ const SelectList = <Mode extends SelectionMode = 'single'>({
     if (p === undefined && px === undefined && py === undefined) {
       return EMPTY_STYLE;
     }
+    if (p !== undefined) {
+      const inset = `${p}`;
+      const scale = isScale(inset);
+      return {
+        ...createSpacingVar('selectlist-item-px', scale ? inset : `${inset}-x`),
+        ...createSpacingVar('selectlist-item-py', scale ? inset : `${inset}-y`),
+      };
+    }
     return {
-      ...(p !== undefined && createSpacingVar('selectlist-item-px', `${p}-x`)),
-      ...(p !== undefined && createSpacingVar('selectlist-item-py', `${p}-y`)),
       ...(px !== undefined && createSpacingVar('selectlist-item-px', `${px}`)),
       ...(py !== undefined && createSpacingVar('selectlist-item-py', `${py}`)),
     };

--- a/packages/components/src/SelectList/SelectList.tsx
+++ b/packages/components/src/SelectList/SelectList.tsx
@@ -242,6 +242,14 @@ const SelectList = <Mode extends SelectionMode = 'single'>({
     if (p === undefined && px === undefined && py === undefined) {
       return EMPTY_STYLE;
     }
+    // Intentionally diverges from resolveInsetAxes (used by Card/Page/Panel):
+    // 1. `p` short-circuits here — px/py are ignored when p is set. resolveInsetAxes
+    //    does the opposite (explicit px/py win over p via `?? `).
+    // 2. No theme-default fallback — the CSS vars cascade from the theme via the
+    //    list slot in SelectList.styles.ts, so we only write them when explicitly set.
+    // 3. Partial-axis overrides are valid — px and py are applied independently,
+    //    letting the theme fill in whichever axis the consumer leaves unset.
+    // Don't "consolidate" this with resolveInsetAxes without accounting for all three.
     if (p !== undefined) {
       const inset = `${p}`;
       const scale = isScale(inset);

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -100,5 +100,6 @@ export {
   isFraction,
   isScale,
   isValidCssCustomPropertyName,
+  resolveInsetAxes,
 } from './utils/css-variables.utils';
 export { get } from './utils/object.utils';

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -8,6 +8,7 @@ import {
   isFraction,
   isScale,
   isValidCssCustomPropertyName,
+  resolveInsetAxes,
 } from './css-variables.utils';
 
 describe('isScale', () => {
@@ -159,6 +160,51 @@ describe('createSpacingVar', () => {
       });
     }
   );
+});
+
+describe('resolveInsetAxes', () => {
+  it('resolves a named token to -x / -y suffixed values', () => {
+    expect(resolveInsetAxes({ defaultInset: 'square-regular' })).toEqual({
+      px: 'square-regular-x',
+      py: 'square-regular-y',
+    });
+  });
+
+  it('resolves a numeric p to the same value on both axes (no -x/-y suffix)', () => {
+    expect(resolveInsetAxes({ p: 4, defaultInset: 'square-regular' })).toEqual({
+      px: '4',
+      py: '4',
+    });
+  });
+
+  it('resolves a string scale p to the same value on both axes', () => {
+    expect(
+      resolveInsetAxes({ p: '8', defaultInset: 'square-regular' })
+    ).toEqual({
+      px: '8',
+      py: '8',
+    });
+  });
+
+  it('explicit px/py override the default inset', () => {
+    expect(
+      resolveInsetAxes({
+        px: 'padding-loose',
+        py: 'padding-tight',
+        defaultInset: 'square-regular',
+      })
+    ).toEqual({
+      px: 'padding-loose',
+      py: 'padding-tight',
+    });
+  });
+
+  it('uses the default inset when p is undefined', () => {
+    expect(resolveInsetAxes({ defaultInset: 'square-relaxed' })).toEqual({
+      px: 'square-relaxed-x',
+      py: 'square-relaxed-y',
+    });
+  });
 });
 
 describe('createWidthVar', () => {

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -141,6 +141,38 @@ const makeDimensionVar =
   };
 
 /**
+ * Resolves `p` / `px` / `py` inset-padding props to per-axis values.
+ *
+ * When `p` is a numeric scale value (e.g. `"4"`) the same value is used on
+ * both axes (`calc(var(--spacing) * 4)`). When it is a named token (e.g.
+ * `"square-regular"`) the conventional `-x` / `-y` suffixes are appended so
+ * the right axis-specific spacing variable is referenced.
+ *
+ * @param p - The shorthand padding prop (`InsetSpacingTokens` or a scale number).
+ * @param px - Explicit horizontal padding (takes precedence over `p`).
+ * @param py - Explicit vertical padding (takes precedence over `p`).
+ * @param defaultInset - Fallback token used when `p` is `undefined`.
+ */
+export const resolveInsetAxes = ({
+  p,
+  px,
+  py,
+  defaultInset,
+}: {
+  p?: string | number;
+  px?: string | number;
+  py?: string | number;
+  defaultInset: string;
+}): { px: string; py: string } => {
+  const inset = `${p ?? defaultInset}`;
+  const scale = isScale(inset);
+  return {
+    px: `${px ?? (scale ? inset : `${inset}-x`)}`,
+    py: `${py ?? (scale ? inset : `${inset}-y`)}`,
+  };
+};
+
+/**
  * Generates a CSS custom property for width.
  *
  * Supports the spacing scale (e.g. `"4"`, `"2.5"`), fractions (e.g. `"1/2"`),

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -148,10 +148,11 @@ const makeDimensionVar =
  * `"square-regular"`) the conventional `-x` / `-y` suffixes are appended so
  * the right axis-specific spacing variable is referenced.
  *
- * @param p - The shorthand padding prop (`InsetSpacingTokens` or a scale number).
- * @param px - Explicit horizontal padding (takes precedence over `p`).
- * @param py - Explicit vertical padding (takes precedence over `p`).
- * @param defaultInset - Fallback token used when `p` is `undefined`.
+ * @param options - Destructured options object.
+ * @param options.p - The shorthand padding prop (`InsetSpacingTokens` or a scale number).
+ * @param options.px - Explicit horizontal padding (takes precedence over `p`).
+ * @param options.py - Explicit vertical padding (takes precedence over `p`).
+ * @param options.defaultInset - Fallback token used when `p` is `undefined`.
  */
 export const resolveInsetAxes = ({
   p,


### PR DESCRIPTION
## Description

Centralises the `p` → `px`/`py` axis-resolution logic that was copy-pasted across `Page`, `Panel`, `Card`, and `SelectList`. The duplication was the root cause of the `<Card p={number}>` silent bug (resolving to a non-existent `var(--spacing-4-x)`) — the same class of bug that had already been fixed independently in `Panel` (DST-1501) and `Page` (DST-1360).

A single `resolveInsetAxes({ p, px, py, defaultInset })` helper is added to `@marigold/system` and adopted in all four components. `SelectList` carries an inline fix using `isScale` directly because its pattern is structurally different: it has no built-in default, supports partial-axis overrides, and sets CSS vars that cascade to child options rather than the root element.

Closes DST-1502

## Test Instructions

1. Run `pnpm test:unit` — new tests for `resolveInsetAxes` (in `css-variables.utils.test.ts`) and the numeric-`p` regression test for `Card` and `SelectList` should all pass.
2. In Storybook, render `<Card p={4}>` and confirm padding is applied on both axes (previously produced no padding).
3. Confirm `<Panel p={4}>` and `<Page p={4}>` still work as before (covered by existing tests in DST-1501 / DST-1360).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)