### PR TITLE
ci: pin Chromatic VRT builds to the real checked-out commit

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -79,6 +79,16 @@ jobs:
             }}
           # Required by Chromatic
           fetch-depth: 0
+      - name: Resolve checked-out commit
+        # The checkout above always lands on a real, persisted commit
+        # (merged squash commit on main / PR head / branch tip). We pin
+        # Chromatic to this SHA so the merge-triggered baseline build isn't
+        # tagged to GITHUB_SHA, which on pull_request events is an ephemeral
+        # test-merge ref that never enters git history — making the main
+        # baseline unusable and freezing the Chromatic ancestor at the last
+        # build that happened to have a real commit.
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: pnpm/action-setup@v6.0.8 # Uses version from package.json#packageManager
       - name: Setup Node (using .node-version)
         uses: actions/setup-node@v6
@@ -92,6 +102,18 @@ jobs:
       - name: Run visual regression tests on chromatic
         id: chromatic
         uses: chromaui/action@latest
+        env:
+          # Force Chromatic to record the build against the real checked-out
+          # commit instead of GITHUB_SHA, which on pull_request events is an
+          # ephemeral test-merge ref that never enters git history (making the
+          # build unusable as a baseline). The CLI only honors this override
+          # when BOTH CHROMATIC_SHA and CHROMATIC_BRANCH are set
+          # (isFromEnvironmentVariable = CHROMATIC_SHA && CHROMATIC_BRANCH);
+          # CHROMATIC_SLUG must also be passed because the override path sets
+          # `slug = CHROMATIC_SLUG` unconditionally and would otherwise clear it.
+          CHROMATIC_SHA: ${{ steps.sha.outputs.sha }}
+          CHROMATIC_BRANCH: ${{ steps.resolve-branch.outputs.branch }}
+          CHROMATIC_SLUG: ${{ github.repository }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           branchName: ${{ steps.resolve-branch.outputs.branch }}


### PR DESCRIPTION
# Description

The Chromatic baseline ("Ancestor") for our Visual Regression Tests had been
frozen ~2 weeks back (build #47, commit `8637d9f`, Jun 2) instead of tracking
`main`. Every new PR was diffed against that stale baseline.

**Root cause.** The Chromatic CLI records each build against `GITHUB_SHA`, not
the commit we check out — and `GITHUB_SHA` differs by trigger:

- On `pull_request` (our merge-into-`main` trigger), `GITHUB_SHA` is GitHub's
  ephemeral test-merge ref. It never enters git history, so the build can't be
  used as a baseline.
- On `issue_comment` (`/run-chromatic`), `GITHUB_SHA` is `main`'s tip — a real
  commit, but the build gets labeled on the feature branch.

The Chromatic dashboard shows this directly: builds #65–#70 are labeled
"on main" but carry `8eecee0`, `8b7101f`, `906d9ba`, … — none of which are real
`main` commits (the real ones are `60b6e03b3`, `3259a3854`, …; two don't exist
in git at all).

Because every merge build was tagged with a non-existent commit, the
GitHub Actions log for the DST-1507 merge run (Chromatic build #70) shows two
distinct symptoms.

1. The build's own commit can't be found:

   ```
   ⚠ Commit 8eecee0 does not exist
     Using it anyway, but commit details (date, author) will be missing.
     We will not be able to retain baselines from builds created by the Visual Tests addon.
   ```

2. As a result, TurboSnap can't use recent builds as baselines and falls back
   to the last build with a real commit (#47):

   ```
   ℹ Missing commit detected
     When detecting git changes for TurboSnap, we couldn't find the commit (8b7101f) for the most recent build (#69).
     To avoid re-snapshotting stories we know haven't changed, we copied from the most recent build (#47) that did have a commit (8637d9f) instead.
   ```

**Fix.** Resolve the real checked-out commit (`git rev-parse HEAD`) after
checkout and pass it to Chromatic via `CHROMATIC_SHA`. The CLI only honors this
override when **both** `CHROMATIC_SHA` and `CHROMATIC_BRANCH` are set
(`isFromEnvironmentVariable = CHROMATIC_SHA && CHROMATIC_BRANCH`), and the
override path assigns `slug = CHROMATIC_SLUG` unconditionally, so all three are
required. The override takes precedence over every trigger's `GITHUB_SHA`
handling.

After this change:
- **merge** builds record the real squashed `main` commit on `main` → a proper,
  durable baseline (the freeze self-heals on the first merge after this lands);
- **comment** builds record the real PR head on the PR branch → fixes the
  secondary bug where PR snapshots were attributed to a `main` commit;
- **dispatch** (`/vrt`) builds record the dispatched branch's real commit.

## Test Instructions

This only takes effect once it's on `main` (the merge trigger runs the workflow
from the default branch).

1. After merge, check the post-merge VRT run: it should no longer log
   `⚠ Commit <sha> does not exist`, and the Chromatic build should appear as
   `<real-sha> on main` (a commit that exists in `main`'s history).
2. On the next PR after that, confirm the Chromatic Ancestor points at that
   recent `main` build rather than the old Jun-2 build (#47).

## Breaking Changes

No. CI-only; no published package is affected.

## Checklist

- [ ] Storybook / Marigold docs preview — N/A (CI only)
- [ ] Stories added/updated — N/A
- [ ] Unit tests added/updated — N/A
- [ ] Component documentation — N/A
- [ ] Accessibility reviewed — N/A
- [ ] Visual regression tests updated — N/A (this *is* the VRT pipeline)
- [ ] Changeset added — N/A (no package release; CI-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
