### PR TITLE
fix(DST-1553): drop dead size literals from Tabs (keep props as theme hooks)

### DIFF
--- a/.changeset/dst-1553-tabs-size-string.md
+++ b/.changeset/dst-1553-tabs-size-string.md
@@ -1,0 +1,11 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1553): drop the dead `'small' | 'medium' | 'large'` literals from `Tabs` `size`
+
+The `size` and `variant` props on `Tabs` resolved to nothing after the RUI theme
+size variants were removed (2025-03-04). `size` now accepts a plain `string`
+(matching `Label` and `HelpText`) instead of advertising specific values that no
+theme backs. The props stay in place as theme hooks, so a consumer theme can
+define its own `size`/`variant` variants without the misleading built-in union.

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -17,13 +17,13 @@ export interface TabsProps extends Omit<
    * @default false
    */
   disabled?: boolean;
-  size?: 'small' | 'medium' | 'large';
+  size?: string;
   variant?: string;
 }
 
 // component
 // ----------------------
-const _Tabs = ({ disabled, variant, size = 'medium', ...rest }: TabsProps) => {
+const _Tabs = ({ disabled, variant, size, ...rest }: TabsProps) => {
   const props: RAC.TabsProps = {
     isDisabled: disabled,
     ...rest,


### PR DESCRIPTION
# Description

`Tabs` advertised `size?: 'small' | 'medium' | 'large'` (default `'medium'`), but no theme has backed those values since the RUI `Tabs` size variants were deleted on 2025-03-04 (commit `abf59735d`). `cva` silently ignores variant props with no matching definition, so `<Tabs size="large">` and `<Tabs size="small">` render identically — a misleading, inert API.

This widens `size` to a plain `string` (matching `Label`/`HelpText`) and removes the `size = 'medium'` default. The `size`/`variant` props stay in place as theme hooks, so a consumer theme can still define its own variants — they just no longer imply specific values that nothing ships. Type-only change, no visual effect (the literals never did anything).

Closes DST-1553

## Test Instructions

1. `pnpm install && pnpm typecheck:only` — passes (verified locally).
2. Confirm `<Tabs size="small">` still typechecks (widening a union to `string` is non-breaking).
3. No manual/visual testing required — the change has no rendered effect; covered by CI.

## Breaking Changes

No — widening the union to `string` is backward compatible (existing `size="small"` etc. still typecheck). Ships as a `patch`.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no rendered change
- [x] Changeset added (\`pnpm changeset\`)