### PR TITLE
fix(DST-1555): omit style on Label and fix dead Panel space control option

### DIFF
--- a/.changeset/label-omit-style-prop.md
+++ b/.changeset/label-omit-style-prop.md
@@ -1,0 +1,10 @@
+---
+'@marigold/components': patch
+---
+
+fix: stop exposing `style` on `Label`
+
+`Label` only removed `className` from its react-aria props, leaving `style` in
+the public interface. It now omits both, matching the `className`/`style`
+removal convention used across the design system (e.g. `Description`,
+`TextValue`). Theme the label via `variant`/`size` instead.

--- a/packages/components/src/Label/Label.tsx
+++ b/packages/components/src/Label/Label.tsx
@@ -2,7 +2,7 @@ import type RAC from 'react-aria-components';
 import { Label } from 'react-aria-components/Label';
 import { cn, useClassNames } from '@marigold/system';
 
-type RemovedProps = 'className';
+type RemovedProps = 'className' | 'style';
 export interface LabelProps extends Omit<RAC.LabelProps, RemovedProps> {
   size?: string;
   variant?: string;

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -57,7 +57,7 @@ const meta = preview.meta({
     },
     space: {
       control: { type: 'radio' },
-      options: ['none', 'tight', 'related', 'regular', 'group', 'section'],
+      options: ['collapsed', 'tight', 'related', 'regular', 'group', 'section'],
       description: 'Spacing between Panel sections.',
       table: { defaultValue: { summary: 'regular' } },
     },


### PR DESCRIPTION
# Description

Two small API-consistency leftovers found in the `beta-release` audit:

- `Label` only removed `className` from its react-aria props, leaving `style` in the public interface. It now omits both, matching the convention used by `Description` and `TextValue`. Theme the label via `variant`/`size` instead.
- `Panel`'s `space` Storybook control still offered a `'none'` option. The universal zero-spacing token was renamed `none` → `collapsed`, so selecting `'none'` resolved to nothing. The control now offers `'collapsed'` (the other five options were already valid).

No rendered change in either case — the `style` prop was never meant to be public, and the Panel fix only corrects a Storybook control option.

Closes DST-1555

## Test Instructions

1. `pnpm typecheck:only` — passes (verified locally).
2. `<Label style={{}}>` no longer typechecks (intended); `variant`/`size` still work.
3. Storybook → Components/Panel: the `space` control now lists `collapsed` instead of `none`, and selecting it collapses spacing.

## Breaking Changes

No — removing the never-functional `style` prop from `Label` is a type-only narrowing; ships as a `patch`. The Panel change is Storybook-only.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, PR targets `beta-release` and has no rendered change
- [x] Changeset added (\`pnpm changeset\`)