### PR TITLE
fix(DST-1557): Title level accepts string form to match Headline

### DIFF
--- a/.changeset/title-level-accepts-string.md
+++ b/.changeset/title-level-accepts-string.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+`Title` `level` now accepts the string form (`level="2"`) in addition to a
+number, matching `Headline`. The two heading primitives now share one `level`
+type. Non-breaking: existing numeric `level={2}` usage is unaffected.

--- a/packages/components/src/Title/Title.test.tsx
+++ b/packages/components/src/Title/Title.test.tsx
@@ -22,6 +22,16 @@ test('respects an explicit "level" prop', () => {
   expect(screen.getByTestId('title').tagName).toBe('H3');
 });
 
+test('accepts the string form of "level"', () => {
+  render(
+    <Basic.Component level="3" data-testid="title">
+      Hi
+    </Basic.Component>
+  );
+
+  expect(screen.getByTestId('title').tagName).toBe('H3');
+});
+
 test('receives "level" from a HeadingContext slot', () => {
   render(
     <Provider values={[[HeadingContext, { slots: { title: { level: 4 } } }]]}>

--- a/packages/components/src/Title/Title.tsx
+++ b/packages/components/src/Title/Title.tsx
@@ -24,10 +24,11 @@ declare module 'react-aria-components' {
 
 export interface TitleProps extends AriaLabelingProps, SlotProps {
   /**
-   * The heading level (h1–h6). Can also be supplied via slot context.
+   * The heading level (h1–h6), as a number or its string form. Can also be
+   * supplied via slot context.
    * @default 2
    */
-  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  level?: '1' | '2' | '3' | '4' | '5' | '6' | 1 | 2 | 3 | 4 | 5 | 6;
   /**
    * The element id.
    */
@@ -64,7 +65,7 @@ const _Title = ({ ref: refProp, ...inputProps }: TitleProps) => {
     // the same slot config we already merged via `useContextProps`, which
     // would otherwise duplicate the slot's `className` on the rendered DOM.
     <Heading
-      level={level}
+      level={Number(level)}
       slot={noSlot}
       {...props}
       // Safe: this branch only runs when `as` is unset, so the element


### PR DESCRIPTION
# Description

`Title.level` accepted a number only, while `Headline.level` accepted a string or a number — so `<Title level="2">` was a type error but `<Headline level="2">` was fine. This widens `Title.level` to `'1'|…|'6' | 1|…|6` so the two heading primitives share one `level` type.

`<Heading>` is rendered with `Number(level)` to coerce the string form, mirroring `Headline`. The default stays `2` (the Headline-h1 / Title-h2 default is intentional and unchanged). Non-breaking: existing numeric `level={2}` usage is unaffected.

Closes DST-1557

## Test Instructions

1. `pnpm test:unit --run packages/components/src/Title/Title.test.tsx` — 8 passing, including the new `accepts the string form of "level"` (asserts `level="3"` renders an `<h3>`).
2. `pnpm typecheck:only` — passes; `<Title level="2">` now typechecks.

## Breaking Changes

No — this only widens an accepted type. Ships as a `patch`.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, PR targets `beta-release` and has no rendered change
- [x] Changeset added (\`pnpm changeset\`)