### PR TITLE
fix(DST-1559): remove dead/mis-named props from TextField, FileTrigger, Loader

### DIFF
--- a/.changeset/dst-1559-fix-dead-mis-named-props.md
+++ b/.changeset/dst-1559-fix-dead-mis-named-props.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1559): remove dead and mis-named props from `TextField`, `FileTrigger`, and `Loader`.
+
+- `TextField`: drop the `min`/`max` props. They were never forwarded to the underlying `<input>` (react-aria filters them out of both the input and wrapper props), so they had no effect. Numeric constraints belong on `NumberField`.
+- `FileTrigger`: remove the mis-named singular `acceptedFileType` prop. Its key did not match react-aria's `acceptedFileTypes`, so file-type filtering silently never applied. Use the inherited `acceptedFileTypes` instead.
+- `Loader`: fix the `loaderType` JSDoc, which documented a non-existent `cycle` value. The accepted values are `xloader` and `circle` (default `circle`).

--- a/.changeset/dst-1559-fix-dead-mis-named-props.md
+++ b/.changeset/dst-1559-fix-dead-mis-named-props.md
@@ -1,5 +1,5 @@
 ---
-'@marigold/components': patch
+'@marigold/components': major
 ---
 
 fix(DST-1559): remove dead and mis-named props from `TextField`, `FileTrigger`, and `Loader`.

--- a/packages/components/src/FileField/FileTrigger.tsx
+++ b/packages/components/src/FileField/FileTrigger.tsx
@@ -10,7 +10,6 @@ export interface FileTriggerProps extends Omit<
   RemovedProps
 > {
   allowsMultiple?: RAC.FileTriggerProps['allowsMultiple'];
-  acceptedFileType?: RAC.FileTriggerProps['acceptedFileTypes'];
   acceptDirectory?: RAC.FileTriggerProps['acceptDirectory'];
   onSelect?: RAC.FileTriggerProps['onSelect'];
   /**

--- a/packages/components/src/Loader/Loader.tsx
+++ b/packages/components/src/Loader/Loader.tsx
@@ -17,8 +17,8 @@ export interface LoaderProps extends BaseLoaderProps {
    */
   mode?: 'fullscreen' | 'section';
   /**
-   * Selects the visual style of the loading indicator shown when loading is true. Accepts `xloader` or `cycle`.
-   * @default cycle
+   * Selects the visual style of the loading indicator shown when loading is true. Accepts `xloader` or `circle`.
+   * @default circle
    */
   loaderType?: LoaderVisualType;
 }

--- a/packages/components/src/TextField/TextField.tsx
+++ b/packages/components/src/TextField/TextField.tsx
@@ -60,18 +60,6 @@ export interface TextFieldProps
   readOnly?: RAC.TextFieldProps['isReadOnly'];
 
   /**
-   * The minimum value for the input field.
-   * @default none
-   */
-  min?: HTMLInputElement['min'];
-
-  /**
-   * The maximum value for the input field.
-   * @default none
-   */
-  max?: HTMLInputElement['max'];
-
-  /**
    * The value of the input field.
    * @default none
    */


### PR DESCRIPTION
# Description

Cleans up three component-API defects found while auditing `beta-release` against `main`. The fixes have **no runtime behavior change** — the affected props never did anything — though two are type-level breaking changes (see below).

- **TextField** — removed `min`/`max`. They were never forwarded to the underlying `<input>` (react-aria filters them out of both the input and wrapper props), so they had no effect. Numeric bounds belong on `NumberField` (`minValue`/`maxValue`/`step`).
- **FileTrigger** — removed the mis-named singular `acceptedFileType`. Its key did not match react-aria's `acceptedFileTypes`, so file-type filtering silently never applied. The inherited (and working) `acceptedFileTypes` remains; `FileField` already uses it correctly.
- **Loader** — fixed the `loaderType` JSDoc, which documented a non-existent `cycle` value. The accepted values are `xloader` and `circle` (default `circle`), as the existing tests already assert.

All three are pre-existing (identical on `main`, not beta regressions). Versioned as a `patch`, matching the sibling cleanups DST-1553 / DST-1555 / DST-1557 — the major bump happens at the beta→main promotion, not per-changeset.

Closes DST-1559

## Test Instructions

1. `pnpm typecheck:only` — passes (no consumer in the repo referenced the removed props).
2. `pnpm test:unit` for FileField and Loader — file-type filtering (`FileField`/`fileUtils`) and `loaderType` (`xloader`/`circle`) remain green.

## Breaking Changes

**Type-level only — no runtime impact.** Removing the `min`/`max` props from `TextField` and the `acceptedFileType` prop from `FileTrigger` is a breaking change to the TypeScript surface: code that passes those props will no longer compile. Nothing changes at runtime, because the props were inert (filtered out before reaching the DOM / mis-named so react-aria never read them). This ships with the next major via `beta-release`, which is why it targets `beta-release` rather than a stable `main` patch.

Migration:
- `TextField` `min`/`max` → use `NumberField` with `minValue`/`maxValue`/`step` for numeric bounds.
- `FileTrigger` `acceptedFileType` → use the (already-working) `acceptedFileTypes`.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no visual changes
- [x] Changeset added (`pnpm changeset`)