### PR TITLE
fix(DST-1560): use defined ui-scrollbar utility on Drawer and Sidebar

### DIFF
--- a/.changeset/dst-1560-ui-scrollbar.md
+++ b/.changeset/dst-1560-ui-scrollbar.md
@@ -1,0 +1,7 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1560): use the defined `ui-scrollbar` utility on Drawer and Sidebar
+
+`Drawer` and `Sidebar` referenced `util-scrollbar`, which is not defined in the theme (only `ui-scrollbar` exists in `ui.css`), so they rendered without the themed scrollbar while Dialog, Tray, and ContextualHelp got it. Corrected both to `ui-scrollbar`.

--- a/themes/theme-rui/src/components/Drawer.styles.ts
+++ b/themes/theme-rui/src/components/Drawer.styles.ts
@@ -11,7 +11,7 @@ export const Drawer: ThemeComponent<'Drawer'> = {
   container: cva({
     base: [
       'w-full relative grid-rows-[auto_1fr_auto]',
-      'rounded-xl ui-surface util-scrollbar',
+      'rounded-xl ui-surface ui-scrollbar',
       'shadow-[var(--shadow-elevation-overlay),0_0_3px_1px_oklch(0_0_0/0.06)]',
       '[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)]',
       'h-full',

--- a/themes/theme-rui/src/components/Sidebar.styles.ts
+++ b/themes/theme-rui/src/components/Sidebar.styles.ts
@@ -14,7 +14,7 @@ export const Sidebar: ThemeComponent<'Sidebar'> = {
   root: cva({
     base: [
       'overflow-hidden',
-      'bg-background border-border shadow-elevation-border util-scrollbar',
+      'bg-background border-border shadow-elevation-border ui-scrollbar',
       'sm:data-[state=expanded]:w-64',
       'sm:data-[state=collapsed]:w-0',
       'sm:transition-[width] sm:duration-200 sm:ease-in-out',


### PR DESCRIPTION
# Description

`Drawer` and `Sidebar` referenced `util-scrollbar` in their theme styles, but that utility is **not defined** in `theme-rui` (only `ui-scrollbar` exists, in `ui.css`). As a result both rendered without the themed scrollbar, while sibling overlay/panel surfaces (Dialog, Tray, ContextualHelp) got it. This corrects both to `ui-scrollbar`.

First PR of the DST-1560 visual-cleanup series (see the PR plan in the ticket). Targets `beta-release`.

Closes DST-1560

## Test Instructions

1. `pnpm build:themes` (or `pnpm sb`), then open the Drawer and Sidebar stories.
2. Confirm the themed scrollbar now appears on overflowing Drawer/Sidebar content, matching Dialog/Tray/ContextualHelp.

## Breaking Changes

No — corrects a non-functional (undefined) class to the intended themed utility.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — Chromatic will diff the scrollbar styling
- [x] Changeset added (`pnpm changeset`)