### PR TITLE
fix(DST-1560): restore Toast close-button hover state

### DIFF
--- a/.changeset/dst-1560-toast-close-hover.md
+++ b/.changeset/dst-1560-toast-close-hover.md
@@ -1,0 +1,7 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1560): restore the `Toast` close-button hover state
+
+The Toast close button kept its `transition-[color,box-shadow]` but lost its hover declaration, so it animated nothing on hover. Added `hover:text-foreground` so the icon darkens on hover, consistent with the system-wide convention that color (not background) animates on interactive controls.

--- a/themes/theme-rui/src/components/Toast.styles.ts
+++ b/themes/theme-rui/src/components/Toast.styles.ts
@@ -26,7 +26,7 @@ export const Toast: ThemeComponent<'Toast'> = {
       'ml-2',
       'flex items-center justify-center',
       'size-5 rounded transition-[color,box-shadow] outline-none',
-      'focus-visible:ui-state-focus outline-none text-secondary',
+      'focus-visible:ui-state-focus outline-none text-secondary hover:text-foreground',
     ],
   }),
   icon: cva({


### PR DESCRIPTION
# Description

The `Toast` close button kept its `transition-[color,box-shadow]` but lost its hover declaration on beta, so it animated nothing on hover — no visible affordance. This adds `hover:text-foreground` so the icon darkens on hover, animated by the existing transition.

Consistent with the system-wide convention (encoded in `ui-button-base`) that **color** animates on interactive controls while hover **background** is instant.

Second PR of the DST-1560 visual-cleanup series. Targets `beta-release`.

> Note: the ActionBar `clearButton`/`actionButton` transition item from the original audit was dropped after review — beta's `transition-[color]` correctly aligns clearButton with the instant-hover-background convention used by every `ui-button-base` button, so it was not a regression.

Closes DST-1560

## Test Instructions

1. `pnpm build:themes` (or `pnpm sb`), open the Toast stories and trigger a toast.
2. Hover the close (✕) button and confirm the icon darkens with a smooth color transition (previously it had no hover change).

## Breaking Changes

No — restores a hover affordance; no API change.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — Chromatic will diff the hover styling
- [x] Changeset added (`pnpm changeset`)