### PR TITLE
fix(DST-1560): align IconButton and Pagination to control sizing token

### DIFF
--- a/.changeset/dst-1560-control-sizing.md
+++ b/.changeset/dst-1560-control-sizing.md
@@ -1,0 +1,7 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1560): align IconButton and Pagination to the control sizing token
+
+IconButton and Pagination hardcoded `h-9`/`size-9` instead of the `h-control`/`size-control` token that every other `ui-button-base` button uses. The values are identical today (`--spacing-control` = `2.25rem` = `h-9`), so there is no rendered change, but the literals would silently drift if the token were retuned. Also dropped IconButton's redundant `disabled:text-disabled disabled:cursor-not-allowed` classes, which `ui-button-base` already applies via `disabled:ui-state-disabled`.

--- a/themes/theme-rui/src/components/IconButton.styles.ts
+++ b/themes/theme-rui/src/components/IconButton.styles.ts
@@ -4,7 +4,7 @@ export const IconButton: ThemeComponent<'IconButton'> = cva({
   variants: {
     variant: {
       navigation:
-        'ui-button-base text-sm hover:ui-state-hover-ghost h-9 py-2 px-2.5 disabled:text-disabled disabled:cursor-not-allowed',
+        'ui-button-base text-sm hover:ui-state-hover-ghost h-control py-2 px-2.5',
     },
   },
 });

--- a/themes/theme-rui/src/components/Pagination.styles.ts
+++ b/themes/theme-rui/src/components/Pagination.styles.ts
@@ -6,7 +6,7 @@ export const Pagination: ThemeComponent<'Pagination'> = {
     base: [
       'ui-button-base',
       'text-sm hover:ui-state-hover-ghost',
-      'h-9 py-2 gap-1 px-2.5',
+      'h-control py-2 gap-1 px-2.5',
       /**
        * Removes the spacing from the button when when there are hidden
        * elements (e.g. the hidden elements for accessibility).
@@ -17,7 +17,7 @@ export const Pagination: ThemeComponent<'Pagination'> = {
   pageButton: cva({
     base: [
       'ui-button-base',
-      'text-sm bg-transparent size-9',
+      'text-sm bg-transparent size-control',
       'data-[selected=true]:ui-surface data-[selected=true]:shadow-elevation-border',
     ],
   }),


### PR DESCRIPTION
# Description

`IconButton` and `Pagination` hardcoded `h-9` / `size-9` for their control height instead of the `h-control` / `size-control` token that every other `ui-button-base` sibling (Button, Menu, ToggleButton, ActionBar) uses. The values are identical today — `--spacing-control` = `2.25rem`, and `h-9` = `9 × 0.25rem` = `2.25rem` — so there is **no rendered change**; this just stops the literals from silently drifting if the token is ever retuned.

Also removed IconButton's `disabled:text-disabled disabled:cursor-not-allowed`, which are redundant: `ui-button-base` → `ui-interactive` → `disabled:ui-state-disabled`, and `ui-state-disabled` already applies exactly `text-disabled cursor-not-allowed`. This aligns IconButton's disabled handling with Button/Menu/ToggleButton.

Third PR of the DST-1560 visual-cleanup series. Targets `beta-release`.

Closes DST-1560

## Test Instructions

1. `pnpm build:themes` (or `pnpm sb`), open the IconButton and Pagination stories.
2. Confirm control heights are unchanged (still 36px) and disabled IconButton still shows the disabled text color + not-allowed cursor.

## Breaking Changes

No — value-preserving token swap; removed classes were duplicates of the shared disabled state.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — no visual change expected; Chromatic confirms
- [x] Changeset added (`pnpm changeset`)