### PR TITLE
refa(DST-1549): rename Tabs.TabPanel → Tabs.Panel for compound-member consistency

### DIFF
--- a/.changeset/dst-1549-tabs-panel-rename.md
+++ b/.changeset/dst-1549-tabs-panel-rename.md
@@ -1,0 +1,15 @@
+---
+'@marigold/components': major
+'@marigold/docs': major
+---
+
+refa([DST-1549]): **Breaking change**: Rename compound member `Tabs.TabPanel` → `Tabs.Panel`
+
+`Tabs` now exposes `.List`, `.Item`, and `.Panel`, so every compound member follows
+one predictable naming rule. `<Tabs.TabPanel>` is removed (hard rename, no deprecated alias).
+
+**Migration:**
+
+| Before                     | After                  |
+| -------------------------- | ---------------------- |
+| `<Tabs.TabPanel id="…">`   | `<Tabs.Panel id="…">`  |

--- a/docs/app/(examples)/examples/inventory/Settings.tsx
+++ b/docs/app/(examples)/examples/inventory/Settings.tsx
@@ -38,7 +38,7 @@ export const Settings = () => (
           <Bell className="size-4" /> Notifications
         </Tabs.Item>
       </Tabs.List>
-      <Tabs.TabPanel id="profile">
+      <Tabs.Panel id="profile">
         <Panel size="form">
           <Panel.Header>
             <Title>Profile</Title>
@@ -73,8 +73,8 @@ export const Settings = () => (
             </Columns>
           </Panel.Content>
         </Panel>
-      </Tabs.TabPanel>
-      <Tabs.TabPanel id="security">
+      </Tabs.Panel>
+      <Tabs.Panel id="security">
         <Panel size="form">
           <Panel.Header>
             <Title>Security</Title>
@@ -95,8 +95,8 @@ export const Settings = () => (
             </Stack>
           </Panel.Content>
         </Panel>
-      </Tabs.TabPanel>
-      <Tabs.TabPanel id="notifications">
+      </Tabs.Panel>
+      <Tabs.Panel id="notifications">
         <Panel size="form">
           <Panel.Header>
             <Title>Notifications</Title>
@@ -127,7 +127,7 @@ export const Settings = () => (
             </Stack>
           </Panel.Content>
         </Panel>
-      </Tabs.TabPanel>
+      </Tabs.Panel>
     </Tabs>
   </Stack>
 );

--- a/docs/app/(examples)/examples/settings-form/page.tsx
+++ b/docs/app/(examples)/examples/settings-form/page.tsx
@@ -21,15 +21,15 @@ const SettingsFormPage = () => (
         <Tabs.Item id="registration">Registration</Tabs.Item>
         <Tabs.Item id="notifications">Notifications</Tabs.Item>
       </Tabs.List>
-      <Tabs.TabPanel id="general">
+      <Tabs.Panel id="general">
         <GeneralSettings />
-      </Tabs.TabPanel>
-      <Tabs.TabPanel id="registration">
+      </Tabs.Panel>
+      <Tabs.Panel id="registration">
         <RegistrationCapacity />
-      </Tabs.TabPanel>
-      <Tabs.TabPanel id="notifications">
+      </Tabs.Panel>
+      <Tabs.Panel id="notifications">
         <Notifications />
-      </Tabs.TabPanel>
+      </Tabs.Panel>
     </Tabs>
     <DangerZone />
   </Page>

--- a/docs/content/components/__internal__/component-guidelines.mdx
+++ b/docs/content/components/__internal__/component-guidelines.mdx
@@ -146,9 +146,9 @@ export const Basic: Story = {
     <Tabs.Item id="2">Settings</Tabs.Item>
     <Tabs.Item id="3">More</Tabs.Item>
   </Tabs.List>
-  <Tabs.TabPanel id="1">Start</Tabs.TabPanel>
-  <Tabs.TabPanel id="2">Settings</Tabs.TabPanel>
-  <Tabs.TabPanel id="3">More</Tabs.TabPanel>
+  <Tabs.Panel id="1">Start</Tabs.Panel>
+  <Tabs.Panel id="2">Settings</Tabs.Panel>
+  <Tabs.Panel id="3">More</Tabs.Panel>
 </Tabs>
 ```
 

--- a/docs/content/components/hooks-and-utils/extendTheme/tabs-slots.demo.tsx
+++ b/docs/content/components/hooks-and-utils/extendTheme/tabs-slots.demo.tsx
@@ -20,25 +20,25 @@ export default () => {
           <Tabs.Item id="notifications">notifications</Tabs.Item>
           <Tabs.Item id="private">private</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="profile">
+        <Tabs.Panel id="profile">
           This panel displays your profile settings. You can upload a profile
           picture, write a brief bio to introduce yourself, and update other
           personal details. Show the world who you are and make a memorable
           impression on other platform users.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="notifications">
+        </Tabs.Panel>
+        <Tabs.Panel id="notifications">
           Here, you'll find settings related to notifications. Choose how you
           want to be notified about new messages, friend requests, and other
           important updates. Stay connected and up-to-date with the latest
           activities happening on the platform.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="private">
+        </Tabs.Panel>
+        <Tabs.Panel id="private">
           The Privacy panel provides options to safeguard your personal
           information and control your privacy. Decide who can view your
           profile, set visibility preferences for your posts and photos, and
           manage your data. Enjoy peace of mind knowing that you have full
           control over your privacy on the platform.
-        </Tabs.TabPanel>
+        </Tabs.Panel>
       </Tabs>{' '}
     </MarigoldProvider>
   );

--- a/docs/content/components/navigation/tabs/index.mdx
+++ b/docs/content/components/navigation/tabs/index.mdx
@@ -103,7 +103,7 @@ current page.
 
 <AutoTypeTable path="Tabs/Tab" name="TabProps" />
 
-### Tabs.TabPanel
+### Tabs.Panel
 
 <AutoTypeTable path="Tabs/TabPanel" name="TabPanelProps" />
 

--- a/docs/content/components/navigation/tabs/tabs-appearance.demo.tsx
+++ b/docs/content/components/navigation/tabs/tabs-appearance.demo.tsx
@@ -7,16 +7,16 @@ export default (props: TabsProps) => (
       <Tabs.Item id="keyboard">Keyboard Settings</Tabs.Item>
       <Tabs.Item id="gamepad">Gamepad Settings</Tabs.Item>
     </Tabs.List>
-    <Tabs.TabPanel id="mouse">
+    <Tabs.Panel id="mouse">
       Adjust the sensitivity, acceleration, and button assignments for your
       mouse.
-    </Tabs.TabPanel>
-    <Tabs.TabPanel id="keyboard">
+    </Tabs.Panel>
+    <Tabs.Panel id="keyboard">
       Customize the key bindings and input behavior for your keyboard.
-    </Tabs.TabPanel>
-    <Tabs.TabPanel id="gamepad">
+    </Tabs.Panel>
+    <Tabs.Panel id="gamepad">
       Configure the controls, dead zones, and vibration settings for your
       gamepad.
-    </Tabs.TabPanel>
+    </Tabs.Panel>
   </Tabs>
 );

--- a/docs/content/components/navigation/tabs/tabs-basic.demo.tsx
+++ b/docs/content/components/navigation/tabs/tabs-basic.demo.tsx
@@ -9,9 +9,9 @@ export default (props: TabsProps) => (
         <Tabs.Item id="past">Past</Tabs.Item>
         <Tabs.Item id="cancelled">Cancelled</Tabs.Item>
       </Tabs.List>
-      <Tabs.TabPanel id="upcoming">Upcoming events.</Tabs.TabPanel>
-      <Tabs.TabPanel id="past">Past events.</Tabs.TabPanel>
-      <Tabs.TabPanel id="cancelled">Cancelled events</Tabs.TabPanel>
+      <Tabs.Panel id="upcoming">Upcoming events.</Tabs.Panel>
+      <Tabs.Panel id="past">Past events.</Tabs.Panel>
+      <Tabs.Panel id="cancelled">Cancelled events</Tabs.Panel>
     </Tabs>
   </>
 );

--- a/docs/content/patterns/layout/admin-master-mark/admin-master-mark-placement.demo.tsx
+++ b/docs/content/patterns/layout/admin-master-mark/admin-master-mark-placement.demo.tsx
@@ -19,7 +19,7 @@ export default () => (
         Sales Notes <Badge variant="admin">Admin</Badge>
       </Tabs.Item>
     </Tabs.List>
-    <Tabs.TabPanel id="overview">
+    <Tabs.Panel id="overview">
       <Stack space={4}>
         <TextField
           label="Organizer Name"
@@ -69,8 +69,8 @@ export default () => (
           </Card.Body>
         </Card>
       </Stack>
-    </Tabs.TabPanel>
-    <Tabs.TabPanel id="events">
+    </Tabs.Panel>
+    <Tabs.Panel id="events">
       <Table aria-label="Event List">
         <Table.Header>
           <Table.Column rowHeader>Name</Table.Column>
@@ -111,8 +111,8 @@ export default () => (
           </Table.Row>
         </Table.Body>
       </Table>
-    </Tabs.TabPanel>
-    <Tabs.TabPanel id="sales">
+    </Tabs.Panel>
+    <Tabs.Panel id="sales">
       <List>
         <List.Item>
           Reached out at Event Business Forum 2023. Very interested in bundling
@@ -131,6 +131,6 @@ export default () => (
           side before next steps.
         </List.Item>
       </List>
-    </Tabs.TabPanel>
+    </Tabs.Panel>
   </Tabs>
 );

--- a/docs/content/patterns/layout/app-frame/index.mdx
+++ b/docs/content/patterns/layout/app-frame/index.mdx
@@ -188,7 +188,7 @@ When a page splits into tabbed views, render [`<Tabs>`](/components/navigation/t
   </Page.Header>
   <Tabs>
     <Tabs.List>...</Tabs.List>
-    <Tabs.TabPanel id="general">...</Tabs.TabPanel>
+    <Tabs.Panel id="general">...</Tabs.Panel>
   </Tabs>
 </Page>
 ```

--- a/packages/components/src/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/Tabs/Tabs.stories.tsx
@@ -37,17 +37,17 @@ export const Basic = meta.story({
           <Tabs.Item id="keyboard">Keyboard Settings</Tabs.Item>
           <Tabs.Item id="gamepad">Gamepad Settings</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="mouse">
+        <Tabs.Panel id="mouse">
           Adjust the sensitivity, acceleration, and button assignments for your
           mouse.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="keyboard">
+        </Tabs.Panel>
+        <Tabs.Panel id="keyboard">
           Customize the key bindings and input behavior for your keyboard.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="gamepad">
+        </Tabs.Panel>
+        <Tabs.Panel id="gamepad">
           Configure the controls, dead zones, and vibration settings for your
           gamepad.
-        </Tabs.TabPanel>
+        </Tabs.Panel>
       </Tabs>
     );
   },
@@ -85,25 +85,25 @@ export const WithDisabledKeys = meta.story({
           <Tabs.Item id="notifications">notifications</Tabs.Item>
           <Tabs.Item id="private">private</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="profile">
+        <Tabs.Panel id="profile">
           This panel displays your profile settings. You can upload a profile
           picture, write a brief bio to introduce yourself, and update other
           personal details. Show the world who you are and make a memorable
           impression on other platform users.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="notifications">
+        </Tabs.Panel>
+        <Tabs.Panel id="notifications">
           Here, you'll find settings related to notifications. Choose how you
           want to be notified about new messages, friend requests, and other
           important updates. Stay connected and up-to-date with the latest
           activities happening on the platform.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="private">
+        </Tabs.Panel>
+        <Tabs.Panel id="private">
           The Privacy panel provides options to safeguard your personal
           information and control your privacy. Decide who can view your
           profile, set visibility preferences for your posts and photos, and
           manage your data. Enjoy peace of mind knowing that you have full
           control over your privacy on the platform.
-        </Tabs.TabPanel>
+        </Tabs.Panel>
       </Tabs>
     );
   },
@@ -118,24 +118,24 @@ export const WithSelectedTab = meta.story({
           <Tabs.Item id="settings">Settings</Tabs.Item>
           <Tabs.Item id="messages">Messages</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="home">
+        <Tabs.Panel id="home">
           Welcome to the Home tab! This is where you can find your personalized
           feed, updates from your friends, and recent activity on the platform.
           Stay connected and explore the latest content tailored to your
           interests.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="settings">
+        </Tabs.Panel>
+        <Tabs.Panel id="settings">
           You're currently in the Settings tab. Here, you can customize your
           account preferences, manage privacy settings, and update your
           notification preferences. Personalize your experience and make the
           platform work exactly how you want it to.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="messages">
+        </Tabs.Panel>
+        <Tabs.Panel id="messages">
           Check out your Messages tab to stay in touch with your contacts. Send
           and receive messages, engage in conversations, and share interesting
           content with your network. Connect with friends, colleagues, and
           like-minded individuals in a private and secure environment.
-        </Tabs.TabPanel>
+        </Tabs.Panel>
       </Tabs>
     );
   },
@@ -157,16 +157,16 @@ export const WithRenderProps = meta.story({
           </Tabs.Item>
           <Tabs.Item id="notifications">Notifications</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="general">
+        <Tabs.Panel id="general">
           Set your display name, email, and default language. These details are
           shown to other users.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="security">
+        </Tabs.Panel>
+        <Tabs.Panel id="security">
           Manage your password, two-factor authentication, and active sessions.
-        </Tabs.TabPanel>
-        <Tabs.TabPanel id="notifications">
+        </Tabs.Panel>
+        <Tabs.Panel id="notifications">
           Choose how you receive emails and in-app notifications.
-        </Tabs.TabPanel>
+        </Tabs.Panel>
       </Tabs>
     );
   },

--- a/packages/components/src/Tabs/Tabs.tsx
+++ b/packages/components/src/Tabs/Tabs.tsx
@@ -43,7 +43,7 @@ const _Tabs = ({ disabled, variant, size, ...rest }: TabsProps) => {
 };
 
 _Tabs.List = TabList;
-_Tabs.TabPanel = TabPanel;
+_Tabs.Panel = TabPanel;
 _Tabs.Item = Tab;
 
 export { _Tabs as Tabs };

--- a/packages/system/src/hooks/extendTheme.test.tsx
+++ b/packages/system/src/hooks/extendTheme.test.tsx
@@ -84,8 +84,8 @@ test('Accepting styles for component with multiple slots', () => {
           <Tabs.Item id="1">tab1</Tabs.Item>
           <Tabs.Item id="2">tab2</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="1">tab-1 content</Tabs.TabPanel>
-        <Tabs.TabPanel id="2">tab-2 content</Tabs.TabPanel>
+        <Tabs.Panel id="1">tab-1 content</Tabs.Panel>
+        <Tabs.Panel id="2">tab-2 content</Tabs.Panel>
       </Tabs>
     </ThemeProvider>
   );
@@ -126,8 +126,8 @@ test('Should support new variant and existing size', () => {
           <Tabs.Item id="1">tab1</Tabs.Item>
           <Tabs.Item id="2">tab2</Tabs.Item>
         </Tabs.List>
-        <Tabs.TabPanel id="1">tab-1 content</Tabs.TabPanel>
-        <Tabs.TabPanel id="2">tab-2 content</Tabs.TabPanel>
+        <Tabs.Panel id="1">tab-1 content</Tabs.Panel>
+        <Tabs.Panel id="2">tab-2 content</Tabs.Panel>
       </Tabs>
     </ThemeProvider>
   );


### PR DESCRIPTION
# Description

Renames the `Tabs` compound member `Tabs.TabPanel` → `Tabs.Panel` so all compound members follow one predictable naming rule (`.List`, `.Item`, `.Panel`). Previously `Tabs.TabPanel` was the odd one out next to `.List` (from `TabList`) and `.Item` (from `Tab`).

This is a **hard rename with no deprecated alias**, folded into the existing `18.0.0` beta major on `beta-release` — so the breaking change costs consumers nothing extra and avoids a future dedicated major just for a rename.

The internal `TabPanel` component, its `TabPanelProps` type, and the file `Tabs/TabPanel.tsx` are intentionally unchanged — only the public compound member name changes (consistent with `.List`/`.Item` already diverging from their internal names).

Closes DST-1549

## Test Instructions

1. In any `Tabs` usage, `<Tabs.Panel id="…">` renders the panel; `<Tabs.TabPanel>` no longer exists.
2. `pnpm typecheck:only` — passes.
3. `pnpm test:unit --run packages/system/src/hooks/extendTheme.test.tsx` — 3/3 pass.
4. `pnpm test:sb --run packages/components/src/Tabs/Tabs.stories.tsx` — 2/2 pass.

## Breaking Changes

**Yes.** `Tabs.TabPanel` is removed.

Migration:

| Before                   | After                 |
| ------------------------ | --------------------- |
| `<Tabs.TabPanel id="…">` | `<Tabs.Panel id="…">` |

A `major` changeset for `@marigold/components` and `@marigold/docs` with this migration note is included (`.changeset/dst-1549-tabs-panel-rename.md`).

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

<sub>Note: no behavioral/styling change — pure rename. Stories & docs updated; generated `docs/public/**/*.md` are gitignored build artifacts and regenerate via the docs pipeline.</sub>
