### PR TITLE
fix(DST-1564): keep vitest out of Storybook story import graphs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,27 @@ export default defineConfig([
     },
   },
   {
+    // Stories render in the Storybook preview, which already provides `expect`,
+    // `fn`, `userEvent`, etc. via `storybook/test`. A bare `vitest` import drags
+    // a second test runtime into the preview and breaks it with a cryptic
+    // `customEqualityTesters` error, so keep `vitest` out of story files.
+    files: ['**/*.stories.tsx'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'vitest',
+              message:
+                'Do not import from "vitest" in stories — use "storybook/test" instead (a vitest import breaks the Storybook preview with a "customEqualityTesters" error).',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     ignores: [
       '**/.next',
       '**/out',

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -4,8 +4,8 @@ import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Form } from '../Form/Form';
-import { makeFile } from './../test.utils';
 import { FileField } from './FileField';
+import { makeFile } from './makeFile';
 
 const meta = preview.meta({
   title: 'Components/FileField',

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -2,8 +2,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nProvider } from 'react-aria-components/I18nProvider';
-import { makeFile } from './../test.utils';
 import { Basic, MultipleFileUpload } from './FileField.stories';
+import { makeFile } from './makeFile';
 
 test('renders default labels (en) for dropzone and button', () => {
   render(<Basic.Component label="Label" />);

--- a/packages/components/src/FileField/fileUtils.test.ts
+++ b/packages/components/src/FileField/fileUtils.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { makeFile } from '../test.utils';
 import {
   filterAcceptedFiles,
   isFileDropItem,
   normalizeAndLimitFiles,
 } from './fileUtils';
+import { makeFile } from './makeFile';
 
 describe('filterAcceptedFiles', () => {
   it('returns all files when accept is undefined', () => {

--- a/packages/components/src/FileField/makeFile.ts
+++ b/packages/components/src/FileField/makeFile.ts
@@ -1,0 +1,9 @@
+/**
+ * Creates a `File` for use in tests and stories.
+ *
+ * Lives in its own module (not `test.utils.tsx`) so story files can import it
+ * without pulling in `vitest` — a bare `vitest` import in a story's graph
+ * breaks the Storybook dev preview (`expect` realm / `customEqualityTesters`).
+ */
+export const makeFile = (name: string, type: string, size = 1024) =>
+  new File([new Uint8Array(size)], name, { type });

--- a/packages/components/src/test.utils.tsx
+++ b/packages/components/src/test.utils.tsx
@@ -46,9 +46,6 @@ export const renderWithOverlay = (ui: ReactNode): RenderResult => {
   return render(ui as ReactElement);
 };
 
-export const makeFile = (name: string, type: string, size = 1024) =>
-  new File([new Uint8Array(size)], name, { type });
-
 /**
  * Mock `matchMedia` for jsdom which does not implement it.
  * Returns a mock that supports the `addEventListener`/`removeEventListener`


### PR DESCRIPTION
# Description

FileField stories load with `Cannot read properties of undefined (reading 'customEqualityTesters')` in `storybook dev` (e.g. at `toBeInTheDocument`), so the stories don't render.

**Root cause:** `FileField.stories.tsx` imported `makeFile` from `test.utils.tsx`, which imports `vitest`. A bare `vitest` import in a story's import graph pulls a second test runtime into the Storybook preview — jest-dom matchers get extended onto one `expect` but run with the other's context, whose `customEqualityTesters` is undefined. The production build collapses everything into one bundle, which is why it only broke locally in `storybook dev` (the deployed Storybook was fine).

**Fix:**
- Move `makeFile` into its own vitest-free module `FileField/makeFile.ts`; stories and tests import it from there.
- `test.utils.tsx` keeps using `vitest` (only `.test.tsx` files import it, and those run in the vitest runner, never the Storybook preview).
- Add a `no-restricted-imports` ESLint rule banning `vitest` imports in `**/*.stories.tsx`, so any future regression surfaces as a clear lint error instead of the cryptic runtime crash. (No existing story violates it.)

## Test Instructions

1. `pnpm sb` → open Components/FileField stories → they render without the `customEqualityTesters` error.
2. `pnpm test:unit packages/components/src/FileField` → FileField/fileUtils tests pass (they use `makeFile` from its new location).
3. `pnpm lint` → green; adding `import { vi } from 'vitest'` to any `*.stories.tsx` now errors.

## Breaking Changes

No — test/story tooling only. `makeFile` and `test.utils` are not part of the published package, so no changeset is needed.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no UI change
- [ ] Changeset added (`pnpm changeset`) — N/A, test/story/lint-config only