### PR TITLE
fix(DST-1560): align Tray content padding and Card radius to surface tokens

### DIFF
--- a/.changeset/dst-1560-tray-content-card-radius.md
+++ b/.changeset/dst-1560-tray-content-card-radius.md
@@ -1,0 +1,9 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1560): align Tray content padding and Card radius to the shared surface tokens
+
+`Tray` content used `p-2` while its own header and actions (and Dialog/Drawer content) follow the `ui-panel-content` rhythm (`px-6 py-4`), leaving the content visually out of step within the same component. Switched it to `ui-panel-content`.
+
+`Card` hardcoded `rounded-md` while the rest of the raised surface tier (`Panel`, `Accordion`) uses `rounded-surface`. Moved Card to `rounded-surface` in its `base` so every variant (`default`, `master`, `admin`) shares the same 8px corner, making the raised tier consistent.

--- a/packages/components/src/Tray/Tray.stories.tsx
+++ b/packages/components/src/Tray/Tray.stories.tsx
@@ -45,17 +45,15 @@ export const Basic = meta.story({
       <Tray {...args}>
         <Tray.Title>Tray Title</Tray.Title>
         <Tray.Content>
-          <Inset p={4}>
-            <Text>
-              This is a tray component that slides in from the bottom of the
-              screen. It's useful for mobile-friendly interactions and quick
-              actions.
-            </Text>
-            <Text>
-              Trays are commonly used for filters, settings, or contextual menus
-              on mobile devices.
-            </Text>
-          </Inset>
+          <Text>
+            This is a tray component that slides in from the bottom of the
+            screen. It's useful for mobile-friendly interactions and quick
+            actions.
+          </Text>
+          <Text>
+            Trays are commonly used for filters, settings, or contextual menus
+            on mobile devices.
+          </Text>
         </Tray.Content>
         <Tray.Actions>
           <Button slot="close">Close</Button>
@@ -118,13 +116,11 @@ export const DismissControlsWithCallbacks = meta.story({
           <Tray {...args} dismissable keyboardDismissable>
             <Tray.Title>Dismiss Controls</Tray.Title>
             <Tray.Content>
-              <Inset p={4}>
-                <Text>
-                  This tray demonstrates all dismiss methods with callback
-                  hooks. Try closing it via the close button, pressing Escape,
-                  or clicking the backdrop.
-                </Text>
-              </Inset>
+              <Text>
+                This tray demonstrates all dismiss methods with callback hooks.
+                Try closing it via the close button, pressing Escape, or
+                clicking the backdrop.
+              </Text>
             </Tray.Content>
             <Tray.Actions>
               <Button slot="close">Cancel</Button>

--- a/packages/components/src/Tray/Tray.stories.tsx
+++ b/packages/components/src/Tray/Tray.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
-import { Inset } from '../Inset/Inset';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { Tray } from './Tray';

--- a/themes/theme-rui/src/components/Card.styles.ts
+++ b/themes/theme-rui/src/components/Card.styles.ts
@@ -2,7 +2,7 @@ import { ThemeComponent, cva } from '@marigold/system';
 
 export const Card: ThemeComponent<'Card'> = {
   container: cva({
-    base: 'rounded-md shadow-elevation-raised [--card-text:currentColor]',
+    base: 'rounded-surface shadow-elevation-raised [--card-text:currentColor]',
     variants: {
       variant: {
         default: 'ui-surface',

--- a/themes/theme-rui/src/components/Tray.styles.ts
+++ b/themes/theme-rui/src/components/Tray.styles.ts
@@ -18,6 +18,6 @@ export const Tray: ThemeComponent<'Tray'> = {
   }),
   header: cva({ base: 'ui-panel-header' }),
   title: cva({ base: 'font-semibold text-base' }),
-  content: cva({ base: 'overflow-y-auto outline-none p-2' }),
+  content: cva({ base: 'ui-panel-content' }),
   actions: cva({ base: 'ui-panel-actions' }),
 };


### PR DESCRIPTION
# Description

Two `theme-rui` surface alignments from the DST-1560 visual-consistency audit (PR 7 in the plan):

- **Tray content padding** — `Tray.Content` used `p-2`, while Tray's own `header`/`actions` and Dialog/Drawer content all follow the `ui-panel-content` rhythm (`px-6 py-4`). Switched Tray content to `ui-panel-content` so it's consistent within the component and across overlays.
- **Card radius** — `Card` hardcoded `rounded-md` (6px) while the rest of the raised surface tier (`Panel`, `Accordion`) uses `rounded-surface` (8px). Moved Card to `rounded-surface` in its `base` so every variant (`default`, `master`, `admin`) shares the same corner.
- **Tray demos** — removed the now-redundant `<Inset p={4}>` wrappers that previously compensated for the tight `p-2`.

Intentionally **not** changed (closed as won't-fix in the audit): the overlay radius split (Dialog/Drawer keep `rounded-xl`) and Drawer's composed shadow ring.

Closes DST-1560 partially (PR 7 of the plan).

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. Tray content padding + Card corners (incl. master/admin variants). -->

## Test Instructions

1. Run `pnpm sb`.
2. Open `Components/Tray` → confirm the content area now uses the same `px-6 py-4` padding as the header/actions (no longer cramped), and the demos render without the extra inset.
3. Open `Components/Card` (default, master, admin variants) → confirm corners are `rounded-surface` (8px), matching Panel/Accordion.
4. `pnpm test:sb` for the Tray and Card stories.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)