### PR TITLE
fix(DST-1560): correct padding safelist token names and stale z-index docs

### DIFF
--- a/.changeset/dst-1560-padding-safelist-token-names.md
+++ b/.changeset/dst-1560-padding-safelist-token-names.md
@@ -1,0 +1,9 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1560): correct the `@source inline` padding safelist to the real spacing tokens
+
+The padding safelist in `styles.css` still used the pre-rename vocabulary `{compact, tight, regular, relaxed, spacious}`, but the spacing tokens were long ago renamed to `{tight, snug, regular, relaxed, loose}`. As a result `compact`/`spacious` force-generated dead utility classes (resolving to undefined `--spacing-*` vars), while the real `snug`/`loose` tokens were never safelisted and so were unavailable in scanner-excluded stories and in the (unscanned) docs app. The leading family-less line was also stale — it predates the `square`/`squish`/`stretch` split.
+
+Replaced the three lines with the three inset-padding families (`square`/`squish`/`stretch`) using the real size names, so utility classes like `p-squish-relaxed` resolve to a concrete value and the full inset vocabulary is available where the scanner can't see it.

--- a/claude.md
+++ b/claude.md
@@ -161,29 +161,29 @@ Z-index values are centralized and standardized across the design system to ensu
 
 **Architecture**:
 
-- Z-index **numeric values** are defined as CSS custom properties in `themes/theme-rui/src/theme.css`
+- Z-index **classes** are plain Tailwind v4 numeric utilities (`z-1`, `z-30`, `z-80`, …). Tailwind v4 generates `z-<integer>` on demand, so there are no `--z-*` custom properties or `theme.css` definitions — the scale below is a shared convention, not a token set
 - Z-index **classes** are applied directly in component implementations (`packages/components/src/`), NOT in theme style files
-- This makes z-index theme-independent while keeping numeric values customizable
+- This keeps stacking order consistent and discoverable without coupling it to the theme layer
 
-**Z-Index Scale**:
+**Z-Index Scale** (the agreed convention for which utility maps to which layer):
 
-```css
+```text
 /* Content Layer (0-10) */
---z-1: 1; /* Sticky headers (Table, Accordion, ListBox) */
---z-10: 10; /* Focus states (Calendar) */
+z-1    /* Sticky headers (Table, Accordion, ListBox) */
+z-10   /* Focus states (Calendar) */
 
 /* Floating Layer (20-49) */
---z-20: 20; /* Dropdowns (Multiselect, Select, ComboBox) */
---z-30: 30; /* Popovers, Menus, Tooltips, ActionBar */
+z-20   /* Dropdowns (Multiselect, Select, ComboBox) */
+z-30   /* Popovers, Menus, Tooltips, ActionBar */
 
 /* Overlay Layer (50-79) */
---z-50: 50; /* Modal overlays, Drawer overlays, Underlay */
+z-50   /* Modal overlays, Drawer overlays, Underlay */
 
 /* Notification Layer (80-99) */
---z-80: 80; /* Toast notifications, Drawer close button */
+z-80   /* Toast notifications, Drawer close button */
 
 /* System Layer (100+) */
---z-100: 100; /* Touch hitbox utility */
+z-100  /* Touch hitbox utility */
 ```
 
 **Component Examples**:

--- a/themes/theme-rui/src/styles.css
+++ b/themes/theme-rui/src/styles.css
@@ -6,11 +6,11 @@
 /* prettier-ignore */
 @source inline('{bg}-{stone}-{50,{100..900..100},950}');
 /* prettier-ignore */
-@source inline('{p,px,py,pt,pr,pb,pl}-{compact,tight,regular,relaxed,spacious}');
+@source inline('{p,px,py,pt,pr,pb,pl}-square-{tight,snug,regular,relaxed,loose}');
 /* prettier-ignore */
-@source inline('{p,px,py,pt,pr,pb,pl}-squish-{compact,tight,regular,relaxed,spacious}');
+@source inline('{p,px,py,pt,pr,pb,pl}-squish-{tight,snug,regular,relaxed,loose}');
 /* prettier-ignore */
-@source inline('{p,px,py,pt,pr,pb,pl}-stretch-{compact,tight,regular,relaxed,spacious}');
+@source inline('{p,px,py,pt,pr,pb,pl}-stretch-{tight,snug,regular,relaxed,loose}');
 
 /* from tailwind.config.ts */
 @source 'src/**/*.*.ts';


### PR DESCRIPTION
# Description

Two pre-existing hygiene fixes from the DST-1560 audit (PR 9 in the plan). Both bugs exist on `main`, so they're fixed here at the source and will propagate into `beta-release` on the next merge.

**1. `@source inline` padding safelist (`themes/theme-rui/src/styles.css`)** — the safelist used the pre-rename vocabulary `{compact, tight, regular, relaxed, spacious}`, but the spacing tokens were renamed to `{tight, snug, regular, relaxed, loose}`. So `compact`/`spacious` force-generated dead utility classes (resolving to undefined `--spacing-*` vars), while the real `snug`/`loose` tokens were never safelisted and unavailable in scanner-excluded stories and the (unscanned) docs app. The leading family-less line was also stale (predates the `square`/`squish`/`stretch` split). Replaced with the three inset families × real sizes.

**2. CLAUDE.md z-index section** — it claimed z-index numeric values are "defined as CSS custom properties in `theme.css`", but no `--z-*` properties exist anywhere in the repo. `z-1`/`z-30`/`z-80` are plain Tailwind v4 numeric utilities. Corrected the architecture description and reframed the scale block as a convention (still-valid rules/hierarchy untouched).

Closes DST-1560 partially (PR 9 of the plan).

## Test Instructions

1. `pnpm build:themes`.
2. Inspect `themes/theme-rui/dist/styles.css`:
   - `p-squish-relaxed` is present and resolves to a concrete value (`padding: calc(var(--spacing) * 2) calc(var(--spacing) * 4)`), not an undefined var.
   - `p-square-*` / `p-squish-*` / `p-stretch-*` classes emit across `{tight,snug,regular,relaxed,loose}`.
   - No `*-compact` / `*-spacious` padding classes remain.
3. Read the CLAUDE.md "Z-Index Management" section — it no longer references non-existent `--z-*` / `theme.css` definitions.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no rendered change (components resolve these tokens via CSS vars; CLAUDE.md is docs)
- [x] Changeset added (\`pnpm changeset\`)