### PR TITLE
fix(DST-1567): align root tsconfig declaration setting with typecheck config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@marigold/tsconfig/react",
   "compilerOptions": {
     "jsx": "preserve",
+    "declaration": false,
+    "declarationMap": false,
     "paths": {
       "@marigold/*": ["./packages/*/src", "./themes/*/src"],
       ".storybook/*": ["./.storybook/*"]


### PR DESCRIPTION
# Description

The root `tsconfig.json` (used by the editor's TypeScript language server) inherited `declaration: true` from the shared base config (`config/tsconfig/base.json`), while `tsconfig.check.json` (used by `pnpm typecheck:only`) overrides it to `false`. That divergence made the editor run TypeScript's declaration-portability check and surface spurious TS2742/TS2883 errors across many Storybook story files. Each exported `meta.story(...)` const infers a type that transitively reaches react-aria-components' internal `ClassNameOrFunction` type, which can't be named portably under declaration emit, so the editor flagged it even though the CLI typecheck was clean.

This adds `declaration: false` / `declarationMap: false` to the root `tsconfig.json` so the editor matches `pnpm typecheck:only`. The root config is not used for any build emit (package builds run per-package via Turbo), so disabling declaration there is safe.

Closes DST-1567

## Test Instructions

1. Run `pnpm typecheck:only` — exits 0 (verified).
2. Reload the editor / restart the TS server; the TS2742/2883 errors previously shown on story files are gone.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, config-only change
- [ ] Changeset added (`pnpm changeset`) — N/A, no `packages/src` or `themes` changes