### PR TITLE
chore(DST-1503): migrate Checkbox, Switch, Radio off deprecated react-aria-components exports

### DIFF
--- a/.changeset/dst-1503-rac-field-button-migration.md
+++ b/.changeset/dst-1503-rac-field-button-migration.md
@@ -2,4 +2,4 @@
 "@marigold/components": patch
 ---
 
-Migrate `Checkbox`, `Switch`, and `Radio` off the deprecated react-aria-components single-element exports (`Checkbox`/`Switch`/`Radio`) to the `*Field` + `*Button` composition introduced in `react-aria-components@1.18.0`. This removes the `ts(6385)` deprecation warnings with no change to the public API, behavior, or visual output.
+chore(DST-1503): Migrate `Checkbox`, `Switch`, and `Radio` off the deprecated react-aria-components single-element exports (`Checkbox`/`Switch`/`Radio`) to the `*Field` + `*Button` composition introduced in `react-aria-components@1.18.0`. This removes the `ts(6385)` deprecation warnings with no change to the public API, behavior, or visual output.

--- a/.changeset/dst-1503-rac-field-button-migration.md
+++ b/.changeset/dst-1503-rac-field-button-migration.md
@@ -1,0 +1,5 @@
+---
+"@marigold/components": patch
+---
+
+Migrate `Checkbox`, `Switch`, and `Radio` off the deprecated react-aria-components single-element exports (`Checkbox`/`Switch`/`Radio`) to the `*Field` + `*Button` composition introduced in `react-aria-components@1.18.0`. This removes the `ts(6385)` deprecation warnings with no change to the public API, behavior, or visual output.

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -77,6 +77,15 @@ test('supports indeterminate state', () => {
   expect(input.indeterminate).toBeTruthy();
 });
 
+test('associates the description with the checkbox via aria-describedby', () => {
+  render(<Basic.Component label="With Label" description="Some help text" />);
+
+  const input = screen.getByLabelText('With Label');
+  const description = screen.getByText('Some help text');
+
+  expect(input.getAttribute('aria-describedby')).toContain(description.id);
+});
+
 test('forwards ref', () => {
   const ref = createRef<HTMLLabelElement>();
   render(<Basic.Component label="Check it" ref={ref} />);

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -7,8 +7,9 @@ import type {
 import { forwardRef } from 'react';
 import type RAC from 'react-aria-components';
 import {
-  Checkbox,
-  CheckboxContext,
+  CheckboxButton,
+  CheckboxField,
+  CheckboxFieldContext,
   Provider,
   TextContext,
 } from 'react-aria-components';
@@ -37,7 +38,7 @@ const Field = ({
     <div className={className}>
       <Provider
         values={[
-          [CheckboxContext, { 'aria-describedby': descriptionId }],
+          [CheckboxFieldContext, { 'aria-describedby': descriptionId }],
           [TextContext, { id: descriptionId }],
         ]}
       >
@@ -90,7 +91,10 @@ export type RemovedProps =
   | 'isIndeterminate'
   | 'defaultSelected';
 
-export interface CheckboxProps extends Omit<RAC.CheckboxProps, RemovedProps> {
+export interface CheckboxProps extends Omit<
+  RAC.CheckboxFieldProps,
+  RemovedProps
+> {
   variant?: string;
   size?: string;
 
@@ -168,7 +172,7 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
     },
     ref
   ) => {
-    const props: RAC.CheckboxProps = {
+    const props: RAC.CheckboxFieldProps = {
       isIndeterminate: indeterminate,
       isDisabled: disabled,
       isReadOnly: readOnly,
@@ -189,26 +193,27 @@ const _Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
 
     return (
       <Field description={description}>
-        <Checkbox
-          ref={ref}
-          className={cn(
-            'group/checkbox flex items-center',
-            'cursor-pointer data-disabled:cursor-not-allowed',
-            classNames.container
-          )}
-          {...props}
-        >
-          {({ isSelected, isIndeterminate }) => (
-            <>
-              <Icon
-                checked={isSelected}
-                indeterminate={isIndeterminate}
-                className={classNames.checkbox}
-              />
-              {label && <div className={classNames.label}>{label}</div>}
-            </>
-          )}
-        </Checkbox>
+        <CheckboxField {...props}>
+          <CheckboxButton
+            ref={ref}
+            className={cn(
+              'group/checkbox flex items-center',
+              'cursor-pointer data-disabled:cursor-not-allowed',
+              classNames.container
+            )}
+          >
+            {({ isSelected, isIndeterminate }) => (
+              <>
+                <Icon
+                  checked={isSelected}
+                  indeterminate={isIndeterminate}
+                  className={classNames.checkbox}
+                />
+                {label && <div className={classNames.label}>{label}</div>}
+              </>
+            )}
+          </CheckboxButton>
+        </CheckboxField>
       </Field>
     );
   }

--- a/packages/components/src/Radio/Radio.test.tsx
+++ b/packages/components/src/Radio/Radio.test.tsx
@@ -7,9 +7,10 @@ test('takes full width by default', () => {
   render(<Basic.Component />);
 
   const radio = screen.getByText('Option 1');
+  // Width lives on the RadioField wrapper, the RadioButton label's parent.
   // eslint-disable-next-line testing-library/no-node-access
-  const container = radio.closest('[data-rac]') || radio.parentElement!;
-  expect(container).toHaveClass('w-full');
+  const field = radio.closest('label')?.parentElement;
+  expect(field).toHaveClass('w-full');
 });
 
 test('forwards ref', () => {

--- a/packages/components/src/Radio/Radio.test.tsx
+++ b/packages/components/src/Radio/Radio.test.tsx
@@ -6,10 +6,12 @@ import { Basic, Error } from './Radio.stories';
 test('takes full width by default', () => {
   render(<Basic.Component />);
 
-  const radio = screen.getByText('Option 1');
-  // Width lives on the RadioField wrapper, the RadioButton label's parent.
+  // Width lives on the RadioField wrapper (a `div`). RadioButton renders a
+  // `label`, so `closest('div[data-rac]')` lands on the field regardless of how
+  // deeply RAC nests the label internally.
+  const radio = screen.getByRole('radio', { name: 'Option 1' });
   // eslint-disable-next-line testing-library/no-node-access
-  const field = radio.closest('label')?.parentElement;
+  const field = radio.closest('div[data-rac]');
   expect(field).toHaveClass('w-full');
 });
 

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -50,13 +50,24 @@ const Icon = ({ checked, className, ...props }: IconProps) => (
 );
 
 const _Radio = forwardRef<HTMLLabelElement, RadioProps>(
-  ({ value, disabled, width, children, ...props }, ref) => {
+  (
+    {
+      value,
+      disabled,
+      width,
+      children,
+      variant: variantProp,
+      size: sizeProp,
+      ...props
+    },
+    ref
+  ) => {
     const { variant, size, width: groupWidth } = useRadioGroupContext();
 
     const classNames = useClassNames({
       component: 'Radio',
-      variant: variant || props.variant,
-      size: size || props.size,
+      variant: variant || variantProp,
+      size: size || sizeProp,
     });
 
     return (

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -5,14 +5,14 @@ import {
   forwardRef,
 } from 'react';
 import type RAC from 'react-aria-components';
-import { Radio } from 'react-aria-components';
+import { RadioButton, RadioField } from 'react-aria-components';
 import { cn, useClassNames } from '@marigold/system';
 import { useRadioGroupContext } from './Context';
 import { RadioGroup } from './RadioGroup';
 
 type RemovedProps = 'className' | 'style' | 'children' | 'isDisabled';
 
-export interface RadioProps extends Omit<RAC.RadioProps, RemovedProps> {
+export interface RadioProps extends Omit<RAC.RadioFieldProps, RemovedProps> {
   variant?: string;
   size?: string;
   /**
@@ -60,31 +60,34 @@ const _Radio = forwardRef<HTMLLabelElement, RadioProps>(
     });
 
     return (
-      <Radio
-        ref={ref}
-        className={cn(
-          'group/radio',
-          'relative flex items-center gap-[1ch]',
-          width || groupWidth || 'w-full',
-          classNames.container
-        )}
+      <RadioField
+        className={cn(width || groupWidth || 'w-full')}
         value={value}
         isDisabled={disabled}
         {...props}
       >
-        {({ isSelected }) => (
-          <>
-            <Icon
-              checked={isSelected}
-              className={cn(
-                disabled ? 'cursor-not-allowed' : 'cursor-pointer',
-                classNames.radio
-              )}
-            />
-            <div className={classNames.label}>{children}</div>
-          </>
-        )}
-      </Radio>
+        <RadioButton
+          ref={ref}
+          className={cn(
+            'group/radio',
+            'relative flex w-full items-center gap-[1ch]',
+            classNames.container
+          )}
+        >
+          {({ isSelected }) => (
+            <>
+              <Icon
+                checked={isSelected}
+                className={cn(
+                  disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                  classNames.radio
+                )}
+              />
+              <div className={classNames.label}>{children}</div>
+            </>
+          )}
+        </RadioButton>
+      </RadioField>
     );
   }
 ) as RadioComponent;

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -28,7 +28,7 @@ export interface RadioProps extends Omit<RAC.RadioFieldProps, RemovedProps> {
    * Set the radio disabled.
    * @default false
    */
-  disabled?: RAC.RadioProps['isDisabled'];
+  disabled?: RAC.RadioFieldProps['isDisabled'];
 }
 
 interface IconProps {

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -28,7 +28,7 @@ test('supports base styling', () => {
     `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
   expect(container.className).toMatchInlineSnapshot(
-    `"group/switch flex w-(--width) items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
+    `"group/switch flex w-full items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
   );
   expect(track.className).toMatchInlineSnapshot(`"relative"`);
   expect(thumb.className).toMatchInlineSnapshot(
@@ -41,7 +41,7 @@ test('takes full width by default', () => {
 
   const { container } = getSwitchParts();
   expect(container.className).toMatchInlineSnapshot(
-    `"group/switch flex w-(--width) items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
+    `"group/switch flex w-full items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
   );
 });
 

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -72,6 +72,9 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
       ...rest,
     } satisfies RAC.SwitchFieldProps;
     return (
+      // Width is split across two levels: the outer SwitchField sizes itself to
+      // the `width` prop via the `--width` CSS variable, and the inner
+      // SwitchButton fills that width with `w-full`.
       <SwitchField
         {...props}
         className="w-(--width)"

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, forwardRef } from 'react';
 import type RAC from 'react-aria-components';
-import { Switch } from 'react-aria-components';
+import { SwitchButton, SwitchField } from 'react-aria-components';
 import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
 import { Label } from '../Label/Label';
 
@@ -13,7 +13,7 @@ type RemovedProps =
   | 'isSelected'
   | 'slot';
 
-export interface SwitchProps extends Omit<RAC.SwitchProps, RemovedProps> {
+export interface SwitchProps extends Omit<RAC.SwitchFieldProps, RemovedProps> {
   variant?: string;
   size?: string;
 
@@ -70,24 +70,28 @@ const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(
       isReadOnly: readOnly,
       isSelected: selected,
       ...rest,
-    } satisfies RAC.SwitchProps;
+    } satisfies RAC.SwitchFieldProps;
     return (
-      <Switch
+      <SwitchField
         {...props}
-        ref={ref}
-        className={cn(
-          'group/switch flex w-(--width) items-center gap-[1ch]',
-          classNames.container
-        )}
+        className="w-(--width)"
         style={createWidthVar('width', width)}
       >
-        {label && <Label elementType="span">{label}</Label>}
-        <div className="relative">
-          <div className={classNames.track}>
-            <div className={classNames.thumb} />
+        <SwitchButton
+          ref={ref}
+          className={cn(
+            'group/switch flex w-full items-center gap-[1ch]',
+            classNames.container
+          )}
+        >
+          {label && <Label elementType="span">{label}</Label>}
+          <div className="relative">
+            <div className={classNames.track}>
+              <div className={classNames.thumb} />
+            </div>
           </div>
-        </div>
-      </Switch>
+        </SwitchButton>
+      </SwitchField>
     );
   }
 );

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -35,19 +35,19 @@ export interface SwitchProps extends Omit<RAC.SwitchFieldProps, RemovedProps> {
    * Disables the switch.
    * @default false
    */
-  disabled?: RAC.SwitchProps['isDisabled'];
+  disabled?: RAC.SwitchFieldProps['isDisabled'];
 
   /**
    * Set the switch to read-only.
    * @default false
    */
-  readOnly?: RAC.SwitchProps['isReadOnly'];
+  readOnly?: RAC.SwitchFieldProps['isReadOnly'];
 
   /**
    * With this prop you can set the switch selected.
    * @default false
    */
-  selected?: RAC.SwitchProps['isSelected'];
+  selected?: RAC.SwitchFieldProps['isSelected'];
 }
 
 const _Switch = forwardRef<HTMLLabelElement, SwitchProps>(


### PR DESCRIPTION
# Description

Migrates `Checkbox`, `Switch`, and `Radio` off the deprecated react-aria-components single-element exports (`Checkbox`/`Switch`/`Radio`) to the `*Field` + `*Button` composition introduced in `react-aria-components@1.18.0`. This removes the `ts(6385)` deprecation warnings.

The migration unavoidably adds one wrapper `<div>` per control (the RAC `*Field`), because `*Button` reads a private context that only `*Field` provides. The `group/*` class, row layout, label, indicator, and forwarded `ref` stay on `*Button`, so the `HTMLLabelElement` ref contract and theme `group-*/…` selectors are preserved. No change to the public Marigold API, behavior, or visual output.

Closes DST-1503

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm typecheck:only` — confirm no `ts(6385)` deprecation warnings remain for these three components.
2. Run `pnpm test:unit` and `pnpm test:sb` — Checkbox/Switch/Radio suites pass (incl. the new Checkbox `aria-describedby` test and updated Switch snapshots).
3. In Storybook, exercise `Components/Checkbox`, `Components/Switch`, `Components/Radio` (and their groups) — verify layout, width-constrained variants, focus, hover, and disabled states are unchanged.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)