### PR TITLE
feat(DST-1561): backport <DateRangePicker> from beta-release to main

### DIFF
--- a/.changeset/add-date-range-picker-component.md
+++ b/.changeset/add-date-range-picker-component.md
@@ -1,0 +1,8 @@
+---
+'@marigold/components': minor
+'@marigold/theme-rui': minor
+---
+
+feat(DST-1551): add `DateRangePicker` component
+
+New `<DateRangePicker>` lets users enter or select a start–end date range through a single field, mirroring `<DatePicker>`'s API and behaviour. Two date inputs (`start`/`end`) sit in one field group with a calendar button that opens a `<RangeCalendar>` in a popover on desktop and a tray on small screens. Supports per-input paste (ISO/EU/US formats), `granularity` (inline time segments), `visibleDuration` (up to three months), and the usual Marigold field props (`disabled`, `readOnly`, `required`, `error`, `errorMessage`, `description`, `minValue`, `maxValue`, `dateUnavailable`, `width`, `variant`, `size`). Adds a matching `DateRangePicker` theme entry to `theme-rui`.

--- a/.changeset/dst-1551-rangecalendar-hover-radius.md
+++ b/.changeset/dst-1551-rangecalendar-hover-radius.md
@@ -1,0 +1,7 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1551): round the `RangeCalendar` hover and focus highlight on days outside the selected range
+
+Days outside the selected range now round their hover and focus highlight to match the selected state, instead of showing a square highlight against the rounded endpoints. In-range cells stay square so the range fill still connects seamlessly.

--- a/docs/content/components/form/datepicker/index.mdx
+++ b/docs/content/components/form/datepicker/index.mdx
@@ -87,6 +87,10 @@ Invalid dates or unrecognized formats are ignored, ensuring data integrity.
 
 <ul>
   <li>
+    [DateRangePicker](/components/form/daterangepicker): Pick a start and end
+    date (a range) through a single field.
+  </li>
+  <li>
     [DateField](/components/form/datefield): Allows users to input a date
     directly.
   </li>

--- a/docs/content/components/form/daterangepicker/date-range-picker-length.demo.tsx
+++ b/docs/content/components/form/daterangepicker/date-range-picker-length.demo.tsx
@@ -1,0 +1,34 @@
+import type { DateValue } from '@internationalized/date';
+import { useState } from 'react';
+import { DateRangePicker } from '@marigold/components';
+
+const MIN_NIGHTS = 2;
+const MAX_NIGHTS = 14;
+
+const getErrorMessage = (nights: number | null): string | undefined => {
+  if (nights === null) return undefined;
+  if (nights < MIN_NIGHTS)
+    return `A stay must be at least ${MIN_NIGHTS} nights.`;
+  if (nights > MAX_NIGHTS) return `A stay can be at most ${MAX_NIGHTS} nights.`;
+  return undefined;
+};
+
+export default () => {
+  const [value, setValue] = useState<{
+    start: DateValue;
+    end: DateValue;
+  } | null>(null);
+
+  const nights = value ? value.end.compare(value.start) : null; // [!code highlight]
+  const message = getErrorMessage(nights);
+
+  return (
+    <DateRangePicker
+      label="Stay"
+      value={value}
+      onChange={setValue}
+      error={Boolean(message)} // [!code highlight]
+      errorMessage={message} // [!code highlight]
+    />
+  );
+};

--- a/docs/content/components/form/daterangepicker/date-range-picker-min-max.demo.tsx
+++ b/docs/content/components/form/daterangepicker/date-range-picker-min-max.demo.tsx
@@ -1,0 +1,14 @@
+import { getLocalTimeZone, today } from '@internationalized/date';
+import { DateRangePicker } from '@marigold/components';
+
+export default () => {
+  const now = today(getLocalTimeZone());
+
+  return (
+    <DateRangePicker
+      label="Booking window"
+      minValue={now} // [!code highlight]
+      maxValue={now.add({ months: 6 })} // [!code highlight]
+    />
+  );
+};

--- a/docs/content/components/form/daterangepicker/date-range-picker-multi-month.demo.tsx
+++ b/docs/content/components/form/daterangepicker/date-range-picker-multi-month.demo.tsx
@@ -1,0 +1,8 @@
+import { DateRangePicker } from '@marigold/components';
+
+export default () => (
+  <DateRangePicker
+    label="Vacation"
+    visibleDuration={{ months: 2 }} // [!code highlight]
+  />
+);

--- a/docs/content/components/form/daterangepicker/date-range-picker-unavailable.demo.tsx
+++ b/docs/content/components/form/daterangepicker/date-range-picker-unavailable.demo.tsx
@@ -1,0 +1,21 @@
+import { getLocalTimeZone, today } from '@internationalized/date';
+import { DateRangePicker } from '@marigold/components';
+
+export default () => {
+  const now = today(getLocalTimeZone());
+
+  // Nights that are already booked and cannot be part of a new stay.
+  const booked = [
+    now.add({ days: 3 }),
+    now.add({ days: 4 }),
+    now.add({ days: 5 }),
+  ];
+
+  return (
+    <DateRangePicker
+      label="Stay dates"
+      minValue={now}
+      dateUnavailable={date => booked.some(d => date.compare(d) === 0)} // [!code highlight]
+    />
+  );
+};

--- a/docs/content/components/form/daterangepicker/date-range-picker-vs-fields.demo.tsx
+++ b/docs/content/components/form/daterangepicker/date-range-picker-vs-fields.demo.tsx
@@ -1,0 +1,23 @@
+import {
+  DatePicker,
+  DateRangePicker,
+  Inline,
+  Stack,
+  Text,
+} from '@marigold/components';
+
+export default () => (
+  <Inline space={12} alignY="top">
+    <Stack space={3}>
+      <Text weight="semibold">One range picker</Text>
+      <DateRangePicker label="Trip dates" /> {/* [!code highlight] */}
+    </Stack>
+    <Stack space={3}>
+      <Text weight="semibold">Two separate fields</Text>
+      <Inline space={4}>
+        <DatePicker label="Arrival" width="fit" />
+        <DatePicker label="Departure" width="fit" />
+      </Inline>
+    </Stack>
+  </Inline>
+);

--- a/docs/content/components/form/daterangepicker/daterangepicker-anatomy.tsx
+++ b/docs/content/components/form/daterangepicker/daterangepicker-anatomy.tsx
@@ -1,0 +1,155 @@
+export const DateRangePickerAnatomy = () => (
+  <svg
+    viewBox="-20 64 780 226"
+    className="mx-auto h-auto w-full max-w-[90%]"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {/* Field label */}
+    <rect
+      x="210"
+      y="116"
+      width="96"
+      height="12"
+      rx="4"
+      className="fill-fd-foreground transition-colors duration-300"
+    />
+
+    {/* Field (the bordered group) */}
+    <rect
+      x="210"
+      y="150"
+      width="350"
+      height="52"
+      rx="8"
+      className="fill-fd-card stroke-fd-border transition-colors duration-300"
+      strokeWidth="2"
+    />
+
+    {/* Start date segments (DD MM YYYY) */}
+    <g className="fill-fd-foreground transition-colors duration-300">
+      <rect x="230" y="168" width="20" height="16" rx="3" />
+      <rect x="256" y="168" width="20" height="16" rx="3" />
+      <rect x="282" y="168" width="34" height="16" rx="3" />
+    </g>
+
+    {/* Separator */}
+    <rect
+      x="326"
+      y="174"
+      width="14"
+      height="4"
+      rx="2"
+      className="fill-fd-muted-foreground transition-colors duration-300"
+    />
+
+    {/* End date segments (DD MM YYYY) */}
+    <g className="fill-fd-foreground transition-colors duration-300">
+      <rect x="350" y="168" width="20" height="16" rx="3" />
+      <rect x="376" y="168" width="20" height="16" rx="3" />
+      <rect x="402" y="168" width="34" height="16" rx="3" />
+    </g>
+
+    {/* Calendar button */}
+    <rect
+      x="508"
+      y="160"
+      width="34"
+      height="34"
+      rx="8"
+      className="fill-fd-card stroke-fd-border transition-colors duration-300"
+      strokeWidth="2"
+    />
+    {/* Calendar glyph */}
+    <g
+      className="stroke-fd-muted-foreground transition-colors duration-300"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    >
+      <rect x="517" y="171" width="16" height="14" rx="2" />
+      <path d="M 521 168 L 521 172" />
+      <path d="M 529 168 L 529 172" />
+      <path d="M 517 177 L 533 177" />
+    </g>
+
+    {/* Description (help text below the field) */}
+    <rect
+      x="210"
+      y="220"
+      width="176"
+      height="10"
+      rx="4"
+      className="fill-fd-muted-foreground transition-colors duration-300"
+    />
+
+    {/* Connector lines */}
+    <g
+      className="stroke-fd-primary transition-colors duration-300"
+      fill="none"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      {/* Label */}
+      <path d="M 210 122 L 160 122" />
+      {/* Field (left edge) */}
+      <path d="M 210 176 L 160 176" />
+      {/* Description */}
+      <path d="M 210 225 L 160 225" />
+      {/* Start date (up from top border) */}
+      <path d="M 273 150 L 273 96" />
+      {/* End date (up from top border) */}
+      <path d="M 393 150 L 393 96" />
+      {/* Separator (down from bottom border) */}
+      <path d="M 333 202 L 333 250" />
+      {/* Calendar button (right edge) */}
+      <path d="M 542 177 L 600 177" />
+    </g>
+
+    {/* Connector dots */}
+    <g className="fill-fd-primary transition-colors duration-300">
+      <circle cx="210" cy="122" r="4" />
+      <circle cx="210" cy="176" r="4" />
+      <circle cx="210" cy="225" r="4" />
+      <circle cx="273" cy="150" r="4" />
+      <circle cx="393" cy="150" r="4" />
+      <circle cx="333" cy="202" r="4" />
+      <circle cx="542" cy="177" r="4" />
+    </g>
+
+    {/* Labels */}
+    <g
+      fontFamily="ui-sans-serif, system-ui, sans-serif"
+      className="fill-fd-primary transition-colors duration-300"
+      fontSize="14"
+      fontWeight="600"
+    >
+      <g textAnchor="end">
+        <text x="150" y="126">
+          Label
+        </text>
+        <text x="150" y="180">
+          Field
+        </text>
+        <text x="150" y="229">
+          Description
+        </text>
+      </g>
+      <g textAnchor="middle">
+        <text x="273" y="88">
+          Start date
+        </text>
+        <text x="393" y="88">
+          End date
+        </text>
+        <text x="333" y="266">
+          Separator
+        </text>
+      </g>
+      <text x="610" y="181" textAnchor="start">
+        Calendar button
+      </text>
+    </g>
+  </svg>
+);

--- a/docs/content/components/form/daterangepicker/daterangepicker-appearance.demo.tsx
+++ b/docs/content/components/form/daterangepicker/daterangepicker-appearance.demo.tsx
@@ -1,0 +1,3 @@
+import { DateRangePicker } from '@marigold/components';
+
+export default () => <DateRangePicker label="Event dates" />;

--- a/docs/content/components/form/daterangepicker/index.mdx
+++ b/docs/content/components/form/daterangepicker/index.mdx
@@ -1,0 +1,173 @@
+---
+title: DateRangePicker
+description: Pick a start and end date through a single field.
+badge: beta
+---
+
+import { DateRangePickerAnatomy } from './daterangepicker-anatomy';
+
+The `<DateRangePicker>` component lets users enter or select a date range, a start date together with an end date, through a single field.
+
+The two dates can be picked together on a calendar or typed directly into the field.
+
+## Anatomy
+
+The Label states the purpose of the field. Two date inputs hold the start and the end of the range, with a separator between them. The Calendar Button opens a range calendar where the user can pick both ends visually.
+
+<DateRangePickerAnatomy />
+
+## Appearance
+
+<AppearanceDemo component={'DateRangePicker'} />
+
+<AppearanceTable component={'DateRangePicker'} />
+
+## Usage
+
+The clearest signal that you want a `<DateRangePicker>` is the span itself. When the time between the two dates is part of what the user is deciding, a trip that lasts a week, a report that covers a quarter, a campaign that runs for ten days, the two dates work as one value and people benefit from seeing the whole stretch on a single calendar.
+
+Choosing both ends on the same calendar also keeps that value consistent. The end can never fall before the start, and rules like a minimum number of nights or blocked dates apply to the pair at once. Two separate fields cannot do this without extra validation, and moving between two calendars makes it easy to click the wrong day once the visible month shifts.
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Use a `<DateRangePicker>` when the time between the two dates matters and
+      people benefit from seeing the whole span on one calendar, like a booking
+      or a reporting period.
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't use it when only the endpoints matter, when one end can stay open,
+      or when the dates are unrelated. Reach for a single
+      [DatePicker](/components/form/datepicker) or two independent fields
+      instead.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
+The same booking captures one value on the left and two on the right. The range picker holds the whole trip in a single control and lets people pick both ends on one calendar, while the separate fields treat arrival and departure as unrelated inputs.
+
+<ComponentDemo name="date-range-picker-vs-fields" />
+
+<Callout title="@internationalized/date" type="info">
+  Marigold represents dates with the `DateValue` type from
+  `@internationalized/date` rather than the native JavaScript `Date`, which
+  avoids the timezone and parsing problems that come with `Date`. It is a peer
+  dependency, so install it if it is not already in your project.
+</Callout>
+
+### Limiting the range
+
+Often only part of the calendar makes sense. A booking cannot start in the past, and a report cannot reach into the future. Set `minValue` and `maxValue` to fence the selectable window, and the calendar prevents anything outside it.
+
+<ComponentDemo name="date-range-picker-min-max" />
+
+### Range length
+
+A range often has rules about how long it can be, such as a stay of at least two nights or at most two weeks. Read the selected `value`, compare its `end` to its `start`, and set `error` with an `errorMessage` when the length falls outside the allowed bounds.
+
+<ComponentDemo name="date-range-picker-length" />
+
+### Blocking unavailable dates
+
+Some days inside the allowed window still cannot be chosen, such as nights that are already booked or public holidays. Return `true` from `dateUnavailable` for any date that should be disabled.
+
+<ComponentDemo name="date-range-picker-unavailable" />
+
+### Showing multiple months
+
+Ranges that stretch across several months are awkward to pick one month at a time, which is common when planning a holiday or a quarter. Set `visibleDuration` to show up to three months at once. On small screens the calendar always falls back to a single month inside a tray.
+
+<ComponentDemo name="date-range-picker-multi-month" />
+
+<Callout title="Narrow screens" type="warning">
+  The field lays out two date inputs, a separator and the calendar button next
+  to each other, so it needs roughly 260px of width for its content. It holds
+  that minimum even when the surrounding layout is narrower and overflows rather
+  than crushing the inputs together. Because of this it is not suited to very
+  small viewports such as a 320px screen. Give it horizontal room, or reach for
+  a single [DatePicker](/components/form/datepicker) when space is tight.
+</Callout>
+
+### Accessibility
+
+Picking a range on the calendar can be slow for people who rely on a keyboard or a screen reader, and people who work with dates all day often prefer to type. For both groups the field stays fully usable without ever opening the calendar. Every segment can be edited directly, and a full date can be pasted into either the start or the end input. The component parses the pasted text, validates it, and fills in that end of the range. Pasted text is recognized in these formats:
+
+- ISO format: `2023-12-25`
+- European format: `25.12.2023` or `25/12/2023`
+- US format: `12/25/2023` or `12-25-2023`
+
+Unrecognized or invalid text is ignored, so the field never ends up in a broken state.
+
+## Props
+
+<StorybookHintMessage component={'DateRangePicker'} />
+
+<AutoTypeTable path="DateRangePicker" name="DateRangePickerProps" />
+
+## Alternative components
+
+<ul>
+  <li>
+    [DatePicker](/components/form/datepicker): Pick a single date through a
+    field with a calendar popover.
+  </li>
+  <li>
+    [RangeCalendar](/components/form/rangecalendar): Select a date range from a
+    calendar that is always visible.
+  </li>
+  <li>
+    [DateField](/components/form/datefield): Let users type a single date
+    directly.
+  </li>
+</ul>
+
+## Related
+
+<TeaserList
+  items={[
+    {
+      title: 'Forms',
+      href: '../../patterns/user-input/forms',
+      caption: 'How to structure, validate, and submit forms with Marigold.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={24}
+          height={24}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+          <path d="M18.375 2.625a2.121 2.121 0 113 3L12 15l-4 1 1-4z" />
+        </svg>
+      ),
+    },
+    {
+      title: 'Form Fields',
+      href: '../../foundations/form-fields',
+      caption: 'Learn how to build forms.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={24}
+          height={24}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+          <path d="M18.375 2.625a2.121 2.121 0 113 3L12 15l-4 1 1-4z" />
+        </svg>
+      ),
+    },
+  ]}
+/>

--- a/docs/content/components/form/meta.json
+++ b/docs/content/components/form/meta.json
@@ -6,6 +6,7 @@
     "combobox",
     "datefield",
     "datepicker",
+    "daterangepicker",
     "file-field",
     "form",
     "multiselect",

--- a/docs/content/components/form/rangecalendar/index.mdx
+++ b/docs/content/components/form/rangecalendar/index.mdx
@@ -24,4 +24,13 @@ The `<RangeCalendar>` component...
 
 <AutoTypeTable path="RangeCalendar" name="RangeCalendarProps" />
 
+## Alternative components
+
+<ul>
+  <li>
+    [DateRangePicker](/components/form/daterangepicker): Select a date range
+    through a single field with this calendar in a popover.
+  </li>
+</ul>
+
 ## Related

--- a/packages/components/src/DateField/DateInput.tsx
+++ b/packages/components/src/DateField/DateInput.tsx
@@ -35,7 +35,9 @@ const extractCalendarDate = (
   }
 };
 
-const parseDateFromString = (dateString: string): CalendarDate | undefined => {
+export const parseDateFromString = (
+  dateString: string
+): CalendarDate | undefined => {
   const formats = [
     // ISO format: YYYY-MM-DD
     { regex: /^(\d{4})-(\d{1,2})-(\d{1,2})$/, order: ['year', 'month', 'day'] },

--- a/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,0 +1,323 @@
+import { CalendarDate } from '@internationalized/date';
+import { useState } from 'react';
+import type { DateValue } from 'react-aria-components';
+import { I18nProvider } from 'react-aria-components/I18nProvider';
+import { expect, spyOn, waitFor } from 'storybook/test';
+import preview from '.storybook/preview';
+import type { RangeValue } from '@react-types/shared';
+import { theme } from '../../../../themes/theme-rui/src/index.js';
+import { Stack } from '../Stack/Stack';
+import { DateRangePicker } from './DateRangePicker';
+
+const smallScreenQuery = `(width < ${theme.screens?.sm})`;
+
+const meta = preview.meta({
+  title: 'Components/DateRangePicker',
+  component: DateRangePicker,
+  argTypes: {
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disable the date range picker',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    width: {
+      control: { type: 'text' },
+      description:
+        'Width of the date range picker input field, using Tailwind tokens',
+    },
+    required: {
+      control: { type: 'boolean' },
+      description: 'Set the date range picker required.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    open: {
+      control: { type: 'boolean' },
+      description: 'Open the date range picker.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    errorMessage: {
+      control: { type: 'text' },
+      description: 'Sets error message for the date range picker.',
+    },
+    description: {
+      control: { type: 'text' },
+      description: 'Sets help text for the date range picker.',
+    },
+    error: {
+      control: { type: 'boolean' },
+      description: 'Sets error for the date range picker.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    readOnly: {
+      control: { type: 'boolean' },
+      description: 'Set readOnly for date range picker.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+  args: {
+    errorMessage: 'Something went wrong!',
+    description: 'This is a description help text.',
+    disabled: false,
+    required: false,
+    error: false,
+  },
+  decorators: [
+    Story => {
+      // Mock matchMedia for tests
+      if (typeof window !== 'undefined' && !window.matchMedia) {
+        Object.defineProperty(window, 'matchMedia', {
+          writable: true,
+          value: (query: string) => ({
+            matches: query === smallScreenQuery,
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+          }),
+        });
+      }
+      return (
+        <div id="storybook-root" className="p-4">
+          <Story />
+        </div>
+      );
+    },
+  ],
+});
+
+export const Basic: any = meta.story({
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker
+        label="Date Range Picker"
+        description="This is a description"
+        errorMessage="This is an error"
+        {...args}
+      />
+    </I18nProvider>
+  ),
+});
+
+export const Controlled: any = meta.story({
+  render: args => {
+    const [value, setValue] = useState<RangeValue<DateValue> | null>({
+      start: new CalendarDate(2025, 8, 7),
+      end: new CalendarDate(2025, 8, 14),
+    });
+
+    return (
+      <I18nProvider locale="de-DE">
+        <Stack>
+          <DateRangePicker
+            label="Date Range Picker"
+            value={value}
+            onChange={setValue}
+            description="Controlled date range"
+            errorMessage="This is an error"
+            {...args}
+          />
+          {value ? (
+            <pre style={{ marginTop: '1rem' }} data-testid="selectedRange">
+              <strong>Range:</strong>
+              {` ${value.start.toString()} → ${value.end.toString()}`}
+            </pre>
+          ) : (
+            <pre>{`No value (${value}).`}</pre>
+          )}
+        </Stack>
+      </I18nProvider>
+    );
+  },
+});
+
+export const MinMax: any = meta.story({
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker
+        label="Date Range Picker"
+        description="Determine min and max value for date range picker"
+        errorMessage="This is an error"
+        minValue={new CalendarDate(2019, 6, 5)}
+        maxValue={new CalendarDate(2019, 6, 20)}
+        {...args}
+      />
+    </I18nProvider>
+  ),
+});
+
+export const UnavailableDate: any = meta.story({
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker
+        label="Date Range Picker"
+        dateUnavailable={date => date.toDate('Europe/Berlin').getDay() === 0}
+        {...args}
+      />
+    </I18nProvider>
+  ),
+});
+
+export const MultiMonth: any = meta.story({
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker
+        label="Date Range Picker"
+        description="Shows up to three months at once"
+        visibleDuration={{ months: 2 }}
+        {...args}
+      />
+    </I18nProvider>
+  ),
+});
+
+export const WithError: any = meta.story({
+  args: {
+    error: true,
+    errorMessage: 'Whoopsie',
+    description: 'Some helpful text',
+  },
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker label="A Label" {...args} />
+    </I18nProvider>
+  ),
+});
+
+export const Mobile: any = meta.story({
+  tags: ['component-test'],
+  globals: {
+    viewport: { value: 'smallScreen' },
+  },
+  render: args => (
+    <I18nProvider locale="de-DE">
+      <DateRangePicker
+        label="Pick a range"
+        defaultValue={{
+          start: new CalendarDate(2025, 8, 1),
+          end: new CalendarDate(2025, 8, 8),
+        }}
+        {...args}
+      />
+    </I18nProvider>
+  ),
+});
+
+Basic.tags = ['component-test'];
+
+Basic.test(
+  'opens the calendar popover and selects a range',
+  async ({ canvas, step, userEvent }: any) => {
+    const trigger = canvas.getByRole('button');
+
+    await step('Open popover via trigger', async () => {
+      await userEvent.click(trigger);
+      await waitFor(() =>
+        expect(canvas.getByRole('application')).toBeVisible()
+      );
+    });
+
+    await step('Calendar grid is visible', async () => {
+      const grid = await canvas.findByRole('grid');
+      await waitFor(() => expect(grid).toBeVisible());
+    });
+  }
+);
+
+Basic.test(
+  'pastes dates into the start and end inputs',
+  async ({ canvas, step }: any) => {
+    const firePaste = (element: Element, text: string) => {
+      const pasteEvent = new Event('paste', {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(pasteEvent, 'clipboardData', {
+        value: { getData: () => text },
+      });
+      element.dispatchEvent(pasteEvent);
+    };
+
+    // 6 segments total: 3 for start, 3 for end (day granularity).
+    const segments = canvas.getAllByRole('spinbutton');
+
+    await step('Paste an ISO date into the start input', async () => {
+      firePaste(segments[0], '2025-09-24');
+      await waitFor(() => {
+        const updated = canvas.getAllByRole('spinbutton');
+        // Year segment of the start input should reflect the pasted year.
+        expect(updated[2]).toHaveTextContent('2025');
+      });
+    });
+
+    await step('Paste a European date into the end input', async () => {
+      const updated = canvas.getAllByRole('spinbutton');
+      firePaste(updated[3], '30.09.2025');
+      await waitFor(() => {
+        const next = canvas.getAllByRole('spinbutton');
+        expect(next[5]).toHaveTextContent('2025');
+      });
+    });
+
+    await step('Ignore an invalid pasted value', async () => {
+      const updated = canvas.getAllByRole('spinbutton');
+      firePaste(updated[0], 'not-a-date');
+      // The start input keeps the year pasted earlier instead of breaking.
+      await waitFor(() => {
+        const next = canvas.getAllByRole('spinbutton');
+        expect(next[2]).toHaveTextContent('2025');
+      });
+    });
+  }
+);
+
+Mobile.test(
+  'opens a tray on small screens',
+  async ({ canvas, step, userEvent }: any) => {
+    const releasePointerCaptureMock = spyOn(
+      Element.prototype,
+      'releasePointerCapture'
+    ).mockImplementation(() => {});
+
+    const trigger = canvas.getByRole('button');
+
+    await step('Open tray by clicking trigger', async () => {
+      await userEvent.click(trigger);
+    });
+
+    await step('Tray content is visible', async () => {
+      const dialog = await canvas.findByRole('dialog');
+      await waitFor(() => expect(dialog).toBeVisible());
+    });
+
+    await step('Calendar is visible in the tray', async () => {
+      const calendar = await canvas.findByRole('grid');
+      await waitFor(() => expect(calendar).toBeVisible());
+    });
+
+    await step('Close tray with Escape key', async () => {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(canvas.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    releasePointerCaptureMock.mockRestore();
+  }
+);

--- a/packages/components/src/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.test.tsx
@@ -1,0 +1,74 @@
+import { CalendarDate } from '@internationalized/date';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockMatchMedia } from '../test.utils';
+import { Basic, UnavailableDate, WithError } from './DateRangePicker.stories';
+
+// A fixed range reused across tests that need pre-filled start/end inputs.
+const defaultRange = {
+  start: new CalendarDate(2019, 2, 3),
+  end: new CalendarDate(2019, 2, 10),
+};
+
+window.matchMedia = mockMatchMedia([]);
+
+describe('DateRangePicker', () => {
+  describe('basics', () => {
+    test('renders start and end inputs with the given range', () => {
+      render(<Basic.Component defaultValue={defaultRange} />);
+
+      const groups = screen.getAllByRole('group');
+      const segments = screen.getAllByRole('spinbutton');
+
+      expect(groups[0]).toBeVisible();
+      expect(segments).toHaveLength(6);
+      // de-DE format renders each input as DD.MM.YYYY.
+      expect(segments[0]).toHaveTextContent('03');
+      expect(segments[1]).toHaveTextContent('02');
+      expect(segments[2]).toHaveTextContent('2019');
+      expect(segments[3]).toHaveTextContent('10');
+      expect(segments[4]).toHaveTextContent('02');
+      expect(segments[5]).toHaveTextContent('2019');
+    });
+
+    test('renders a calendar separator between the inputs', () => {
+      render(<Basic.Component defaultValue={defaultRange} />);
+
+      expect(screen.getByText('–')).toBeInTheDocument();
+    });
+
+    test('renders the calendar when the picker is open', async () => {
+      render(<Basic.Component open />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('application')).toBeVisible();
+      });
+      expect(screen.getByRole('grid')).toBeVisible();
+    });
+  });
+
+  describe('states', () => {
+    test('supports a disabled picker', () => {
+      render(<Basic.Component disabled />);
+
+      const segments = screen.getAllByRole('spinbutton');
+
+      segments.forEach(segment => {
+        expect(segment).toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    test('shows the error message when invalid', () => {
+      render(<WithError.Component />);
+
+      expect(screen.getByText('Whoopsie')).toBeVisible();
+    });
+
+    test('marks unavailable dates via dateUnavailable', async () => {
+      render(<UnavailableDate.Component open />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('application')).toBeVisible();
+      });
+    });
+  });
+});

--- a/packages/components/src/DateRangePicker/DateRangePicker.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.tsx
@@ -1,0 +1,257 @@
+import type { ReactElement, Ref } from 'react';
+import { use } from 'react';
+import type RAC from 'react-aria-components';
+import { DateInput as AriaDateInput } from 'react-aria-components/DateField';
+import {
+  DateRangePicker,
+  DateRangePickerStateContext,
+} from 'react-aria-components/DateRangePicker';
+import type { DateValue } from 'react-aria-components/DateRangePicker';
+import { Dialog } from 'react-aria-components/Dialog';
+import { Group } from 'react-aria-components/Group';
+import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { WidthProp, cn, useClassNames, useSmallScreen } from '@marigold/system';
+import { Button } from '../Button/Button';
+import { parseDateFromString } from '../DateField/DateInput';
+import { DateSegment } from '../DateField/DateSegment';
+import { FieldBase, FieldBaseProps } from '../FieldBase/FieldBase';
+import { IconButton } from '../IconButton/IconButton';
+import { Popover } from '../Overlay/Popover';
+import { RangeCalendar } from '../RangeCalendar/RangeCalendar';
+import { Tray } from '../Tray/Tray';
+import { Calendar as CalendarIcon } from '../icons/Calendar';
+import { intlMessages } from '../intl/messages';
+
+type RemovedProps =
+  | 'isDisabled'
+  | 'isDateUnavailable'
+  | 'isReadOnly'
+  | 'isRequired'
+  | 'isInvalid'
+  | 'style'
+  | 'className'
+  | 'isOpen';
+
+export interface DateRangePickerProps
+  extends
+    Omit<RAC.DateRangePickerProps<DateValue>, RemovedProps>,
+    Pick<FieldBaseProps<'label'>, 'label' | 'description' | 'errorMessage'> {
+  /**
+   * Callback that is called for each date of the calendar. If it returns true, then the date is unavailable.
+   */
+  dateUnavailable?: RAC.DateRangePickerProps<DateValue>['isDateUnavailable'];
+
+  /**
+   * If `true`, the date range picker is disabled.
+   * @default false
+   */
+  disabled?: RAC.DateRangePickerProps<DateValue>['isDisabled'];
+
+  /**
+   * If `true`, the date range picker is required.
+   * @default false
+   */
+  required?: RAC.DateRangePickerProps<DateValue>['isRequired'];
+
+  /**
+   * If `true`, the date range picker is readOnly.
+   * @default false
+   */
+  readOnly?: RAC.DateRangePickerProps<DateValue>['isReadOnly'];
+
+  /**
+   * If `true`, the field is considered invalid and if set the errorMessage is shown instead of the `description`.
+   * @default false
+   */
+  error?: RAC.DateRangePickerProps<DateValue>['isInvalid'];
+
+  /**
+   * Whether the calendar is open by default (controlled).
+   * @default false
+   */
+  open?: RAC.DateRangePickerProps<DateValue>['isOpen'];
+
+  variant?: string;
+  size?: string;
+
+  /**
+   * The number of months to display at once in the calendar popover. Up to 3 months are supported.
+   * @default { months: 1 }
+   */
+  visibleDuration?: { months: 1 | 2 | 3 };
+
+  /**
+   * Controls how the calendar pages when navigating.
+   * - 'single': Page by one month at a time
+   * - 'visible': Page by the number of visible months
+   * @default 'visible'
+   */
+  pageBehavior?: RAC.DateRangePickerProps<DateValue>['pageBehavior'];
+
+  /**
+   * Sets the width of the field. You can see allowed tokens here: https://tailwindcss.com/docs/width
+   *
+   * Numeric/scale values are spacing-scale tokens, not pixels: `width={64}`
+   * resolves to `calc(var(--spacing) * 64)` ~= 16rem (256px), not 64px.
+   *
+   * When unset, the field hugs its content (`'fit'`) on larger screens and
+   * fills the available space (`'full'`) on small screens, where two dates plus
+   * the separator and calendar button would otherwise be too cramped to fit.
+   * @default 'fit'
+   */
+  width?: WidthProp['width'];
+}
+
+const DateRangePickerBase = ({
+  dateUnavailable,
+  disabled,
+  required,
+  readOnly,
+  error,
+  variant,
+  size,
+  open,
+  granularity = 'day',
+  visibleDuration,
+  pageBehavior,
+  width,
+  onChange,
+  ref,
+  ...rest
+}: DateRangePickerProps & { ref?: Ref<HTMLDivElement> }) => {
+  const props: RAC.DateRangePickerProps<DateValue> = {
+    isDateUnavailable: dateUnavailable,
+    isDisabled: disabled,
+    isReadOnly: readOnly,
+    isRequired: required,
+    isInvalid: error,
+    isOpen: open,
+    granularity,
+    onChange,
+    ...rest,
+  };
+
+  const classNames = useClassNames({
+    component: 'DateRangePicker',
+    size,
+    variant,
+  });
+
+  const isSmallScreen = useSmallScreen();
+  const stringFormatter = useLocalizedStringFormatter(intlMessages);
+
+  // Hug the content on larger screens, but fill the available space on small
+  // screens so the two inputs, separator and button are not cramped or clipped.
+  // Leaving the width unset lets `FieldBase` fall back to its full-width layout.
+  const resolvedWidth = width ?? (isSmallScreen ? undefined : 'fit');
+
+  return (
+    <FieldBase
+      as={DateRangePicker}
+      variant={variant}
+      size={size}
+      width={resolvedWidth}
+      {...props}
+      ref={ref}
+    >
+      <DateRangeInput
+        action={
+          <IconButton className={classNames}>
+            <CalendarIcon size="16" data-testid="action" />
+          </IconButton>
+        }
+      />
+      {isSmallScreen ? (
+        <Tray>
+          <Tray.Title>{rest.label}</Tray.Title>
+          <Tray.Content>
+            <RangeCalendar disabled={disabled} />
+          </Tray.Content>
+          <Tray.Actions>
+            <Button slot="close">{stringFormatter.format('close')}</Button>
+          </Tray.Actions>
+        </Tray>
+      ) : (
+        <Popover>
+          <Dialog>
+            <RangeCalendar
+              disabled={disabled}
+              visibleDuration={visibleDuration}
+              pageBehavior={pageBehavior}
+            />
+          </Dialog>
+        </Popover>
+      )}
+    </FieldBase>
+  );
+};
+
+export { DateRangePickerBase as DateRangePicker };
+
+interface DateRangeInputProps {
+  action?: ReactElement<any>;
+}
+
+const DateRangeInput = ({ action }: DateRangeInputProps) => {
+  const ctx = use(DateRangePickerStateContext);
+  const classNames = useClassNames({ component: 'DateField' });
+
+  const handlePaste =
+    (part: 'start' | 'end') => (event: React.ClipboardEvent) => {
+      try {
+        const parsedDate = parseDateFromString(
+          event.clipboardData.getData('text')
+        );
+        if (parsedDate) {
+          event.preventDefault();
+          // `setDateTime` is the same commit path the start/end inputs use on
+          // their own `onChange`: it writes the pasted part into `state.value`
+          // (preserving the other part), which the controlled inputs reflect.
+          // `setDate` alone keeps an incomplete range as in-progress only and
+          // would not update the field display.
+          ctx?.setDateTime(part, parsedDate);
+        }
+      } catch (error) {
+        console.warn('Failed to parse pasted date:', error);
+      }
+    };
+
+  return (
+    <Group
+      className={cn(
+        classNames.field,
+        // `min-w-fit` keeps the field at least as wide as its content (two
+        // inputs, separator and button) so it never crushes them together on
+        // narrow screens. It needs more room than fits at e.g. 320px.
+        'w-(--field-width) max-w-full min-w-fit overflow-hidden'
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center">
+        <div className="min-w-0" onPaste={handlePaste('start')}>
+          <AriaDateInput
+            slot="start"
+            className={cn('flex items-center pr-0', classNames.input)}
+          >
+            {segment => (
+              <DateSegment className={classNames.segment} segment={segment} />
+            )}
+          </AriaDateInput>
+        </div>
+        <span aria-hidden="true" className="text-placeholder shrink-0 px-1">
+          –
+        </span>
+        <div className="min-w-0" onPaste={handlePaste('end')}>
+          <AriaDateInput
+            slot="end"
+            className={cn('flex items-center pl-0', classNames.input)}
+          >
+            {segment => (
+              <DateSegment className={classNames.segment} segment={segment} />
+            )}
+          </AriaDateInput>
+        </div>
+      </div>
+      {action}
+    </Group>
+  );
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -92,6 +92,9 @@ export type { DateFieldProps } from './DateField/DateField';
 export { DatePicker } from './DatePicker/DatePicker';
 export type { DatePickerProps } from './DatePicker/DatePicker';
 
+export { DateRangePicker } from './DateRangePicker/DateRangePicker';
+export type { DateRangePickerProps } from './DateRangePicker/DateRangePicker';
+
 export { Dialog } from './Dialog/Dialog';
 export type { DialogProps } from './Dialog/Dialog';
 export { ConfirmationDialog } from './Dialog/ConfirmationDialog';

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -255,6 +255,7 @@ export type Theme = {
       ComponentStyleFunction<string, string>
     >;
     DatePicker?: ComponentStyleFunction<string, string>;
+    DateRangePicker?: ComponentStyleFunction<string, string>;
     ComboBox?: Record<
       'icon' | 'mobileTrigger',
       ComponentStyleFunction<string, string>

--- a/themes/theme-rui/scripts/build-appearances.mjs
+++ b/themes/theme-rui/scripts/build-appearances.mjs
@@ -18,6 +18,9 @@ console.log('🎨 Generating appearances data...');
 const sharedAppearances = {
   LinkButton: 'Button',
   ToggleButtonGroup: 'ToggleButton',
+  // `DateRangePicker` re-exports DatePicker's styles (see DateRangePicker.styles.ts),
+  // so it shares the same (empty) variant/size vocabulary.
+  DateRangePicker: 'DatePicker',
 };
 
 /**

--- a/themes/theme-rui/src/components/DateRangePicker.styles.ts
+++ b/themes/theme-rui/src/components/DateRangePicker.styles.ts
@@ -1,0 +1,9 @@
+import { type ThemeComponent } from '@marigold/system';
+import { DatePicker } from './DatePicker.styles';
+
+/**
+ * The DateRangePicker trigger button styling is identical to DatePicker today.
+ * Re-export the DatePicker styles under a dedicated key so the two components
+ * can diverge later without touching the component implementation.
+ */
+export const DateRangePicker: ThemeComponent<'DateRangePicker'> = DatePicker;

--- a/themes/theme-rui/src/components/RangeCalendar.styles.ts
+++ b/themes/theme-rui/src/components/RangeCalendar.styles.ts
@@ -6,6 +6,9 @@ export const RangeCalendar: ThemeComponent<'RangeCalendar'> = {
   calendarCell: cva({
     base: [
       'h-9 w-full rounded-none',
+      // Cells outside the selected range round their hover/focus highlight to
+      // match the selected state; in-range cells stay square so the fill connects.
+      'not-data-[in-range]:data-hovered:rounded-lg not-data-[in-range]:focus-visible:rounded-lg',
       'data-[in-range]:bg-brand/15 data-[in-range]:text-foreground',
       'selection-start:bg-brand selection-start:text-brand-foreground selection-start:rounded-l-lg',
       'selection-end:bg-brand selection-end:text-brand-foreground selection-end:rounded-r-lg',

--- a/themes/theme-rui/src/components/index.ts
+++ b/themes/theme-rui/src/components/index.ts
@@ -13,6 +13,7 @@ export { Collapsible } from './Collapsible.styles';
 export { ContextualHelp } from './ContextualHelp.styles';
 export { DateField } from './DateField.styles';
 export { DatePicker } from './DatePicker.styles';
+export { DateRangePicker } from './DateRangePicker.styles';
 export { Dialog } from './Dialog.styles';
 export { Divider } from './Divider.styles';
 export { Drawer } from './Drawer.styles';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,10 @@ import { playwright } from '@vitest/browser-playwright';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import configShared, { browserDeps } from './vitest.config.shared.js';
+import configShared, {
+  browserDeps,
+  browserScanEntries,
+} from './vitest.config.shared.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,6 +18,7 @@ export default mergeConfig(
     plugins: [react(), tailwindcss()],
     optimizeDeps: {
       include: browserDeps,
+      entries: browserScanEntries,
     },
     resolve: {
       // Force a single copy of React/React DOM across all entry points so a
@@ -41,6 +45,7 @@ export default mergeConfig(
           },
           optimizeDeps: {
             include: browserDeps,
+            entries: browserScanEntries,
           },
           test: {
             name: 'unit-tests',
@@ -92,6 +97,7 @@ export default mergeConfig(
           },
           optimizeDeps: {
             include: browserDeps,
+            entries: browserScanEntries,
           },
           test: {
             name: 'storybook-tests',

--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -1,12 +1,21 @@
 import { defineConfig } from 'vitest/config';
 
 /**
- * Deps that must be pre-bundled for browser-mode vitest projects.
+ * Root-level deps that must be pre-bundled for browser-mode vitest projects.
  *
  * Without pre-bundling, Vite discovers these deps at runtime and triggers
  * on-demand optimization, which races with concurrent browser test execution
  * in CI (cold cache, constrained resources) and produces:
  *   `TypeError: error loading dynamically imported module`
+ *
+ * IMPORTANT: only list deps that resolve from the MONOREPO ROOT here.
+ * `optimizeDeps.include` is resolved from the Vite root (this repo root), so
+ * packages installed under a workspace (e.g. react-aria-components and
+ * `@react-aria/*`, which live under packages/components in this pnpm repo) are
+ * NOT resolvable here — listing them only emits "Failed to resolve dependency"
+ * warnings and does nothing. Those workspace-nested deps are instead crawled
+ * up front via `optimizeDeps.entries` (see vite.config.ts), which resolves
+ * imports from each source file's own location.
  *
  * Keep this list next to the coverage config so adding a provider
  * doesn't silently break projects that override `optimizeDeps`.
@@ -32,12 +41,25 @@ export const browserDeps = [
   // surfacing as `resolveDispatcher() is null` during renderToString/hydrateRoot.
   'react-dom/server',
   'react-dom/client',
-  // RAC subpath import used in stories/tests (see DST-1512). Without
-  // pre-bundling, the unit-tests project discovers it at runtime and
-  // re-optimizes mid-run, cascading "error loading dynamically imported module".
-  'react-aria-components/I18nProvider',
   // Test setup (extends expect at module load time)
   '@testing-library/jest-dom/vitest',
+];
+
+/**
+ * Glob of entry files Vite's dep scanner crawls before serving, so the FULL
+ * import graph (all `react-aria-components/<Subpath>` and `@react-aria/*` deps,
+ * which are workspace-nested and therefore NOT listable in `optimizeDeps.include`
+ * — see browserDeps above) is discovered and pre-bundled in a single pass up
+ * front. This is what actually prevents the mid-run re-optimization race that
+ * surfaces as `error loading dynamically imported module` (the DateField ->
+ * `useButton` CI flake): unlike `include`, the scanner resolves each import from
+ * its own file location, so workspace deps resolve correctly.
+ *
+ * Covers test + story files (the browser-mode entry points) across all packages;
+ * their transitive source imports are followed automatically by the scanner.
+ */
+export const browserScanEntries = [
+  'packages/*/src/**/*.{test,stories}.{ts,tsx}',
 ];
 
 const exclude = [


### PR DESCRIPTION
# Description

Backports the `<DateRangePicker>` component (DST-1551, originally shipped on `beta-release` via #5556) to `main` so it can release in a stable minor instead of waiting for the whole beta train to be promoted.

`<DateRangePicker>` lets users enter or select a start–end date range through a single field, mirroring `<DatePicker>`'s API and behaviour: two date inputs in one field group with a calendar button that opens a `<RangeCalendar>` in a popover on desktop and a tray on small screens. All runtime dependencies (`RangeCalendar`, `Tray`, `useSmallScreen`, `data-in-range`) already exist on `main`.

Applied as a squashed cumulative diff of the DST-1551 commits. Three shared files were resolved by hand to bring only the DST-1551 delta and exclude beta-only baseline that doesn't exist on `main`:

- `components/src/index.ts` — added only the `DateRangePicker` exports (the beta-only `Description` export stays out).
- `themes/theme-rui/scripts/build-appearances.mjs` — added only the `DateRangePicker` alias (beta-only `Title`/`ActionMenu` excluded).
- `themes/theme-rui/src/components/RangeCalendar.styles.ts` — kept `main`'s `brand` tokens and added only the new hover/focus rounding rule (the `selected`/`selected-bold` token migration is a separate beta-only effort).

Every DateRangePicker-specific file (component, tests, stories, docs, demos, anatomy, theme styles) is byte-identical to beta.

Closes DST-1561
Related: DST-1551

## Previews

- **Docs (DateRangePicker page):** https://marigold-docs-git-dst-1561-backport-date-range-picker-marigold.vercel.app/components/form/daterangepicker
- **Storybook:** https://marigold-storybook-git-dst-1561-backport-date-r-b27a4a-marigold.vercel.app

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm install && pnpm build`.
2. Open Storybook (`pnpm sb`) → `Components/DateRangePicker` and exercise each story.
3. Verify desktop opens a popover calendar and small screens open a tray.
4. `pnpm test:unit DateRangePicker` and `pnpm test:sb DateRangePicker` (verified locally: 6 unit + 5 interaction tests pass).
5. Run `pnpm start` → `/components/form/daterangepicker` to review the docs page.

## Breaking Changes

No

## Accessibility

Audited with the `a11y-audit` agent. The component is built entirely on react-aria-components and is byte-identical to the already-reviewed, merged beta version (#5556), so it introduces no a11y change versus what shipped on `beta-release`.

- **Calendar trigger accessible name** — verified empirically (render test): the trigger button receives a non-empty `aria-label` from RAC, same wiring as `DatePicker` (`aria-label="Kalender"`). No blocker.
- Keyboard nav (segment arrows, Tab order), the `aria-hidden` separator, `disabled`/error plumbing, tray Escape dismissal, and `prefers-reduced-motion` handling all pass.
- **Follow-up (non-blocking, pre-existing):** the calendar trigger has no explicit `focus-visible` rule in `DatePicker.styles.ts` / `DateRangePicker.styles.ts` (shared with the already-shipped `DatePicker`); and dedicated `aria-label`/focus-on-open *test coverage* could be added to match `DatePicker.test.tsx`. Neither is introduced by this backport.

## CI note

The `Unit Tests` / `Coverage Report` jobs are failing due to an environment-wide CI issue (`@vitest/coverage-istanbul` fails to load dynamically, cascading into unhandled errors across unrelated files such as `ActionBar.test.tsx`). This is **not** caused by this PR — the same failure appears on other PRs run today (e.g. #5570). The DateRangePicker `Storybook Tests`, `Typecheck`, and `Lint` jobs all pass, and the unit + interaction tests pass locally.

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
