### PR TITLE
fix(DST-1573): default Page and Page.Content space to regular

### DIFF
--- a/.changeset/page-default-spacing-regular.md
+++ b/.changeset/page-default-spacing-regular.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': minor
+---
+
+fix(DST-1573): default `<Page>` and `<Page.Content>` spacing to `regular`
+
+The `space` prop on `<Page>` and `<Page.Content>` — which controls the vertical rhythm between a page's children (the `<Page.Header>` and the `<Panel>`s/sections below it) — now defaults to `regular` (`spacing(6)`, 24px) instead of `group` (`spacing(12)`, 48px). The previous default produced too much whitespace between sections. Consumers can opt back into the larger gap with `space="group"`.

--- a/packages/components/src/Page/Page.tsx
+++ b/packages/components/src/Page/Page.tsx
@@ -42,7 +42,7 @@ interface PageBaseProps extends Omit<
   /**
    * Vertical rhythm between page sections (the `<Page.Header>` and the
    * `<Panel>`s below it).
-   * @default 'group'
+   * @default 'regular'
    */
   space?: SpaceProp<SpacingTokens>['space'];
 }
@@ -81,7 +81,7 @@ export const Page = ({
   children,
   'aria-label': ariaLabel,
   headingLevel = 1,
-  space = 'group',
+  space = 'regular',
   p,
   px,
   py,

--- a/packages/components/src/Page/PageContent.tsx
+++ b/packages/components/src/Page/PageContent.tsx
@@ -12,7 +12,7 @@ export interface PageContentProps {
   /**
    * Vertical rhythm between the content's sections. Lets the gap _between_
    * sections differ from the `<Page>`'s header-to-content gap.
-   * @default 'group'
+   * @default 'regular'
    */
   space?: SpaceProp<SpacingTokens>['space'];
 }
@@ -24,7 +24,7 @@ export interface PageContentProps {
  */
 export const PageContent = ({
   children,
-  space = 'group',
+  space = 'regular',
 }: PageContentProps) => {
   const { classNames } = usePageContext();
 


### PR DESCRIPTION
# Description

Changes the default `space` prop on `<Page>` and `<Page.Content>` from `'group'` (`spacing(12)`, 48px) to `'regular'` (`spacing(6)`, 24px). `space` controls the vertical rhythm between a page's children — the `<Page.Header>` and the `<Panel>`s/sections below it. The old `group` default produced too much whitespace, leaving pages feeling sparse out of the box. Consumers can still opt into the larger gap with `space="group"`.

Closes DST-1573

## Screenshots / Preview

| Before (`group`, 48px) | After (`regular`, 24px) |
| ---------------------- | ----------------------- |
|                        |                         |

<!-- Paste screenshots/GIFs above, or link the Storybook/docs preview once it's built. -->

## Test Instructions

1. Open Storybook → `Components/Page` (or the docs preview).
2. Confirm the default gap between the header and the panels/sections is the tighter `regular` (24px) spacing.
3. Set `space="group"` on `<Page>` and confirm the larger 48px gap is still available.

## Breaking Changes

No — but note this is a **visual default change**: pages that don't set `space` will render with tighter spacing than before. The prop and all its values are unchanged; `space="group"` restores the previous look. Released as a `minor` bump.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)