### PR TITLE
feat(DST-1574): surface example apps in the docs cmdk search

### DIFF
--- a/.changeset/examples-in-cmdk-search.md
+++ b/.changeset/examples-in-cmdk-search.md
@@ -1,0 +1,7 @@
+---
+'@marigold/docs': patch
+---
+
+feat(DST-1574): surface example apps in the docs ⌘K search
+
+The interactive example demos are now discoverable from the docs command menu. Typing an example's name — or just "example" — lists the standalone demos (App Shell, Filter, Event Form, Settings Form, Auto-Save Settings, Inventory) as "Example: …" quick actions. Internal screens of a larger demo (e.g. the App Shell's Billing/Users/Teams pages) are intentionally not surfaced as separate examples.

--- a/docs/app/(examples)/examples/navigation.test.ts
+++ b/docs/app/(examples)/examples/navigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { config, examplePages } from './navigation';
+
+describe('examplePages', () => {
+  it('surfaces exactly the standalone demos', () => {
+    // The full contract of the docs cmdk search: one entry per standalone
+    // demo. A future nav edit that drops or duplicates a demo should break here.
+    expect(examplePages()).toEqual([
+      { name: 'App Shell', url: '/examples' },
+      { name: 'Filter', url: '/examples/filter' },
+      { name: 'Event Form', url: '/examples/event-form' },
+      { name: 'Settings Form', url: '/examples/settings-form' },
+      { name: 'Auto-Save Settings', url: '/examples/auto-save-settings' },
+      { name: 'Inventory', url: '/examples/inventory' },
+    ]);
+  });
+
+  it('collapses a self-contained app to a single entry at its landing', () => {
+    // "App Shell" has an empty-slug index child, so it collapses to one entry
+    // pointing at the base — its internal screens are not standalone examples.
+    const appShell = examplePages().filter(page => page.name === 'App Shell');
+    expect(appShell).toEqual([{ name: 'App Shell', url: config.base }]);
+  });
+
+  it('does not surface the internal screens of a self-contained app', () => {
+    const names = examplePages().map(page => page.name);
+    // App Shell internal navigation (Analytics, Users, Teams, Billing, …).
+    expect(names).not.toContain('Users');
+    expect(names).not.toContain('Teams');
+    expect(names).not.toContain('Billing');
+    expect(names).not.toContain('Analytics');
+    expect(names).not.toContain('General');
+    expect(names).not.toContain('Security');
+  });
+
+  it('recurses into a plain sidebar grouping and surfaces each child', () => {
+    // "Form" has no index child, so it is a grouping — each child is its own
+    // demo rather than being collapsed away.
+    const names = examplePages().map(page => page.name);
+    expect(names).not.toContain('Form');
+    expect(names).toContain('Event Form');
+    expect(names).toContain('Settings Form');
+    expect(names).toContain('Auto-Save Settings');
+  });
+
+  it('skips non-route nodes (GroupLabel, Separator)', () => {
+    const names = examplePages().map(page => page.name);
+    // "Settings" is a GroupLabel inside App Shell, not a route.
+    expect(names).not.toContain('Settings');
+  });
+});

--- a/docs/app/(examples)/examples/navigation.tsx
+++ b/docs/app/(examples)/examples/navigation.tsx
@@ -1,5 +1,5 @@
 import { people } from '@/lib/data/people';
-import type { NavSection, ShellConfig } from '../_shared';
+import type { NavNode, NavSection, ShellConfig } from '../_shared';
 
 const appShellDocs = {
   docsHref: '/patterns/layout/app-frame',
@@ -99,3 +99,35 @@ export const config: ShellConfig = {
   // Label the dynamic `users/[id]` segment with the member's name.
   resolveLabel: id => people.find(person => person.id === id)?.name,
 };
+
+// Flatten the nav tree into the set of *standalone* example demos for the docs
+// cmdk search. Only standalone demos are surfaced — not the internal screens of
+// a larger demo. GroupLabels and Separators are not routes, so we skip them.
+//
+// A group with an index child (empty slug) is a single self-contained app
+// (e.g. "App Shell", whose Users/Billing/… screens are internal navigation, not
+// standalone examples): we collapse it to one entry pointing at its landing. A
+// group without an index is just a sidebar grouping (e.g. "Form"), so we recurse
+// and surface each child as its own demo.
+const collectDemos = (
+  items: NavNode[],
+  base: string
+): { name: string; url: string }[] =>
+  items.flatMap(item => {
+    if (item.kind !== 'Item') return [];
+    if (item.children) {
+      const isSelfContainedApp = item.children.some(
+        child => child.kind === 'Item' && !child.children && child.slug === ''
+      );
+      return isSelfContainedApp
+        ? [{ name: item.label, url: base }]
+        : collectDemos(item.children, base);
+    }
+    return [
+      { name: item.label, url: item.slug ? `${base}/${item.slug}` : base },
+    ];
+  });
+
+/** All standalone example demos as `{ name, url }` entries from the nav config. */
+export const examplePages = (): { name: string; url: string }[] =>
+  config.sections.flatMap(section => collectDemos(section.items, config.base));

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -4,8 +4,9 @@ import { flattenTree } from 'fumadocs-core/page-tree';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { Inter } from 'next/font/google';
+import { examplePages } from './(examples)/examples/navigation';
 import './global.css';
-import { Providers } from './providers';
+import { type PageEntry, Providers } from './providers';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -31,18 +32,23 @@ export const metadata: Metadata = {
 // Layout
 // ---------------
 const Layout = ({ children }: LayoutProps<'/'>) => {
+  const docsPages: PageEntry[] = flattenTree(source.pageTree.children)
+    .filter(
+      (item): item is typeof item & { name: string } =>
+        typeof item.name === 'string'
+    )
+    .map(item => ({ name: item.name, url: item.url, kind: 'doc' }));
+
+  const exampleEntries: PageEntry[] = examplePages().map(page => ({
+    ...page,
+    kind: 'example',
+  }));
+
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
         <Suspense>
-          <Providers
-            pages={flattenTree(source.pageTree.children)
-              .filter(
-                (item): item is typeof item & { name: string } =>
-                  typeof item.name === 'string'
-              )
-              .map(item => ({ name: item.name, url: item.url }))}
-          >
+          <Providers pages={[...docsPages, ...exampleEntries]}>
             {children}
           </Providers>
           <div id="portalContainer" data-theme="rui" className="not-prose" />

--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -9,6 +9,8 @@ const SearchDialog = dynamic(() => import('@/ui/SearchDialog'));
 export interface PageEntry {
   name: string;
   url: string;
+  /** Distinguishes docs pages from interactive example apps in the cmdk search. */
+  kind?: 'doc' | 'example';
 }
 
 const PagesContext = createContext<PageEntry[]>([]);

--- a/docs/ui/SearchDialog.tsx
+++ b/docs/ui/SearchDialog.tsx
@@ -16,7 +16,7 @@ import {
   type SearchItemType,
   type SharedProps,
 } from 'fumadocs-ui/components/dialog/search';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, LayoutDashboard } from 'lucide-react';
 import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 
@@ -29,24 +29,35 @@ export default function CustomSearchDialog(props: SharedProps) {
     if (search.length === 0) return [];
 
     const normalized = search.toLowerCase();
-    const matches = pages.filter(p =>
-      p.name.toLowerCase().includes(normalized)
+    const matches = pages.filter(
+      p =>
+        p.name.toLowerCase().includes(normalized) ||
+        // Let users surface every example app by typing "example(s)" (or any
+        // substring of it), since the page names themselves don't contain it.
+        (p.kind === 'example' && 'examples'.includes(normalized))
     );
 
-    return matches.map((match, i) => ({
-      id: `quick-action-${i}`,
-      type: 'action' as const,
-      node: (
-        <div className="text-fd-muted-foreground flex h-full items-center gap-2">
-          <ArrowRight className="size-4" />
-          <p>
-            Jump to{' '}
-            <span className="text-fd-foreground font-medium">{match.name}</span>
-          </p>
-        </div>
-      ),
-      onSelect: () => router.push(match.url),
-    }));
+    return matches.map((match, i) => {
+      const isExample = match.kind === 'example';
+      const Icon = isExample ? LayoutDashboard : ArrowRight;
+
+      return {
+        id: `quick-action-${i}`,
+        type: 'action' as const,
+        node: (
+          <div className="text-fd-muted-foreground flex h-full items-center gap-2">
+            <Icon className="size-4" />
+            <p>
+              {isExample ? 'Example:' : 'Jump to'}{' '}
+              <span className="text-fd-foreground font-medium">
+                {match.name}
+              </span>
+            </p>
+          </div>
+        ),
+        onSelect: () => router.push(match.url),
+      };
+    });
   }, [router, search, pages]);
 
   const items = useMemo(() => {


### PR DESCRIPTION
# Description

The interactive example demos under `docs/app/(examples)/` were not discoverable from the docs ⌘K command menu — the fumadocs content index only covers MDX docs, and the "Jump to …" quick actions were built solely from the docs page tree.

This flattens the `(examples)` navigation config into the existing `PagesContext` quick-action path, so example demos now appear in the cmdk search:

- They show as **`Example: …`** quick actions (distinct icon/label from the docs `Jump to`).
- They match by name **or** by typing `example` (or any substring of it).
- Only **standalone demos** are surfaced. A self-contained app (App Shell) collapses to a single entry; its internal screens (Billing, Users, Teams, …) are intentionally not listed as separate examples. Pure sidebar groupings (Form) expand to their individual demos.

Resulting entries: App Shell, Filter, Event Form, Settings Form, Auto-Save Settings, Inventory.

Closes DST-1574

## Preview

Verified in-browser against the running docs app: searching `example`, an example name (e.g. `filter`), or `app shell` surfaces the demos and navigates correctly (e.g. `Example: App Shell` → `/examples`). No empty/internal entries (Billing, Users, …) appear.

## Test Instructions

1. Run `pnpm start` and open [localhost:3000](http://localhost:3000).
2. Open the search dialog (⌘K / click **Search**).
3. Type `example` — confirm the six standalone demos appear as `Example: …` actions.
4. Type `app shell` — confirm `Example: App Shell` appears and selecting it navigates to `/examples`.
5. Type `billing` — confirm no `Example:` entry appears (it's an App Shell internal screen, only the docs result remains).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no component/theme changes
- [x] Changeset added (`pnpm changeset`)