### PR TITLE
ci: forward-port vitest browser-mode dep-race fix to main

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,10 @@ import { playwright } from '@vitest/browser-playwright';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import configShared, { browserDeps } from './vitest.config.shared.js';
+import configShared, {
+  browserDeps,
+  browserScanEntries,
+} from './vitest.config.shared.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -15,6 +18,7 @@ export default mergeConfig(
     plugins: [react(), tailwindcss()],
     optimizeDeps: {
       include: browserDeps,
+      entries: browserScanEntries,
     },
     resolve: {
       // Force a single copy of React/React DOM across all entry points so a
@@ -41,6 +45,7 @@ export default mergeConfig(
           },
           optimizeDeps: {
             include: browserDeps,
+            entries: browserScanEntries,
           },
           test: {
             name: 'unit-tests',
@@ -92,6 +97,7 @@ export default mergeConfig(
           },
           optimizeDeps: {
             include: browserDeps,
+            entries: browserScanEntries,
           },
           test: {
             name: 'storybook-tests',

--- a/vitest.config.shared.ts
+++ b/vitest.config.shared.ts
@@ -1,12 +1,21 @@
 import { defineConfig } from 'vitest/config';
 
 /**
- * Deps that must be pre-bundled for browser-mode vitest projects.
+ * Root-level deps that must be pre-bundled for browser-mode vitest projects.
  *
  * Without pre-bundling, Vite discovers these deps at runtime and triggers
  * on-demand optimization, which races with concurrent browser test execution
  * in CI (cold cache, constrained resources) and produces:
  *   `TypeError: error loading dynamically imported module`
+ *
+ * IMPORTANT: only list deps that resolve from the MONOREPO ROOT here.
+ * `optimizeDeps.include` is resolved from the Vite root (this repo root), so
+ * packages installed under a workspace (e.g. react-aria-components and
+ * `@react-aria/*`, which live under packages/components in this pnpm repo) are
+ * NOT resolvable here — listing them only emits "Failed to resolve dependency"
+ * warnings and does nothing. Those workspace-nested deps are instead crawled
+ * up front via `optimizeDeps.entries` (see vite.config.ts), which resolves
+ * imports from each source file's own location.
  *
  * Keep this list next to the coverage config so adding a provider
  * doesn't silently break projects that override `optimizeDeps`.
@@ -32,12 +41,25 @@ export const browserDeps = [
   // surfacing as `resolveDispatcher() is null` during renderToString/hydrateRoot.
   'react-dom/server',
   'react-dom/client',
-  // RAC subpath import used in stories/tests (see DST-1512). Without
-  // pre-bundling, the unit-tests project discovers it at runtime and
-  // re-optimizes mid-run, cascading "error loading dynamically imported module".
-  'react-aria-components/I18nProvider',
   // Test setup (extends expect at module load time)
   '@testing-library/jest-dom/vitest',
+];
+
+/**
+ * Glob of entry files Vite's dep scanner crawls before serving, so the FULL
+ * import graph (all `react-aria-components/<Subpath>` and `@react-aria/*` deps,
+ * which are workspace-nested and therefore NOT listable in `optimizeDeps.include`
+ * — see browserDeps above) is discovered and pre-bundled in a single pass up
+ * front. This is what actually prevents the mid-run re-optimization race that
+ * surfaces as `error loading dynamically imported module` (the DateField ->
+ * `useButton` CI flake): unlike `include`, the scanner resolves each import from
+ * its own file location, so workspace deps resolve correctly.
+ *
+ * Covers test + story files (the browser-mode entry points) across all packages;
+ * their transitive source imports are followed automatically by the scanner.
+ */
+export const browserScanEntries = [
+  'packages/*/src/**/*.{test,stories}.{ts,tsx}',
 ];
 
 const exclude = [


### PR DESCRIPTION
# Description

Forward-ports the vitest browser-mode **dep-race fix** from `beta-release` (#5565) to `main`.

CI's browser-mode vitest discovered `react-aria-components/*` subpath imports and bare `@react-aria/*` packages **at runtime**, triggering mid-run Vite dep re-optimization that invalidated in-flight dynamic imports — surfacing as:

```
TypeError: error loading dynamically imported module: .../@vitest/coverage-istanbul?import
```

This flake fails **Unit Tests** on essentially every PR cut from `main` (e.g. #5575, the DateRangePicker backport). The fix already lives on `beta-release` (merged in #5565) but was never brought back to `main`, so the bug persists on the trunk.

## What changed

- `vitest.config.shared.ts`: drop the no-op `react-aria-components/I18nProvider` `include` entry (workspace-nested deps don't resolve from the repo root, so `optimizeDeps.include` can't reach them); add `browserScanEntries` — a glob over all `packages/*/src/**/*.{test,stories}.{ts,tsx}` entry files.
- `vite.config.ts`: wire `entries: browserScanEntries` into all three `optimizeDeps` blocks (root, `unit-tests`, `storybook-tests`).

The dep scanner crawls those entry files up front and resolves each import from its own file location, so the full react-aria graph is discovered and pre-bundled in a **single pass before any test runs** — which is what actually prevents the mid-run re-optimization race.

This is byte-identical to PR #5565's change (the unrelated `**/icons/**` exclude removal from that branch was deliberately excluded).

## Verification

Cold cache (`rm -rf node_modules/.vite/vitest`), then ran browser-mode unit tests:

- Single optimization pass (`scanning…` → `bundling…`), **no** "Vite unexpectedly reloaded a test", **no** dynamic-import error.
- `DateField` unit tests: **21/21 passed**.

## Type of change

- [x] CI / build configuration

## Checklist

- [x] No changeset needed — CI-config only, no shipped code changes (matches #5565)
- [x] Verified locally on a cold cache
