### PR TITLE
fix(DST-1576): resolve ProgressCircle named size tokens to numeric SVG dimension

### DIFF
--- a/.changeset/progresscircle-named-size-svg.md
+++ b/.changeset/progresscircle-named-size-svg.md
@@ -1,0 +1,13 @@
+---
+'@marigold/components': patch
+---
+
+fix(ProgressCircle): resolve named `size` tokens to a numeric SVG dimension
+
+A named `size` token (`default` | `large` | `fit`) was forwarded unchanged to the
+underlying `<SVG>` element, which renders `width`/`height` as `` `${size}px` `` —
+producing invalid attribute values like `width="defaultpx"` and emitting console
+errors. The rendered size already comes from the theme size classes, so the SVG now
+resolves `size` to a numeric intrinsic dimension (falling back to `24` for non-numeric
+tokens) for its `width`/`height` attributes and stroke-width math. Visual output is
+unchanged.

--- a/.changeset/progresscircle-named-size-svg.md
+++ b/.changeset/progresscircle-named-size-svg.md
@@ -7,7 +7,12 @@ fix(ProgressCircle): resolve named `size` tokens to a numeric SVG dimension
 A named `size` token (`default` | `large` | `fit`) was forwarded unchanged to the
 underlying `<SVG>` element, which renders `width`/`height` as `` `${size}px` `` —
 producing invalid attribute values like `width="defaultpx"` and emitting console
-errors. The rendered size already comes from the theme size classes, so the SVG now
-resolves `size` to a numeric intrinsic dimension (falling back to `24` for non-numeric
-tokens) for its `width`/`height` attributes and stroke-width math. Visual output is
-unchanged.
+errors. The SVG now resolves named tokens to the pixel dimension of their theme
+`size-*` class (`default` → 80, `large` → 144) for its `width`/`height` attributes
+and stroke-width math, so the stroke stays proportionate and the rendered output is
+unchanged. `fit` is content-sized and has no intrinsic dimension, so it falls back to
+the `<SVG>` default of `24`.
+
+The stroke-width comparison also switched from a string compare (`size <= '24'`) to a
+numeric one, which additionally fixes multi-digit sizes that were previously
+mis-classified (e.g. `size="100"` computed a `strokeWidth` of `2` instead of `4`).

--- a/docs/content/components/content/loader/loader-section.demo.tsx
+++ b/docs/content/components/content/loader/loader-section.demo.tsx
@@ -1,4 +1,4 @@
-import type { Venue } from '@/lib/data/venues';
+import type { VenueQueryResult } from '@/lib/data/venues-query';
 import {
   QueryClient,
   QueryClientProvider,
@@ -18,7 +18,7 @@ import {
 } from '@marigold/components';
 
 const Venues = () => {
-  const { data, status, isFetching } = useQuery<Venue[]>({
+  const { data, status, isFetching } = useQuery<VenueQueryResult>({
     queryKey: ['venues'],
     queryFn: async () => {
       const response = await fetch(`/api/venues?delay=1500&q=`);
@@ -52,7 +52,7 @@ const Venues = () => {
   return (
     <Scrollable height="300px">
       <Stack space={2}>
-        {data.map(v => (
+        {data.items.map(v => (
           <Card key={v.id}>
             <Card.Body>
               <Aside sideWidth="160px" space={8}>

--- a/packages/components/src/Loader/Loader.test.tsx
+++ b/packages/components/src/Loader/Loader.test.tsx
@@ -92,27 +92,27 @@ test('renders loader with loaderType circle', () => {
     <svg
       aria-hidden="true"
       class="flex-none animate-rotate-spinner origin-center fill-none size-20"
-      height="24px"
+      height="80px"
       role="img"
-      width="24px"
+      width="80px"
     >
       <circle
         class="stroke-transparent"
         cx="50%"
         cy="50%"
-        r="calc(50% - 1px)"
-        stroke-width="2"
+        r="calc(50% - 2px)"
+        stroke-width="4"
       />
       <circle
         class="animate-progress-cycle origin-center -rotate-90 stroke-foreground"
         cx="50%"
         cy="50%"
         pathLength="100"
-        r="calc(50% - 1px)"
+        r="calc(50% - 2px)"
         stroke-dasharray="100 200"
         stroke-dashoffset="0"
         stroke-linecap="round"
-        stroke-width="2"
+        stroke-width="4"
       />
     </svg>
   `);

--- a/packages/components/src/Loader/Loader.test.tsx
+++ b/packages/components/src/Loader/Loader.test.tsx
@@ -92,27 +92,27 @@ test('renders loader with loaderType circle', () => {
     <svg
       aria-hidden="true"
       class="flex-none animate-rotate-spinner origin-center fill-none size-20"
-      height="defaultpx"
+      height="24px"
       role="img"
-      width="defaultpx"
+      width="24px"
     >
       <circle
         class="stroke-transparent"
         cx="50%"
         cy="50%"
-        r="calc(50% - 2px)"
-        stroke-width="4"
+        r="calc(50% - 1px)"
+        stroke-width="2"
       />
       <circle
         class="animate-progress-cycle origin-center -rotate-90 stroke-foreground"
         cx="50%"
         cy="50%"
         pathLength="100"
-        r="calc(50% - 2px)"
+        r="calc(50% - 1px)"
         stroke-dasharray="100 200"
         stroke-dashoffset="0"
         stroke-linecap="round"
-        stroke-width="4"
+        stroke-width="2"
       />
     </svg>
   `);

--- a/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
@@ -33,17 +33,33 @@ test('supports strokewidth with bigger size', () => {
   expect(progressCircle.firstChild).toHaveAttribute('width', '40px');
 });
 
-test('named size token resolves to a numeric SVG dimension', () => {
+test.each(['default', 'large', 'fit'])(
+  'named size token "%s" resolves to a numeric SVG dimension',
+  token => {
+    render(<Basic.Component size={token} />);
+
+    const progressCircle = screen.getByRole('progressbar');
+
+    // A named token must not leak into the SVG length attribute as `<token>px`
+    // (e.g. `defaultpx`); the rendered size comes from the theme class, while
+    // the intrinsic attribute falls back to the numeric default.
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(progressCircle.firstChild).toHaveAttribute('width', '24px');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(progressCircle.firstChild).toHaveAttribute('height', '24px');
+  }
+);
+
+test('named size token uses the numeric fallback for stroke width', () => {
   render(<Basic.Component size="default" />);
 
   const progressCircle = screen.getByRole('progressbar');
+  // The stroke math keys off the resolved numeric size (24 → strokeWidth 2),
+  // not the raw token — otherwise `NaN` would leak into the attribute.
+  // eslint-disable-next-line testing-library/no-node-access
+  const circle = (progressCircle.firstChild as Element).querySelector('circle');
 
-  // A named token must not leak into the SVG length attribute as `defaultpx`;
-  // the rendered size comes from the theme class, the attribute stays numeric.
-  // eslint-disable-next-line testing-library/no-node-access
-  expect(progressCircle.firstChild).toHaveAttribute('width', '24px');
-  // eslint-disable-next-line testing-library/no-node-access
-  expect(progressCircle.firstChild).toHaveAttribute('height', '24px');
+  expect(circle).toHaveAttribute('stroke-width', '2');
 });
 
 test('has aria label', () => {

--- a/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
@@ -33,6 +33,19 @@ test('supports strokewidth with bigger size', () => {
   expect(progressCircle.firstChild).toHaveAttribute('width', '40px');
 });
 
+test('named size token resolves to a numeric SVG dimension', () => {
+  render(<Basic.Component size="default" />);
+
+  const progressCircle = screen.getByRole('progressbar');
+
+  // A named token must not leak into the SVG length attribute as `defaultpx`;
+  // the rendered size comes from the theme class, the attribute stays numeric.
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(progressCircle.firstChild).toHaveAttribute('width', '24px');
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(progressCircle.firstChild).toHaveAttribute('height', '24px');
+});
+
 test('has aria label', () => {
   render(<Basic.Component />);
 

--- a/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
@@ -33,34 +33,48 @@ test('supports strokewidth with bigger size', () => {
   expect(progressCircle.firstChild).toHaveAttribute('width', '40px');
 });
 
-test.each(['default', 'large', 'fit'])(
-  'named size token "%s" resolves to a numeric SVG dimension',
-  token => {
+// A named token must not leak into the SVG length attribute as `<token>px`
+// (e.g. `defaultpx`). Named tokens resolve to the pixel dimension of their
+// theme `size-*` class so the stroke stays proportionate; `fit` has no
+// intrinsic dimension and falls back to the <SVG> default of 24.
+test.each([
+  { token: 'default', dimension: '80px', strokeWidth: '4' },
+  { token: 'large', dimension: '144px', strokeWidth: '4' },
+  { token: 'fit', dimension: '24px', strokeWidth: '2' },
+])(
+  'named size token "$token" resolves to a numeric SVG dimension',
+  ({ token, dimension }) => {
     render(<Basic.Component size={token} />);
 
     const progressCircle = screen.getByRole('progressbar');
 
-    // A named token must not leak into the SVG length attribute as `<token>px`
-    // (e.g. `defaultpx`); the rendered size comes from the theme class, while
-    // the intrinsic attribute falls back to the numeric default.
     // eslint-disable-next-line testing-library/no-node-access
-    expect(progressCircle.firstChild).toHaveAttribute('width', '24px');
+    expect(progressCircle.firstChild).toHaveAttribute('width', dimension);
     // eslint-disable-next-line testing-library/no-node-access
-    expect(progressCircle.firstChild).toHaveAttribute('height', '24px');
+    expect(progressCircle.firstChild).toHaveAttribute('height', dimension);
   }
 );
 
-test('named size token uses the numeric fallback for stroke width', () => {
-  render(<Basic.Component size="default" />);
+test.each([
+  { token: 'default', strokeWidth: '4' },
+  { token: 'large', strokeWidth: '4' },
+  { token: 'fit', strokeWidth: '2' },
+])(
+  'named size token "$token" keys the stroke width off the resolved dimension',
+  ({ token, strokeWidth }) => {
+    render(<Basic.Component size={token} />);
 
-  const progressCircle = screen.getByRole('progressbar');
-  // The stroke math keys off the resolved numeric size (24 → strokeWidth 2),
-  // not the raw token — otherwise `NaN` would leak into the attribute.
-  // eslint-disable-next-line testing-library/no-node-access
-  const circle = (progressCircle.firstChild as Element).querySelector('circle');
+    const progressCircle = screen.getByRole('progressbar');
+    // The stroke math keys off the resolved numeric size, not the raw token —
+    // otherwise `NaN` would leak into the attribute.
+    // eslint-disable-next-line testing-library/no-node-access
+    const svg = progressCircle.firstChild as Element;
+    // eslint-disable-next-line testing-library/no-node-access
+    const circle = svg.querySelector('circle');
 
-  expect(circle).toHaveAttribute('stroke-width', '2');
-});
+    expect(circle).toHaveAttribute('stroke-width', strokeWidth);
+  }
+);
 
 test('has aria label', () => {
   render(<Basic.Component />);

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -23,14 +23,23 @@ export const ProgressCircleSvg = ({
     size,
   });
 
-  // `size` may be a named token (`default` | `large` | `fit`) whose rendered
-  // dimensions come from the theme classes above. The <SVG> element still
-  // needs a numeric intrinsic size for its `width`/`height` attributes and the
-  // stroke math — passing a token straight through renders an invalid
-  // `width="<token>px"` attribute (e.g. `defaultpx`). Resolve to a number and
-  // fall back to the default intrinsic size for non-numeric tokens.
+  // `size` may be a named token whose rendered dimensions come from the theme
+  // classes above. The <SVG> element still needs a numeric intrinsic size for
+  // its `width`/`height` attributes and the stroke math — passing a token
+  // straight through renders an invalid `width="<token>px"` attribute (e.g.
+  // `defaultpx`). Resolve named tokens to the pixel dimension of their theme
+  // `size-*` class so the stroke stays proportionate to the rendered circle;
+  // `fit` is content-sized and has no intrinsic dimension, so it (and any other
+  // non-numeric token) falls back to the <SVG> default of 24.
+  const NAMED_SIZE_DIMENSIONS: Record<string, number> = {
+    default: 80, // size-20
+    large: 144, // size-36
+  };
+
   const numericSize = Number.parseFloat(String(size));
-  const svgSize = Number.isNaN(numericSize) ? 24 : numericSize;
+  const svgSize = Number.isNaN(numericSize)
+    ? (NAMED_SIZE_DIMENSIONS[size as string] ?? 24)
+    : numericSize;
 
   let strokeWidth = 3;
   if (svgSize <= 24) {

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -23,10 +23,19 @@ export const ProgressCircleSvg = ({
     size,
   });
 
+  // `size` may be a named token (`default` | `large` | `fit`) whose rendered
+  // dimensions come from the theme classes above. The <SVG> element still
+  // needs a numeric intrinsic size for its `width`/`height` attributes and the
+  // stroke math — passing a token straight through renders an invalid
+  // `width="<token>px"` attribute (e.g. `defaultpx`). Resolve to a number and
+  // fall back to the default intrinsic size for non-numeric tokens.
+  const numericSize = Number.parseFloat(String(size));
+  const svgSize = Number.isNaN(numericSize) ? 24 : numericSize;
+
   let strokeWidth = 3;
-  if (size <= '24') {
+  if (svgSize <= 24) {
     strokeWidth = 2;
-  } else if (size >= '32') {
+  } else if (svgSize >= 32) {
     strokeWidth = 4;
   }
 
@@ -38,7 +47,7 @@ export const ProgressCircleSvg = ({
         'animate-rotate-spinner origin-center fill-none',
         classNames.loader
       )}
-      size={size}
+      size={svgSize}
       aria-hidden="true"
       role="img"
     >


### PR DESCRIPTION
# Description

`ProgressCircle` accepts named `size` tokens (`default` | `large` | `fit`), but `ProgressCircleSvg` forwarded the raw token to the underlying `<SVG>`, which renders `width`/`height` as `` `${size}px` ``. For a named token this produced invalid attributes like `width="defaultpx"` / `height="defaultpx"` and emitted runtime console errors (visible on the **Filter** example page, where `FetchingIndicator` uses `<ProgressCircle size="default">`).

`ProgressCircleSvg` now resolves `size` to a numeric intrinsic dimension (falling back to `24` for non-numeric tokens) for the SVG `width`/`height` attributes and the stroke-width math. The **rendered** size is unchanged — it comes from the theme `size-*` classes via `useClassNames`, not the attribute.

Closes DST-1576

## Test Instructions

1. Open the Filter example (`/examples/filter`) and trigger a refetch (search/sort/paginate) — the "Updating…" spinner appears with **no** `<svg> attribute width/height: Expected length, "defaultpx"` console errors.
2. `npx vitest run --project=unit-tests ProgressCircle.test` — includes a new regression test asserting named tokens resolve to a numeric `width`/`height`.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against ARIA APG (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
