### PR TITLE
feat(DST-1578): make Analytics example genuinely analytical

### DIFF
--- a/docs/app/(examples)/examples/analytics/page.tsx
+++ b/docs/app/(examples)/examples/analytics/page.tsx
@@ -2,7 +2,6 @@
 
 import { venues } from '@/lib/data/venues';
 import {
-  Badge,
   Card,
   Columns,
   Description,
@@ -21,6 +20,31 @@ const stats = [
   { label: 'Avg. rating', value: '4.6', hint: 'across 1,200 reviews' },
   { label: 'Refund rate', value: '1.2%', hint: '-0.3pt vs last month' },
 ];
+
+// Tickets sold per venue for the reporting period, keyed by venue id. This is
+// the metric the "Top venues" ranking is built on — keying by id keeps the
+// ranking correct if the underlying dataset changes.
+const ticketsSoldByVenue: Record<string, number> = {
+  '1': 4120,
+  '2': 1860,
+  '3': 920,
+  '4': 5240,
+  '5': 2670,
+  '6': 3480,
+  '7': 1530,
+  '8': 2090,
+  '9': 760,
+  '10': 4480,
+};
+
+// Highest-grossing venues this period: attach the metric, rank by it, take the top 6.
+const topVenues = venues
+  .map(venue => ({
+    ...venue,
+    ticketsSold: ticketsSoldByVenue[venue.id] ?? 0,
+  }))
+  .sort((a, b) => b.ticketsSold - a.ticketsSold)
+  .slice(0, 6);
 
 const sources = [
   { id: 's1', source: 'Direct', sessions: '18,440', share: '38%' },
@@ -59,7 +83,9 @@ const AnalyticsPage = () => (
   <Page>
     <Page.Header>
       <Title>Analytics</Title>
-      <Description>Trends, breakdowns, and reports.</Description>
+      <Description>
+        Sessions, top venues, and traffic sources for June 2026.
+      </Description>
     </Page.Header>
 
     <Tiles stretch equalHeight tilesWidth="14rem" space="regular">
@@ -72,27 +98,25 @@ const AnalyticsPage = () => (
       <Panel>
         <Panel.Header>
           <Title>Top venues</Title>
-          <Description>Largest venues by capacity.</Description>
+          <Description>Ranked by tickets sold this month.</Description>
         </Panel.Header>
         <Panel.Content bleed>
-          <Table aria-label="Top venues">
+          <Table aria-label="Top venues by tickets sold">
             <Table.Header>
               <Table.Column rowHeader>Venue</Table.Column>
               <Table.Column>City</Table.Column>
-              <Table.Column alignX="right">Capacity</Table.Column>
+              <Table.Column alignX="right">Tickets sold</Table.Column>
               <Table.Column alignX="right">Rating</Table.Column>
             </Table.Header>
             <Table.Body>
-              {venues.slice(0, 6).map(venue => (
+              {topVenues.map(venue => (
                 <Table.Row key={venue.id}>
                   <Table.Cell>{venue.name}</Table.Cell>
                   <Table.Cell>{venue.city}</Table.Cell>
                   <Table.Cell alignX="right">
-                    {venue.capacity.toLocaleString()}
+                    {venue.ticketsSold.toLocaleString()}
                   </Table.Cell>
-                  <Table.Cell alignX="right">
-                    <Badge variant="info">{`★ ${venue.rating}`}</Badge>
-                  </Table.Cell>
+                  <Table.Cell alignX="right">{`★ ${venue.rating}`}</Table.Cell>
                 </Table.Row>
               ))}
             </Table.Body>


### PR DESCRIPTION
# Description

The **Analytics** example was clean but conceptually hollow — it promised "Trends, breakdowns, and reports" and delivered four static stat tiles plus a "Top venues" table mislabeled "Largest venues by capacity" whose rows weren't even capacity-sorted, with `variant="info"` (blue) on every rating badge (decoration, not meaning).

This makes the page read as real analytics, using only shipped Marigold components:

- **Time anchor** — the subtitle now reads "Sessions, top venues, and traffic sources for **June 2026**", so the numbers are verifiable against a period.
- **A real ranking** — the venues table gains a **Tickets sold** metric (page-local demo data, keyed by venue id), is **sorted by it descending**, and the panel reads "Ranked by tickets sold this month." The non-analytical Capacity column is dropped, which also removes the label/sort mismatch.
- **Color = meaning** — ratings render as plain `★ 4.7` text instead of a blue `info` Badge. Ratings are data, not status.

Closes DST-1578

## Screenshots / Preview

Open `/examples/analytics`: the Top venues table is ranked 5,240 → 2,090 tickets, ratings are plain stars, and the subtitle names the period.

## Test Instructions

1. Run the docs app, open `/examples/analytics`.
2. Confirm the **Top venues** panel says "Ranked by tickets sold this month" and rows descend by the Tickets sold column.
3. Confirm ratings render as `★ <n>` plain text (no blue badge), and the page subtitle names "June 2026".

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against ARIA APG (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added — N/A (docs-only example, `@marigold/docs` is not published)
