### PR TITLE
fix(DST-1579): tidy Filter toolbar — hide empty applied-filters, right-size spinner

### DIFF
--- a/docs/app/(examples)/examples/filter/AppliedFilter.tsx
+++ b/docs/app/(examples)/examples/filter/AppliedFilter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { Tag, Text } from '@marigold/components';
+import { Tag } from '@marigold/components';
 import { NumericFormat } from '@marigold/system';
 import {
   type FilterKeys,
@@ -47,6 +47,13 @@ const getLabel = (filter: VenueFilter, key: FilterKeys): ReactNode => {
 
 export const AppliedFilter = () => {
   const { filter, removeFilter, activeFilterKeys } = useFilter();
+  const activeKeys = activeFilterKeys();
+
+  // Nothing to show at rest (the default, no-filter state) — render nothing
+  // rather than a permanent "None" row of dead space.
+  if (activeKeys.length === 0) {
+    return null;
+  }
 
   return (
     <Tag.Group
@@ -55,13 +62,8 @@ export const AppliedFilter = () => {
       // every Tag.id below is a FilterKey, so the narrower cast is safe.
       onRemove={keys => removeFilter(keys as Set<FilterKeys>)}
       removeAll
-      emptyState={() => (
-        <Text variant="muted" fontSize="sm" fontStyle="italic">
-          None
-        </Text>
-      )}
     >
-      {activeFilterKeys().map(name => (
+      {activeKeys.map(name => (
         <Tag id={name} key={name}>
           {getLabel(filter, name)}
         </Tag>

--- a/docs/app/(examples)/examples/filter/FetchingIndicator.tsx
+++ b/docs/app/(examples)/examples/filter/FetchingIndicator.tsx
@@ -15,7 +15,7 @@ export const FetchingIndicator = () => {
 
   return (
     <Inline space={1} alignY="center" aria-hidden>
-      <ProgressCircle size="default" isIndeterminate aria-label="Updating" />
+      <ProgressCircle size="16" isIndeterminate aria-label="Updating" />
       <Text fontSize="sm" variant="muted">
         Updating…
       </Text>


### PR DESCRIPTION
# Description

Two small craft fixes on the **Filter** example toolbar:

- **`AppliedFilter` renders `null` when no filters are active.** Previously it always showed an "Applied Filters / None" block — a full-width row of dead space on every fresh visit (the default state), training users to ignore the region. It now appears only once filters are applied.
- **`FetchingIndicator` uses a small `ProgressCircle size="16"`** instead of `size="default"` (which maps to the ~80px `size-20` class) so the inline "Updating…" indicator is appropriately sized.

The fetching indicator stays `aria-hidden` on purpose: `VenuesTable` already exposes a `role="status"` live region announcing result counts, so the visual spinner doesn't need to double-announce.

Closes DST-1579

## Test Instructions

1. Open `/examples/filter` with no filters applied — there is **no** "Applied Filters / None" row; the table sits directly under the toolbar.
2. Apply a filter via the Filter drawer — the applied-filter chips now appear.
3. Trigger a refetch (search/sort/paginate) — the "Updating…" spinner is a small inline indicator.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against ARIA APG (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added — N/A (docs-only example, `@marigold/docs` is not published)
