### PR TITLE
refactor(DST-1585): drive SegmentedControl reduced-motion scroll from CSS

### DIFF
--- a/.changeset/dst-1585-segmented-control-reduced-motion.md
+++ b/.changeset/dst-1585-segmented-control-reduced-motion.md
@@ -1,0 +1,14 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+---
+
+refactor(DST-1585): drive SegmentedControl's reduced-motion scroll from CSS
+
+SegmentedControl now gates its selection-reveal scroll animation with the same
+CSS approach as Tabs: the scroll container carries `motion-safe:scroll-smooth`
+and the component's `scrollTo` uses `behavior: 'auto'`, which follows that CSS —
+animating when motion is allowed and jumping instantly under reduced motion.
+This replaces the previous JS `window.matchMedia('(prefers-reduced-motion)')`
+check. Behavior is unchanged; the initial mount reveal stays instant. No API
+change.

--- a/packages/components/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControl.tsx
@@ -129,11 +129,12 @@ function SegmentedControlBase({
 
   // Store the scroll container and reveal the initially selected option as soon
   // as it mounts — a ref callback instead of an effect (it runs once the node
-  // and its options are in the DOM, with no extra render).
+  // and its options are in the DOM, with no extra render). The first paint must
+  // never animate, so this reveal is `'instant'` regardless of motion settings.
   const attachScrollContainer = useCallback(
     (node: HTMLDivElement | null) => {
       scrollRef.current = node;
-      if (node) scrollSelectedIntoView('auto');
+      if (node) scrollSelectedIntoView('instant');
     },
     [scrollSelectedIntoView]
   );
@@ -141,13 +142,11 @@ function SegmentedControlBase({
   const handleChange = (value: string) => {
     onChange?.(value);
 
-    const reduced =
-      typeof window !== 'undefined' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-    requestAnimationFrame(() =>
-      scrollSelectedIntoView(reduced ? 'auto' : 'smooth')
-    );
+    // Defer to the next frame so the newly-selected option's geometry has
+    // settled, then reveal it. `behavior: 'auto'` follows the container's CSS
+    // `scroll-behavior` (`motion-safe:scroll-smooth`), so it animates when
+    // motion is allowed and jumps under reduced motion — no JS media query.
+    requestAnimationFrame(() => scrollSelectedIntoView('auto'));
   };
 
   const props: RAC.RadioGroupProps = {

--- a/themes/theme-rui/src/components/SegmentedControl.styles.ts
+++ b/themes/theme-rui/src/components/SegmentedControl.styles.ts
@@ -33,8 +33,12 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
   //     from the track edge. We accept that the inset focus ring is clipped ~1px
   //     at the very first/last segment's outer edge — a minor cosmetic trim that
   //     keeps the scroller exactly the track width.
+  //   - `motion-safe:scroll-smooth` makes the selection-reveal scroll animate
+  //     for users who allow motion and jump instantly for those who don't; the
+  //     component's `scrollTo` defers to it via `behavior: 'auto'`, so no JS
+  //     media query is needed (matches Tabs' `tabsListScroll`).
   list: cva({
-    base: 'flex w-full items-center ui-scroll-mask-x py-1 -my-1',
+    base: 'flex w-full items-center ui-scroll-mask-x py-1 -my-1 motion-safe:scroll-smooth',
     variants: {
       variant: {
         default: 'gap-0',


### PR DESCRIPTION
# Description

Closes DST-1585.

SegmentedControl already solved the same horizontal-overflow-scroll problem as Tabs, but it gated its selection-reveal scroll animation in JS (`window.matchMedia('(prefers-reduced-motion: reduce)')` + `requestAnimationFrame`). The Tabs overflow work uses a cleaner, declarative approach instead — `motion-safe:scroll-smooth` on the scroll container plus `scrollTo({ behavior: 'auto' })`, which follows the container's CSS `scroll-behavior`.

This PR brings that same approach to SegmentedControl:

- The `list` scroll container now carries `motion-safe:scroll-smooth`.
- `handleChange` reveals the selected option with `behavior: 'auto'`, which animates when motion is allowed and jumps instantly under reduced motion — no JS media query.
- The initial mount reveal is now explicitly `'instant'` (first paint must never animate, regardless of motion settings).

**Behavior is unchanged for users** (smooth on selection when motion is allowed, instant otherwise; instant on first paint); this just removes the JS branch in favor of CSS and aligns the two components.

> Surfaced while reviewing the Tabs overflow-scroll PR #5578.

## Breaking Changes

No — no public API change.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable) — existing stories cover this; behavior unchanged
- [ ] Unit tests added/updated — existing 14 SegmentedControl tests pass; the removed branch was untested
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against ARIA APG
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)