### PR TITLE
test(DST-1589): pin DateRangePicker story calendars to a fixed month

### DIFF
--- a/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -109,6 +109,7 @@ export const Basic: any = meta.story({
         label="Date Range Picker"
         description="This is a description"
         errorMessage="This is an error"
+        placeholderValue={new CalendarDate(2026, 7, 1)}
         {...args}
       />
     </I18nProvider>
@@ -168,6 +169,7 @@ export const UnavailableDate: any = meta.story({
       <DateRangePicker
         label="Date Range Picker"
         dateUnavailable={date => date.toDate('Europe/Berlin').getDay() === 0}
+        placeholderValue={new CalendarDate(2026, 7, 1)}
         {...args}
       />
     </I18nProvider>
@@ -181,6 +183,7 @@ export const MultiMonth: any = meta.story({
         label="Date Range Picker"
         description="Shows up to three months at once"
         visibleDuration={{ months: 2 }}
+        placeholderValue={new CalendarDate(2026, 7, 1)}
         {...args}
       />
     </I18nProvider>


### PR DESCRIPTION
# Description

The `Basic`, `UnavailableDate` and `MultiMonth` DateRangePicker stories rendered with no `value`/`defaultValue`. Their open-calendar Chromatic snapshots therefore defaulted to the *current* month and drifted every month, producing spurious visual diffs with no code change.

This pins each of the three stories to `placeholderValue={new CalendarDate(2026, 7, 1)}` — fixing the opening month without pre-selecting a range. July 2026 matches the current live baseline layout, so the one-time approval diff is near-zero. The already-pinned stories (`Controlled`, `MinMax`, `Mobile`) are untouched.

Closes DST-1589

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |
<!-- Chromatic will show a one-time baseline shift to July 2026; approve once and it stays stable. -->

## Test Instructions

1. Run `pnpm test:sb --run DateRangePicker` — all 5 story tests pass.
2. In Storybook (`pnpm sb`), open Components/DateRangePicker → Basic, open the calendar, confirm it lands on July 2026.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`) — N/A, stories file is not published