### PR TITLE
refactor(DST-1534): build Calendar year dropdown on RAC CalendarYearPicker

### DIFF
--- a/.changeset/dst-1534-year-picker-rac.md
+++ b/.changeset/dst-1534-year-picker-rac.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+refactor(DST-1534): build the `Calendar` year dropdown on react-aria's `CalendarYearPicker`
+
+The year dropdown now consumes react-aria's `CalendarYearPicker` render-prop (mirroring how the month dropdown already uses `CalendarMonthPicker`), replacing the hand-rolled year list and its localized `aria-label` workaround. This was unblocked by react-aria's June 2026 fix that makes `maxValue` inclusive, so the boundary year is reachable. Unbounded calendars keep the ±20-year window and bounded ranges stay fully reachable at both ends. When only one bound is set, the open side now widens to keep that bound reachable instead of staying at a fixed ±20 years.

--- a/packages/components/src/Calendar/Calendar.stories.tsx
+++ b/packages/components/src/Calendar/Calendar.stories.tsx
@@ -248,6 +248,34 @@ Basic.test(
   }
 );
 
+// A wide bounded range must reach both ends. `CalendarYearPicker` centers a
+// fixed window on the focused year and clamps it, so `visibleYears` has to be
+// large enough to span the whole range, not just a handful of years.
+Basic.test(
+  'Reaches both ends of a wide bounded year range',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    tags: ['component-test'],
+    args: {
+      minValue: new CalendarDate(1900, 1, 1),
+      maxValue: new CalendarDate(2100, 12, 31),
+      defaultValue: new CalendarDate(2000, 6, 15),
+    },
+  },
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: '2000' }));
+
+    const years = within(canvas.getByRole('listbox', { name: 'year' }))
+      .getAllByRole('option')
+      .map(option => option.textContent);
+
+    await expect(years[0]).toBe('1900');
+    await expect(years[years.length - 1]).toBe('2100');
+    await expect(canvas.queryByText('1899')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('2101')).not.toBeInTheDocument();
+  }
+);
+
 // Switching from a Feb 29 focus to a non-leap year must clamp to Feb 28.
 Basic.test(
   'Selecting a non-leap year from a Feb 29 focus resolves cleanly',

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { CalendarYearPicker } from 'react-aria-components/Calendar';
+import { CalendarYearPicker } from 'react-aria-components';
 import { useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { useDateFormatter, useLocale } from '@react-aria/i18n';
+import { CalendarYearPicker } from 'react-aria-components';
 import { useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 
@@ -9,53 +9,32 @@ interface YearDropdownProps {
 
 const YearListBox = ({ setSelectedDropdown }: YearDropdownProps) => {
   const state = useCalendarOrRangeState();
-  const focusedYear = state.focusedDate.year;
+  const focused = state.focusedDate.year;
 
-  // Derive the year list from the calendar's bounds so out-of-range years are
-  // never rendered. Both boundaries are inclusive. We can't use react-aria's
-  // `CalendarYearPicker` here: it treats `maxValue` as exclusive and drops the
-  // max year, so it would be unreachable from the dropdown. Unbounded sides keep
-  // the previous focused-year ±20 window. `set({ year })` clamps invalid days
-  // (e.g. Feb 29 on a non-leap target) to the last valid day of the month.
-  //
-  // When both bounds are set we render every in-range year (one option each) on
-  // purpose — that is what keeps `minValue`/`maxValue` reachable. For
-  // pathologically wide ranges this grows the DOM; virtualizing the listbox is
-  // the path forward if that ever becomes a concern.
-  const minYear = state.minValue ? state.minValue.year : focusedYear - 20;
-  const maxYear = state.maxValue ? state.maxValue.year : focusedYear + 20;
-
-  const years = Array.from(
-    { length: Math.max(maxYear - minYear + 1, 0) },
-    (_, i) => state.focusedDate.set({ year: minYear + i })
-  );
-
-  const formatter = useDateFormatter({
-    year: 'numeric',
-    timeZone: state.timeZone,
-  });
-
-  // Localized accessible name, matching what react-aria's CalendarYearPicker
-  // would expose (e.g. "year"/"Jahr"). Computed inline — this only mounts when
-  // the dropdown opens, so memoizing the lookup isn't worth a hook.
-  const { locale } = useLocale();
-  const ariaLabel =
-    new Intl.DisplayNames(locale, { type: 'dateTimeField' }).of('year') ??
-    'year';
+  // `CalendarYearPicker` centers a fixed `visibleYears` window on the focused
+  // year and clamps it to the bounds, so size the window to reach whichever
+  // bound is farther. Unbounded sides keep the focused-year ±20 window. A wide
+  // both-bounds range still renders every in-range year, so virtualizing the
+  // listbox is the path forward if the DOM size ever becomes a concern.
+  const min = state.minValue ? state.minValue.year : focused - 20;
+  const max = state.maxValue ? state.maxValue.year : focused + 20;
+  const visibleYears = 2 * Math.max(focused - min, max - focused) + 1;
 
   return (
-    <ListBox
-      ariaLabel={ariaLabel}
-      items={years}
-      // Every rendered year is in range, so `isDisabled` is omitted (defaults to
-      // nothing disabled).
-      isSelected={year => year.year === focusedYear}
-      onSelect={year => {
-        state.setFocusedDate(year);
-        setSelectedDropdown(undefined);
-      }}
-      format={year => formatter.format(year.toDate(state.timeZone))}
-    />
+    <CalendarYearPicker visibleYears={visibleYears}>
+      {({ items, value, onChange, 'aria-label': ariaLabel }) => (
+        <ListBox
+          ariaLabel={ariaLabel}
+          items={items}
+          isSelected={item => item.id === value}
+          onSelect={item => {
+            onChange(item.id);
+            setSelectedDropdown(undefined);
+          }}
+          format={item => item.formatted}
+        />
+      )}
+    </CalendarYearPicker>
   );
 };
 

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -9,16 +9,16 @@ interface YearDropdownProps {
 
 const YearListBox = ({ setSelectedDropdown }: YearDropdownProps) => {
   const state = useCalendarOrRangeState();
-  const focused = state.focusedDate.year;
+  const focusedYear = state.focusedDate.year;
 
   // `CalendarYearPicker` centers a fixed `visibleYears` window on the focused
   // year and clamps it to the bounds, so size the window to reach whichever
   // bound is farther. Unbounded sides keep the focused-year ±20 window. A wide
   // both-bounds range still renders every in-range year, so virtualizing the
   // listbox is the path forward if the DOM size ever becomes a concern.
-  const min = state.minValue ? state.minValue.year : focused - 20;
-  const max = state.maxValue ? state.maxValue.year : focused + 20;
-  const visibleYears = 2 * Math.max(focused - min, max - focused) + 1;
+  const min = state.minValue ? state.minValue.year : focusedYear - 20;
+  const max = state.maxValue ? state.maxValue.year : focusedYear + 20;
+  const visibleYears = 2 * Math.max(focusedYear - min, max - focusedYear) + 1;
 
   return (
     <CalendarYearPicker visibleYears={visibleYears}>

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { CalendarYearPicker } from 'react-aria-components';
+import { CalendarYearPicker } from 'react-aria-components/Calendar';
 import { useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 


### PR DESCRIPTION
# Description

The `Calendar` year dropdown (`YearListBox`) now consumes react-aria's `CalendarYearPicker` render-prop, mirroring how the month dropdown already uses `CalendarMonthPicker`. This replaces the hand-rolled year list, the local `useDateFormatter`, and the inline `Intl.DisplayNames` `aria-label` workaround.

The custom code existed only because RAC treated `maxValue` as **exclusive**, dropping the max year so it was unreachable from the dropdown. react-aria's June 2026 fix ([#10149](https://github.com/adobe/react-spectrum/pull/10149)) made it inclusive, and the repo already resolves the fixed versions (`react-aria@3.50.0` / `react-aria-components@1.19.0`), so the workaround's reason to exist is gone.

`CalendarYearPicker` centers a fixed `visibleYears` window on the focused year and clamps it to the bounds, so `visibleYears` is sized to reach whichever bound is farther. Behavior:
- **Unbounded** — keeps the focused-year ±20 window (41 years, unchanged).
- **Both bounds** — the full in-range list stays reachable at both ends (validated for a wide 1900–2100 range).
- **One-sided** — the open side now widens to keep the single bound reachable, instead of staying at a fixed ±20 years (the one intentional behavior change).

Closes DST-1534

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm sb` and open `Components/Calendar`.
2. Open the year dropdown on an unbounded calendar — confirm the focused year is centered with ~±20 years around it.
3. On a calendar with `minValue={1900}` / `maxValue={2100}`, open the year dropdown and scroll — confirm both `1900` and `2100` are present and selectable.
4. Select a year and confirm the calendar navigates to it (incl. Feb 29 → non-leap year clamps to Feb 28).
5. `pnpm test:sb --run Calendar.stories` and `pnpm test:unit --run Calendar.test` both pass.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)