### PR TITLE
chore(DST-1547): move z-index classes out of theme style files into component implementations

### DIFF
--- a/.changeset/dst-1547-move-zindex-to-components.md
+++ b/.changeset/dst-1547-move-zindex-to-components.md
@@ -1,0 +1,8 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+---
+
+chore(DST-1547): move z-index classes out of theme style files into component implementations
+
+Per the z-index management rule (`CLAUDE.md`), `z-*` utilities belong in component implementations, never in theme `*.styles.ts` files. The local focus/drop/sticky stacking classes for `Calendar`/`RangeCalendar`, `LegacyTable`, `ListBox`, `Table`, `ToggleButton` and `SegmentedControl` have been moved from their `theme-rui` styles into the matching component `className` (via `cn()`), preserving the exact modifiers and important flag. No visual or stacking change.

--- a/packages/components/src/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/Calendar/CalendarGrid.tsx
@@ -6,6 +6,7 @@ import {
   CalendarGridBody,
 } from 'react-aria-components/Calendar';
 import { RangeCalendarStateContext } from 'react-aria-components/RangeCalendar';
+import { cn } from '@marigold/system';
 import { CalendarGridHeader } from './CalendarGridHeader';
 import { useCalendarContext } from './Context';
 
@@ -44,7 +45,7 @@ const _CalendarGrid = ({ offset }: CalendarGridProps) => {
           return (
             <CalendarCell
               date={date}
-              className={classNames.calendarCell}
+              className={cn(classNames.calendarCell, 'data-focus-visible:z-10')}
               data-in-range={isInRange ? '' : undefined}
             />
           );

--- a/packages/components/src/ListBox/ListBox.tsx
+++ b/packages/components/src/ListBox/ListBox.tsx
@@ -40,7 +40,12 @@ const ListBoxBase = ({
   const listBox = (
     <RACListBox
       {...props}
-      className={cn('overflow-y-auto', classNames.list)}
+      className={cn(
+        'overflow-y-auto',
+        classNames.list,
+        // `!` overrides the inline `z-index: 0` set by RAC's virtualizer wrapper
+        '[&_:has(>:focus-visible)]:z-1!'
+      )}
       ref={ref as Ref<HTMLDivElement>}
       // Bound the virtualized list so the Virtualizer has a viewport to
       // clip against. Without this, the list grows to fit all items and

--- a/packages/components/src/ListBox/ListBoxItem.tsx
+++ b/packages/components/src/ListBox/ListBoxItem.tsx
@@ -3,6 +3,7 @@ import type RAC from 'react-aria-components';
 import { ListBoxItem } from 'react-aria-components/ListBox';
 import { TextContext } from 'react-aria-components/Text';
 import { Provider } from 'react-aria-components/slots';
+import { cn } from '@marigold/system';
 import { Check } from '../icons/Check';
 import { useMergedTextSlots } from '../utils/useMergedTextSlots';
 import { useListBoxContext } from './Context';
@@ -54,7 +55,7 @@ export const _ListBoxItem = (props: ListBoxItemProps) => {
   return (
     <ListBoxItem
       {...props}
-      className={classNames.item}
+      className={cn(classNames.item, 'focus-visible:z-1')}
       style={virtualized ? { height: '100%', minHeight: 0 } : undefined}
       // textValue needed because ListBoxItem in this case has multiple children
       textValue={props.textValue ?? String(props.children)}

--- a/packages/components/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControl.tsx
@@ -233,8 +233,10 @@ function SegmentedControlOption({
       className={cn(classNames.field, context.stretch && 'grow basis-0')}
       {...props}
     >
-      <SelectionIndicator className={classNames.indicator} />
-      <RadioButton className={classNames.option}>{children}</RadioButton>
+      <SelectionIndicator className={cn(classNames.indicator, 'z-0')} />
+      <RadioButton className={cn(classNames.option, 'z-10')}>
+        {children}
+      </RadioButton>
     </RadioField>
   );
 }

--- a/packages/components/src/Table/TableDropIndicator.tsx
+++ b/packages/components/src/Table/TableDropIndicator.tsx
@@ -30,7 +30,11 @@ export const TableDropIndicator = ({
   return (
     <DropIndicator
       {...props}
-      className={cn('transform-gpu', classNames.dropIndicator)}
+      className={cn(
+        'transform-gpu',
+        classNames.dropIndicator,
+        'drop-target:before:z-10'
+      )}
     />
   );
 };

--- a/packages/components/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/components/src/ToggleButton/ToggleButton.test.tsx
@@ -11,7 +11,7 @@ test('renders correctly', () => {
   expect(label).toMatchInlineSnapshot(`
     <button
       aria-pressed="false"
-      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 text-sm h-control px-4 py-2 [&_svg]:size-4"
+      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border text-sm h-control px-4 py-2 [&_svg]:size-4 in-[.group]:focus-visible:z-10"
       data-rac=""
       data-react-aria-pressable="true"
       tabindex="0"
@@ -55,7 +55,7 @@ test('supports different sizes', () => {
   expect(button).toMatchInlineSnapshot(`
     <button
       aria-pressed="false"
-      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 text-xs h-control-small px-3 [&_svg]:size-3.5"
+      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border text-xs h-control-small px-3 [&_svg]:size-3.5 in-[.group]:focus-visible:z-10"
       data-rac=""
       data-react-aria-pressable="true"
       tabindex="0"
@@ -69,7 +69,7 @@ test('supports different sizes', () => {
   expect(screen.getByRole('button')).toMatchInlineSnapshot(`
     <button
       aria-pressed="false"
-      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 size-control [&_svg]:size-4"
+      class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border size-control [&_svg]:size-4 in-[.group]:focus-visible:z-10"
       data-rac=""
       data-react-aria-pressable="true"
       tabindex="0"

--- a/packages/components/src/ToggleButton/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import { use } from 'react';
 import type RAC from 'react-aria-components';
 import { ToggleButton } from 'react-aria-components/ToggleButton';
-import { useClassNames } from '@marigold/system';
+import { cn, useClassNames } from '@marigold/system';
 import { ToggleButtonContext } from './Context';
 import { ToggleButtonGroup } from './ToggleButtonGroup';
 
@@ -43,7 +43,7 @@ export const _ToggleButton = ({
     <ToggleButton
       isSelected={selected}
       isDisabled={disabled}
-      className={classNames.button}
+      className={cn(classNames.button, 'in-[.group]:focus-visible:z-10')}
       {...props}
     >
       {children}

--- a/packages/components/src/ToggleButton/ToggleButtonGroup.test.tsx
+++ b/packages/components/src/ToggleButton/ToggleButtonGroup.test.tsx
@@ -16,7 +16,7 @@ test('renders correctly with children', () => {
     >
       <button
         aria-checked="true"
-        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 text-sm h-control px-4 py-2 [&_svg]:size-4"
+        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border text-sm h-control px-4 py-2 [&_svg]:size-4 in-[.group]:focus-visible:z-10"
         data-rac=""
         data-react-aria-pressable="true"
         data-selected="true"
@@ -28,7 +28,7 @@ test('renders correctly with children', () => {
       </button>
       <button
         aria-checked="false"
-        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 text-sm h-control px-4 py-2 [&_svg]:size-4"
+        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border text-sm h-control px-4 py-2 [&_svg]:size-4 in-[.group]:focus-visible:z-10"
         data-rac=""
         data-react-aria-pressable="true"
         role="radio"
@@ -39,7 +39,7 @@ test('renders correctly with children', () => {
       </button>
       <button
         aria-checked="false"
-        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border in-[.group]:focus-visible:z-10 text-sm h-control px-4 py-2 [&_svg]:size-4"
+        class="ui-button-base gap-2 ui-surface shadow-elevation-border hover:[--ui-background-color:var(--color-hover)] hover:[--ui-border-color:oklch(from_var(--color-border)_calc(l-0.1)_c_h)] hover:text-foreground selected:[--ui-background-color:var(--color-selected-bold)] selected:text-selected-bold-foreground selected:shadow-none disabled:shadow-none disabled:[--ui-background-color:var(--color-disabled-surface)] in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial] in-[.group]:disabled:border-r-border text-sm h-control px-4 py-2 [&_svg]:size-4 in-[.group]:focus-visible:z-10"
         data-rac=""
         data-react-aria-pressable="true"
         role="radio"

--- a/packages/components/src/legacy/Table/TableHeader.tsx
+++ b/packages/components/src/legacy/Table/TableHeader.tsx
@@ -21,9 +21,9 @@ export const TableHeader = ({ stickyHeader, children }: TableHeaderProps) => {
     <thead
       {...rowGroupProps}
       className={cn(
+        classNames?.thead,
         // sticky header lifts above the scrolled rows
         'z-1',
-        classNames?.thead,
         // for rui sticky is applied to thead
         stickyHeader ? 'sticky [&_th]:sticky [&_th]:top-0' : ''
       )}

--- a/packages/components/src/legacy/Table/TableHeader.tsx
+++ b/packages/components/src/legacy/Table/TableHeader.tsx
@@ -21,6 +21,8 @@ export const TableHeader = ({ stickyHeader, children }: TableHeaderProps) => {
     <thead
       {...rowGroupProps}
       className={cn(
+        // sticky header lifts above the scrolled rows
+        'z-1',
         classNames?.thead,
         // for rui sticky is applied to thead
         stickyHeader ? 'sticky [&_th]:sticky [&_th]:top-0' : ''

--- a/themes/theme-rui/src/components/Calendar.styles.ts
+++ b/themes/theme-rui/src/components/Calendar.styles.ts
@@ -9,7 +9,7 @@ export const calendarCellBase = [
   'border border-transparent p-0 text-sm font-normal text-foreground',
   'outline-offset-2 duration-150 transition-[color]',
   'data-hovered:ui-state-hover',
-  'data-focus-visible:z-10 focus-visible:ui-state-focus outline-none',
+  'focus-visible:ui-state-focus outline-none',
   'disabled:cursor-not-allowed disabled:text-disabled',
   'unavailable:cursor-not-allowed unavailable:text-disabled unavailable:line-through',
   'outside-month:hidden',

--- a/themes/theme-rui/src/components/LegacyTable.styles.ts
+++ b/themes/theme-rui/src/components/LegacyTable.styles.ts
@@ -12,7 +12,7 @@ export const LegacyTable: ThemeComponent<'LegacyTable'> = {
   }),
   thead: cva({
     // for sticky header
-    base: 'bg-surface/90 top-0 z-1 backdrop-blur-xs ',
+    base: 'bg-surface/90 top-0 backdrop-blur-xs ',
     variants: {
       variant: {
         default: '',

--- a/themes/theme-rui/src/components/ListBox.styles.ts
+++ b/themes/theme-rui/src/components/ListBox.styles.ts
@@ -15,11 +15,7 @@ export const ListBox: ThemeComponent<'ListBox'> = {
     ],
   }),
   list: cva({
-    base: [
-      'p-1 text-sm outline-0 space-y-px overflow-y-auto w-full',
-      // `!` overrides the inline `z-index: 0` set by RAC's virtualizer wrapper
-      '[&_:has(>:focus-visible)]:z-1!',
-    ],
+    base: ['p-1 text-sm outline-0 space-y-px overflow-y-auto w-full'],
   }),
   item: cva({
     base: [
@@ -28,7 +24,7 @@ export const ListBox: ThemeComponent<'ListBox'> = {
       'selected:bg-selected selected:[&_.selection-indicator>svg]:visible',
       'hover:ui-state-hover',
       'disabled:cursor-not-allowed disabled:text-disabled',
-      'focus-visible:ui-state-focus outline-none focus-visible:z-1 transition-[border,color]',
+      'focus-visible:ui-state-focus outline-none transition-[border,color]',
       'cursor-default data-selection-mode:cursor-pointer',
     ],
   }),

--- a/themes/theme-rui/src/components/SegmentedControl.styles.ts
+++ b/themes/theme-rui/src/components/SegmentedControl.styles.ts
@@ -60,7 +60,7 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
   // The clickable segment (a radio rendered as a button).
   option: cva({
     base: [
-      'relative z-10 w-full',
+      'relative w-full',
       'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-surface font-medium',
       // bg stays out of the transition list (DS-wide instant-bg convention,
       // see ui.css / DST-1436); only the label color animates. No press scale
@@ -115,7 +115,7 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
     // ring the slide would visibly lag behind the arrow keys, so dropping the
     // transition (same `transition-property: none` mechanism as reduced motion)
     // makes the FLIP a no-op. Pointer selection keeps the slide.
-    base: 'absolute z-0 transition-[translate,width] duration-200 ease-out-quint group-has-[[data-focus-visible]]/segmented:transition-none motion-reduce:transition-none',
+    base: 'absolute transition-[translate,width] duration-200 ease-out-quint group-has-[[data-focus-visible]]/segmented:transition-none motion-reduce:transition-none',
     variants: {
       variant: {
         // Raised surface like the Switch thumb; ~2px inset to the track edge.

--- a/themes/theme-rui/src/components/Table.styles.ts
+++ b/themes/theme-rui/src/components/Table.styles.ts
@@ -136,7 +136,7 @@ export const Table: ThemeComponent<'Table'> = {
     base: [
       'relative',
       'before:absolute before:inset-0 before:h-0.5 before:-translate-y-1/2 before:bg-border',
-      'drop-target:before:z-10 drop-target:before:bg-primary',
+      'drop-target:before:bg-primary',
     ],
   }),
 

--- a/themes/theme-rui/src/components/ToggleButton.styles.ts
+++ b/themes/theme-rui/src/components/ToggleButton.styles.ts
@@ -27,7 +27,6 @@ export const ToggleButton: ThemeComponent<'ToggleButton'> = {
       // Group: buttons share the group's outer surface and border
       'in-[.group]:rounded-none in-[.group]:shadow-none in-[.group]:border-y-0 in-[.group]:border-l-0 in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial]',
       'in-[.group]:disabled:border-r-border',
-      'in-[.group]:focus-visible:z-10',
     ],
     variants: {
       size: {


### PR DESCRIPTION
# Description

Per the z-index management rule in `CLAUDE.md`, `z-*` utilities belong in component implementations, never in theme `*.styles.ts` files. This moves the remaining local focus/drop/sticky stacking classes out of `theme-rui` styles into the matching component `className` (via `cn()`), preserving the exact modifiers and important flag. No visual or stacking change.

| Class | From (theme) | To (component) |
| --- | --- | --- |
| `data-focus-visible:z-10` | `Calendar.styles` (shared `calendarCellBase`) | `CalendarGrid.tsx` — covers Calendar + RangeCalendar |
| `z-1` (sticky header) | `LegacyTable.styles` | `legacy/Table/TableHeader.tsx` |
| `[&_:has(>:focus-visible)]:z-1!` | `ListBox.styles` (`list`) | `ListBox.tsx` — RAC-virtualizer comment carried over |
| `focus-visible:z-1` | `ListBox.styles` (`item`) | `ListBoxItem.tsx` |
| `drop-target:before:z-10` | `Table.styles` | `TableDropIndicator.tsx` |
| `in-[.group]:focus-visible:z-10` | `ToggleButton.styles` | `ToggleButton.tsx` |
| `z-10` (option) + `z-0` (indicator) | `SegmentedControl.styles` | `SegmentedControl.tsx` |

After this change `git grep "z-" themes/theme-rui/src/components/*.styles.ts` returns nothing.

> Note: SegmentedControl (`z-10`/`z-0`) was included beyond the ticket's original table — its option/indicator form a local stacking pair that broke the same rule.

Closes DST-1547

## Test Instructions

1. `git grep "z-\[0-9]\|z-\[" themes/theme-rui/src/components/*.styles.ts` → no results.
2. `pnpm typecheck:only` → passes.
3. `pnpm test:sb` for Calendar / ListBox / Table / ToggleButton / SegmentedControl → all pass (236 tests).
4. Manual: focus rings still lift above siblings (Calendar cells, ListBox/ToggleButton items), sticky legacy Table header overlaps rows, Table drag drop-indicator renders above content, SegmentedControl option sits above the sliding indicator.

## Breaking Changes

No

## Checklist

- [x] Stories added/updated (with `component-test` tag where applicable) — no story changes needed; existing story tests pass
- [ ] Unit tests added/updated — n/a (no behavior change)
- [ ] Component documentation added/updated (if it exists) — n/a
- [x] Accessibility reviewed — focus-visible stacking preserved on the same DOM elements
- [ ] Visual regression tests updated — n/a (targets `beta-release`)
- [x] Changeset added (`pnpm changeset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)