### PR TITLE
docs(DST-1535): document SelectList as the selectable-card pattern

### DIFF
--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -45,7 +45,7 @@ Reach for selectable cards when the user has to pick from a set of card-shaped o
 
 `<Card>` cannot do any of that. It renders a non-interactive `<article>` meant for grouping content, so making it selectable means rebuilding the whole selection layer by hand: tracking which card is active, wiring a hidden radio or checkbox so the value posts with the form, adding roving arrow-key focus across the grid, and setting the ARIA roles a screen reader needs to announce a card as "selected." That is a lot of accessibility-critical behaviour to reinvent, and it is easy to get subtly wrong.
 
-[`<SelectList>`](/components/form/selectlist#options-as-cards) with `variant="bordered"` is exactly that machinery, already built and tested. Each option renders as its own outlined card, so you keep the card look while the component owns selection state, form integration, keyboard navigation, and the "selected" announcements. Use `selectionMode="single"` for a plan or payment-method picker where one card wins, or `selectionMode="multiple"` when several cards can be active at once, such as add-ons or notification channels.
+[`<SelectList>`](../../form/selectlist#options-as-cards) with `variant="bordered"` is exactly that machinery, already built and tested. Each option renders as its own outlined card, so you keep the card look while the component owns selection state, form integration, keyboard navigation, and the "selected" announcements. Use `selectionMode="single"` for a plan or payment-method picker where one card wins, or `selectionMode="multiple"` when several cards can be active at once, such as add-ons or notification channels.
 
 ### Header
 

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -192,7 +192,7 @@ Every slot is inset with `p="square-regular"`, mirroring `Panel`. Use `square-lo
   items={[
     {
       title: 'SelectList',
-      href: '/components/form/selectlist#options-as-cards',
+      href: '../../form/selectlist#options-as-cards',
       caption:
         'The selectable-card pattern. Use SelectList with variant="bordered" when each card is an option the user picks from.',
       icon: (

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -39,6 +39,14 @@ The card component supports variants for general content grouping as well as acc
 
 A card represents one item in a set. Reach for it when the same type of item repeats in a grid or list (events, products, venues, team members) and each entry links to its own detail view. Repetition is the core case. If the element doesn't repeat, a card is probably the wrong tool. If the items need sorting, filtering, or bulk actions, [`<Table>`](../table) is a better fit. For a named, non-repeating page region like "Billing" or "Team members", use [`<Panel>`](../../layout/panel) instead.
 
+### Selectable cards
+
+Reach for selectable cards when the user has to pick from a set of card-shaped options and that choice becomes part of a form. A checkout choosing between Standard, VIP, and Student tickets, a billing page swapping between saved payment methods, a shipping step picking Express over Standard. What sets these apart from a plain card grid is that each card carries a value the form has to submit, exactly one (or a bounded set) can be active at a time, and the selection has to survive keyboard and screen-reader use.
+
+`<Card>` cannot do any of that. It renders a non-interactive `<article>` meant for grouping content, so making it selectable means rebuilding the whole selection layer by hand: tracking which card is active, wiring a hidden radio or checkbox so the value posts with the form, adding roving arrow-key focus across the grid, and setting the ARIA roles a screen reader needs to announce a card as "selected." That is a lot of accessibility-critical behaviour to reinvent, and it is easy to get subtly wrong.
+
+[`<SelectList>`](/components/form/selectlist#options-as-cards) with `variant="bordered"` is exactly that machinery, already built and tested. Each option renders as its own outlined card, so you keep the card look while the component owns selection state, form integration, keyboard navigation, and the "selected" announcements. Use `selectionMode="single"` for a plan or payment-method picker where one card wins, or `selectionMode="multiple"` when several cards can be active at once, such as add-ons or notification channels.
+
 ### Header
 
 `Card.Header` is slot-aware: drop a [`<Title>`](../../content/title) and an optional [`<Description>`](../../content/description) directly inside it. The header wires up the heading level, id, and accessible name automatically.
@@ -182,6 +190,28 @@ Every slot is inset with `p="square-regular"`, mirroring `Panel`. Use `square-lo
 
 <TeaserList
   items={[
+    {
+      title: 'SelectList',
+      href: '/components/form/selectlist#options-as-cards',
+      caption:
+        'The selectable-card pattern. Use SelectList with variant="bordered" when each card is an option the user picks from.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-5"
+        >
+          <rect x="3" y="4" width="18" height="6" rx="2" />
+          <rect x="3" y="14" width="18" height="6" rx="2" />
+          <path d="M7 17h6" />
+        </svg>
+      ),
+    },
     {
       title: 'Panel',
       href: '../../layout/panel',

--- a/docs/content/components/form/selectlist/index.mdx
+++ b/docs/content/components/form/selectlist/index.mdx
@@ -43,6 +43,16 @@ Hidden lists make users do invisible work. Comparing two options in a dropdown m
 
 Use `<SelectList>` when comparison is the point of the field, not when it is one step among many. That usually means a peer-level choice where each option is its own commitment, and getting it right matters more than moving through the form quickly.
 
+### Options as cards
+
+The `bordered` variant renders each option as its own outlined card with a small gap between rows, instead of a continuous surface with dividers. Reach for it when the choice is commit-level and each option is a peer the user weighs against the others, like event spaces, subscription plans, payment methods, or shipping modes. The card framing reads as "pick one of these" more strongly than a plain list, and each card has room for a thumbnail, a title, and a short description, the same anatomy as a [`<Card>`](/components/collection/card).
+
+This is also the answer whenever you catch yourself wanting a grid of selectable cards. `<Card>` renders a non-interactive `<article>` for grouping content, so it has no selection, form, or keyboard support. A bordered `<SelectList>` keeps the card look while owning the selection state, the value the form submits, and the keyboard navigation.
+
+Set `variant="bordered"` and pick a `selectionMode`. The example below takes the venue [card grid](/components/collection/card) and rebuilds it as a selectable list, laid out with `orientation="horizontal"` so the cards sit side by side. Each option keeps the same photo, title, and details, and now carries single selection and the value the form submits.
+
+<ComponentDemo name="selectlist-selectable-cards" />
+
 ### Number of options
 
 The right control depends on list length and how much space the field can take. `<SelectList>` earns its space when comparing options side by side or hosting per-row actions matters. For shorter lists of plain choices, longer lists, or when space is tight, a lighter control fits better. The table below maps common situations to the control that fits.
@@ -192,6 +202,8 @@ This two-tier model is what lets a per-row button or menu coexist with row selec
 Always give the list a `label`, or pass `aria-labelledby` when a heading nearby already names it. Without one, screen readers announce a list with no idea what it's for.
 
 For rows with rich content like a wrapped label, a logo, or a trailing action, set `textValue` on the option. Screen readers use it as the option's accessible name. Without it, the announcement collapses to whatever text fragment is reachable, which is rarely the right one.
+
+When an option carries an image, decide whether it conveys information. A decorative photo, like the venue thumbnails in the [Options as cards](#options-as-cards) example, takes `alt=""` so screen readers skip it, since the `textValue` already names the option. Give the image a real `alt` only when it says something the surrounding text does not.
 
 ## Props
 

--- a/docs/content/components/form/selectlist/selectlist-selectable-cards.demo.tsx
+++ b/docs/content/components/form/selectlist/selectlist-selectable-cards.demo.tsx
@@ -1,0 +1,59 @@
+import { venueTypes, venues } from '@/lib/data/venues';
+import { Badge, Inline, SelectList, Stack, Text } from '@marigold/components';
+
+const featured = venues.slice(0, 3);
+
+export default () => (
+  <SelectList
+    label="Event space"
+    description="Pick the venue to book. You can change it before you confirm."
+    variant="bordered"
+    orientation="horizontal"
+    selectionMode="single"
+    defaultSelectedKeys={[featured[0].id]}
+  >
+    {featured.map(venue => (
+      <SelectList.Option
+        key={venue.id}
+        id={venue.id}
+        textValue={`${venue.name}, ${venueTypes[venue.type]}`}
+      >
+        <div className="col-start-2 row-span-2 w-48 min-w-0">
+          <Stack space="regular">
+            <img
+              src={venue.image}
+              alt=""
+              className="h-40 w-full max-w-full rounded-sm object-cover"
+            />
+            <Stack space={1}>
+              {/* Reserve two lines so a one-line title (e.g. "Oak Ridge
+                  Barn") keeps every horizontal tile the same height, which
+                  keeps the photos aligned across the row. */}
+              <div className="min-h-14">
+                <Text size="lg" weight="semibold">
+                  {venue.name}
+                </Text>
+              </div>
+              <Text size="sm" variant="muted">
+                {venue.city}, {venue.country}
+              </Text>
+            </Stack>
+            <Stack space="tight">
+              <Inline space="related">
+                <Badge variant="info">{venueTypes[venue.type]}</Badge>
+              </Inline>
+              <Text size="sm" variant="muted">
+                Up to {venue.capacity.toLocaleString()} guests
+              </Text>
+            </Stack>
+            <Inline space="related" alignY="center">
+              <Text size="sm" weight="bold">
+                ${venue.price.from.toLocaleString()}
+              </Text>
+            </Inline>
+          </Stack>
+        </div>
+      </SelectList.Option>
+    ))}
+  </SelectList>
+);


### PR DESCRIPTION
# Description

There's no built-in "selectable Card" component, and it wasn't obvious that `SelectList` with `variant="bordered"` already covers the case. This documents that path so the next person reaching for selectable cards is pointed at the existing machinery instead of rebuilding selection/form/a11y on a non-interactive `<article>`.

- Adds an "Options as cards" section to the SelectList docs with a horizontal `variant="bordered"` demo that rebuilds the venue card grid as a bordered SelectList, matching Card typography and spacing.
- Cross-references SelectList from the Card docs (a "Selectable cards" Usage subsection and a Related teaser), pointing at `#options-as-cards`.
- Adds an accessibility note on decorative vs informative image alt text for image-bearing options.

Closes DST-1535

## Test Instructions

1. Run `pnpm start` and open `/components/form/selectlist` → confirm the new "Options as cards" section and the horizontal selectable-card demo render.
2. Open `/components/collection/card` → confirm the "Selectable cards" Usage subsection and the SelectList teaser under "Related", and that both links land on the SelectList "Options as cards" section.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with \`component-test\` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, docs-only on beta-release
- [ ] Changeset added (\`pnpm changeset\`) — N/A, docs-only