### PR TITLE
test(DST-1593): stabilize DatePicker UnavailableDate Chromatic story

### DIFF
--- a/packages/components/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/DatePicker/DatePicker.stories.tsx
@@ -188,7 +188,7 @@ export const UnavailableDate = meta.story({
       <DatePicker
         label="Date Picker"
         defaultValue={new CalendarDate(2019, 6, 1)}
-        dateUnavailable={date => date.toDate('Europe/Berlin').getDate() !== 1}
+        dateUnavailable={date => date.day !== 1}
         {...args}
       />
     </I18nProvider>

--- a/packages/components/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/DatePicker/DatePicker.stories.tsx
@@ -187,6 +187,7 @@ export const UnavailableDate = meta.story({
     <I18nProvider locale="de-DE">
       <DatePicker
         label="Date Picker"
+        defaultValue={new CalendarDate(2019, 6, 1)}
         dateUnavailable={date => date.toDate('Europe/Berlin').getDate() !== 1}
         {...args}
       />


### PR DESCRIPTION
# Description

The `UnavailableDate` story for `DatePicker` produced a non-deterministic Chromatic snapshot, causing intermittent VRT failures on unrelated PRs.

The story renders with `open: true` but set no `value`/`defaultValue` and did not mock the current date. Because no value was set, react-aria opened the calendar on the real current month and auto-focused the real "today". Unavailable dates in react-aria are still keyboard-focusable, so the focus ring landed on today's cell, and the `dateUnavailable` predicate marks every day except the 1st as unavailable. Since the baseline and each run happen on different days, the displayed month and focused cell drifted, so Chromatic saw a pixel diff and failed.

Fix: pin `defaultValue={new CalendarDate(2019, 6, 1)}` (an available day) so the displayed month and focused date are deterministic, while still demonstrating the unavailable-date feature.

Closes DST-1593

## Screenshots / Preview

Story: `Components/DatePicker/UnavailableDate`. The calendar now consistently opens on June 2019 with the 1st focused.

## Test Instructions

1. Open Storybook (`pnpm sb`) and view `Components/DatePicker` → `UnavailableDate`.
2. Confirm the calendar opens on June 2019 with the 1st (the only available day) focused, regardless of the current date.

## Breaking Changes

No

## Checklist

- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [x] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`) — not needed, story-only change with no published package impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)