### PR TITLE
test(DST-1592): convert remaining beta-branch stories to .test() syntax

### DIFF
--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -61,7 +61,10 @@ test('supports showing an error', () => {
 });
 
 test('does not allow width="fit"', () => {
-  renderWithOverlay(<Basic.Component label="Label" width="fit" />);
+  renderWithOverlay(
+    // @ts-expect-error - `width="fit"` is intentionally unsupported; assert it is not applied
+    <Basic.Component label="Label" width="fit" />
+  );
 
   // eslint-disable-next-line testing-library/no-node-access
   const container = screen.getByText('Label').parentElement;

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { expect, fn, userEvent } from 'storybook/test';
 import preview from '.storybook/preview';
-import { Download, Facebook } from '@marigold/icons';
+import { Facebook } from '@marigold/icons';
 import { Stack } from '../Stack/Stack';
 import { Button } from './Button';
 

--- a/packages/components/src/Button/Button.test.tsx
+++ b/packages/components/src/Button/Button.test.tsx
@@ -7,9 +7,10 @@ import { ResetButtonContext } from './ResetButtonContext';
 test('add icon in button works as expected', () => {
   render(<ButtonVariants.Component />);
 
-  // ButtonVariants renders one button with a Facebook icon and "Submit" label.
-  const button = screen.getByText('Submit');
-  const icon = screen.getByTestId(/download/);
+  // ButtonVariants renders a button with a Facebook icon and "Submit" label.
+  // `surface: 'both'` renders the story on two surfaces, so scope to the first.
+  const button = screen.getAllByText('Submit')[0];
+  const icon = screen.getAllByTestId('facebook')[0];
 
   expect(button).toHaveClass('items-center justify-center');
   expect(getComputedStyle(icon).width).toBe('16px');

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent } from 'storybook/test';
+import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Edit } from '@marigold/icons';
 import { Button } from '../Button/Button';
@@ -32,27 +32,24 @@ export const Basic = meta.story({
       <Button aria-label="Delete">Delete</Button>
     </ButtonGroup>
   ),
-  play: async ({ canvas }) => {
+});
+
+Basic.test(
+  'renders a labelled toolbar with all its buttons',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     const toolbar = canvas.getByRole('toolbar', { name: 'Item actions' });
     const buttons = canvas.getAllByRole('button');
 
     await expect(toolbar).toBeInTheDocument();
     await expect(buttons).toHaveLength(3);
-  },
-});
+  }
+);
 
-export const KeyboardNavigation = meta.story({
-  tags: ['component-test'],
-  render: () => (
-    <ButtonGroup aria-label="Item actions">
-      <Button aria-label="Edit">
-        <Edit />
-      </Button>
-      <Button aria-label="Duplicate">Duplicate</Button>
-      <Button aria-label="Delete">Delete</Button>
-    </ButtonGroup>
-  ),
-  play: async ({ canvas }) => {
+Basic.test(
+  'arrow keys move focus between buttons',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas, userEvent }) => {
     const [first, second, third] = canvas.getAllByRole('button');
     first.focus();
 
@@ -61,8 +58,8 @@ export const KeyboardNavigation = meta.story({
 
     await expect(second).not.toHaveFocus();
     await expect(third).toHaveFocus();
-  },
-});
+  }
+);
 
 export const DisabledCascade = meta.story({
   tags: ['component-test'],
@@ -72,19 +69,24 @@ export const DisabledCascade = meta.story({
       <Button aria-label="Delete">Delete</Button>
     </ButtonGroup>
   ),
-  play: async ({ canvas }) => {
+});
+
+DisabledCascade.test(
+  'cascades disabled to every button',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     const buttons = canvas.getAllByRole('button');
+
     for (const button of buttons) {
       await expect(button).toBeDisabled();
     }
-  },
-});
+  }
+);
 
 // Uniform precedence: a local prop ALWAYS wins over the group — including
 // `size` (which is the change from the former `ActionGroup`, where the group
 // won `size`).
 export const CascadePrecedence = meta.story({
-  tags: ['component-test'],
   render: () => (
     <ButtonGroup
       aria-label="Cascade precedence"
@@ -106,7 +108,6 @@ export const CascadePrecedence = meta.story({
 });
 
 export const WithActionMenu = meta.story({
-  tags: ['component-test'],
   render: () => (
     <ButtonGroup aria-label="With ActionMenu" size="small" variant="ghost">
       <Button aria-label="Edit">Edit</Button>

--- a/packages/components/src/Card/Card.stories.tsx
+++ b/packages/components/src/Card/Card.stories.tsx
@@ -64,59 +64,38 @@ export const Basic = meta.story({
   ),
 });
 
-Basic.test('renders an article labelled by the Title', async ({ canvas }) => {
-  const title = canvas.getByRole('heading', {
-    name: 'Professor Severus Snape',
-  });
-  const article = canvas.getByRole('article', {
-    name: 'Professor Severus Snape',
-  });
-
-  expect(title.tagName).toBe('H3');
-  expect(article.tagName).toBe('ARTICLE');
-  expect(article.getAttribute('aria-labelledby')).toBe(title.id);
-});
-
-export const HeadingLevels = meta.story({
-  args: { headingLevel: 4 },
-  tags: ['component-test'],
-  render: args => (
-    <Card {...args}>
-      <Card.Header>
-        <Title>Heading at level 4</Title>
-      </Card.Header>
-      <Card.Body>
-        <Text>The Title renders as an h4 in the document outline.</Text>
-      </Card.Body>
-    </Card>
-  ),
-});
-
-HeadingLevels.test(
-  'renders the Title at the configured heading level',
+Basic.test(
+  'renders an article labelled by the Title',
+  { parameters: { chromatic: { disableSnapshot: true } } },
   async ({ canvas }) => {
-    const title = canvas.getByRole('heading', { name: 'Heading at level 4' });
+    const title = canvas.getByRole('heading', {
+      name: 'Professor Severus Snape',
+    });
+    const article = canvas.getByRole('article', {
+      name: 'Professor Severus Snape',
+    });
 
-    expect(title.tagName).toBe('H4');
+    expect(title.tagName).toBe('H3');
+    expect(article.tagName).toBe('ARTICLE');
+    expect(article.getAttribute('aria-labelledby')).toBe(title.id);
   }
 );
 
-export const AriaLabeled = meta.story({
-  tags: ['component-test'],
-  render: args => (
-    <Card {...args} aria-label="Quick stats card">
-      <Card.Body>
-        <Text>
-          A Card can be labelled with <code>aria-label</code> when there is no
-          visible Title.
-        </Text>
-      </Card.Body>
-    </Card>
-  ),
-});
-
-AriaLabeled.test(
+Basic.test(
   'uses aria-label as the accessible name and omits aria-labelledby',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    render: args => (
+      <Card {...args} aria-label="Quick stats card">
+        <Card.Body>
+          <Text>
+            A Card can be labelled with <code>aria-label</code> when there is no
+            visible Title.
+          </Text>
+        </Card.Body>
+      </Card>
+    ),
+  },
   async ({ canvas }) => {
     const article = canvas.getByRole('article', { name: 'Quick stats card' });
 
@@ -126,7 +105,6 @@ AriaLabeled.test(
 );
 
 export const WithFooter = meta.story({
-  tags: ['component-test'],
   render: args => (
     <Card {...args}>
       <Card.Header>
@@ -168,13 +146,6 @@ export const WithMedia = meta.story({
       </Card.Body>
     </Card>
   ),
-});
-
-export const Stretch = meta.story({
-  ...Basic.input,
-  args: {
-    stretch: true,
-  },
 });
 
 export const WithPaddingProp = meta.story({
@@ -230,6 +201,7 @@ export const WithNumericPadding = meta.story({
 
 WithNumericPadding.test(
   'applies equal horizontal and vertical padding from a numeric scale value',
+  { parameters: { chromatic: { disableSnapshot: true } } },
   async ({ canvas }) => {
     const article = canvas.getByRole('article');
     const style = getComputedStyle(article);
@@ -282,6 +254,7 @@ export const WithBleedFooter = meta.story({
  * Content will have no horizontal padding. Wrap content in `Card.Body` instead.
  */
 export const BareChildrenAntiPattern = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Stack space={4}>
       <Card {...args} aria-label="Bare children anti-pattern">
@@ -349,6 +322,7 @@ export const TitleOnlyWithoutHeader = meta.story({
 
 TitleOnlyWithoutHeader.test(
   'labels the article when Title is used without Card.Header',
+  { parameters: { chromatic: { disableSnapshot: true } } },
   async ({ canvas }) => {
     const title = canvas.getByRole('heading', { name: 'Quick Settings' });
     const article = canvas.getByRole('article', { name: 'Quick Settings' });

--- a/packages/components/src/Card/Card.test.tsx
+++ b/packages/components/src/Card/Card.test.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable testing-library/no-node-access */
 import { render, screen } from '@testing-library/react';
 import {
-  AriaLabeled,
   Basic,
   MasterAndAdmin,
-  Stretch,
   TitleOnlyWithoutHeader,
   WithBleedBody,
   WithBleedFooter,
@@ -48,15 +46,6 @@ describe('Card', () => {
         screen.getByRole('button', { name: 'Cancel' })
       ).toBeInTheDocument();
     });
-
-    test('supports `aria-label` as the accessible name and omits `aria-labelledby`', () => {
-      render(<AriaLabeled.Component />);
-
-      const article = screen.getByRole('article', { name: 'Quick stats card' });
-
-      expect(article).not.toHaveAttribute('aria-labelledby');
-      expect(article).toHaveAttribute('aria-label', 'Quick stats card');
-    });
   });
 
   describe('Layout', () => {
@@ -71,7 +60,7 @@ describe('Card', () => {
     });
 
     test('does not apply w-fit when stretch is enabled', () => {
-      render(<Stretch.Component data-testid="card" />);
+      render(<Basic.Component data-testid="card" stretch={true} />);
 
       const card = screen.getByTestId('card');
 

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -110,7 +110,10 @@ test('hides loading state when loading is false', () => {
 });
 
 test('does not allow width="fit"', () => {
-  renderWithOverlay(<Basic.Component label="Label" width="fit" />);
+  renderWithOverlay(
+    // @ts-expect-error - `width="fit"` is intentionally unsupported; assert it is not applied
+    <Basic.Component label="Label" width="fit" />
+  );
 
   // eslint-disable-next-line testing-library/no-node-access
   const container = screen.getByText('Label').parentElement;

--- a/packages/components/src/ContextualHelp/ContextualHelp.stories.tsx
+++ b/packages/components/src/ContextualHelp/ContextualHelp.stories.tsx
@@ -102,7 +102,7 @@ Basic.test('Opens contextual help', async ({ canvas, userEvent }) => {
   const helpButton = await canvas.getByLabelText(/help|hilfe/i);
   await userEvent.click(helpButton);
 
-  expect(await canvas.findByText('Whats this?')).toBeInTheDocument();
+  expect(await canvas.findByText(/What.s this\?/)).toBeInTheDocument();
   expect(
     await canvas.findByText(
       'This feature explains important functions to you directly in the context of the page.'
@@ -113,6 +113,22 @@ Basic.test('Opens contextual help', async ({ canvas, userEvent }) => {
       name: 'To the documentation',
     })
   ).toBeInTheDocument();
+});
+
+export const WithDescription = meta.story({
+  render: args => (
+    <div className="flex h-96 items-center justify-center">
+      <ContextualHelp {...args}>
+        <ContextualHelp.Title>Feature overview</ContextualHelp.Title>
+        <ContextualHelp.Description>
+          A short summary of this feature.
+        </ContextualHelp.Description>
+        <ContextualHelp.Content>
+          More detail about how this feature works.
+        </ContextualHelp.Content>
+      </ContextualHelp>
+    </div>
+  ),
 });
 
 export const WithTextField = meta.story({

--- a/packages/components/src/Description/Description.stories.tsx
+++ b/packages/components/src/Description/Description.stories.tsx
@@ -13,6 +13,7 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
   args: {
     children: 'Helps a user understand what the parent region is for.',
   },
@@ -21,16 +22,12 @@ export const Basic = meta.story({
   ),
 });
 
-export const Renders = meta.story({
-  tags: ['component-test'],
-  render: () => (
-    <Description>
-      Helps a user understand what the parent region is for.
-    </Description>
-  ),
-  play: async ({ canvas }) => {
+Basic.test(
+  'renders its children',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     await expect(
       canvas.getByText('Helps a user understand what the parent region is for.')
     ).toBeInTheDocument();
-  },
-});
+  }
+);

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -6,12 +6,9 @@ import { ButtonGroup } from '../ButtonGroup/ButtonGroup';
 import { Description } from '../Description/Description';
 import { Form } from '../Form/Form';
 import { ActionMenu } from '../Menu/ActionMenu';
-import { Menu } from '../Menu/Menu';
-import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { TextField } from '../TextField/TextField';
 import { Title } from '../Title/Title';
-import { ConfirmationDialog } from './ConfirmationDialog';
 import { Dialog } from './Dialog';
 
 const meta = preview.meta({
@@ -45,6 +42,7 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
   parameters: { chromatic: { disableSnapshot: true } },
   render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
@@ -71,7 +69,7 @@ export const Basic = meta.story({
 Basic.test(
   'Open dialog',
   {
-    parameters: { chromatic: { disableSnapshot: true } },
+    parameters: { chromatic: { disableSnapshot: false } },
   },
   async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
@@ -126,36 +124,9 @@ export const WithFormValidation = meta.story({
   ),
 });
 
-export const TextOnly = meta.story({
-  tags: ['component-test'],
-  render: ({ size, ...args }) => (
-    <Dialog.Trigger {...args}>
-      <Button variant="primary">Open</Button>
-      <Dialog size={size} closeButton>
-        <Title>Information</Title>
-        <Dialog.Content>
-          Your session will expire in 30 minutes. Save your work to avoid losing
-          any unsaved changes.
-        </Dialog.Content>
-      </Dialog>
-    </Dialog.Trigger>
-  ),
-});
-
-TextOnly.test(
-  'Shows only text',
-  {
-    parameters: { chromatic: { disableSnapshot: true } },
-  },
-  async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
-
-    await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
-  }
-);
-
 export const VeryLongContent = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => {
     const { size, ...triggerArgs } = args;
     return (
@@ -306,7 +277,7 @@ export const VeryLongContent = meta.story({
 VeryLongContent.test(
   'Shows very long content',
   {
-    parameters: { chromatic: { disableSnapshot: true } },
+    parameters: { chromatic: { disableSnapshot: false } },
   },
   async ({ canvas, userEvent }) => {
     await userEvent.click(
@@ -341,6 +312,7 @@ VeryLongContent.test(
  */
 export const SlotPrimitives = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
       <Button variant="primary">Open</Button>
@@ -377,7 +349,14 @@ export const SlotPrimitives = meta.story({
       </Dialog>
     </Dialog.Trigger>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+SlotPrimitives.test(
+  'Renders slot primitives with grouped actions',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
     await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
 
@@ -390,8 +369,8 @@ export const SlotPrimitives = meta.story({
     expect(
       canvas.getByRole('toolbar', { name: 'Event actions' })
     ).toBeInTheDocument();
-  },
-});
+  }
+);
 
 /**
  * A bare `<Title slot="title">` (no `<Dialog.Header>`, no description) is a
@@ -400,6 +379,7 @@ export const SlotPrimitives = meta.story({
  */
 export const TitleOnlyWithoutHeader = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: ({ size, ...args }) => (
     <Dialog.Trigger {...args}>
       <Button variant="primary">Open</Button>
@@ -412,7 +392,14 @@ export const TitleOnlyWithoutHeader = meta.story({
       </Dialog>
     </Dialog.Trigger>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+TitleOnlyWithoutHeader.test(
+  'Labels the dialog with a bare Title',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
 
     const dialog = await waitFor(() =>
@@ -422,5 +409,5 @@ export const TitleOnlyWithoutHeader = meta.story({
 
     expect(title.tagName).toBe('H2');
     expect(dialog).toHaveAttribute('aria-labelledby', title.id);
-  },
-});
+  }
+);

--- a/packages/components/src/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/Drawer/Drawer.stories.tsx
@@ -38,6 +38,7 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
   parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Stack space={8} alignX="left">
@@ -97,13 +98,19 @@ export const Basic = meta.story({
   ),
 });
 
-Basic.test('Open drawer', async ({ canvas, userEvent }) => {
-  await userEvent.click(canvas.getByRole('button', { name: 'Open Drawer' }));
+Basic.test(
+  'Open drawer',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button', { name: 'Open Drawer' }));
 
-  await waitFor(() =>
-    expect(canvas.getByText('Drawer Title')).toBeInTheDocument()
-  );
-});
+    await waitFor(() =>
+      expect(canvas.getByText('Drawer Title')).toBeInTheDocument()
+    );
+  }
+);
 
 export const WithForms = meta.story({
   parameters: { surface: false, chromatic: { disableSnapshot: true } },
@@ -333,7 +340,7 @@ export const Controlled = meta.story({
 /** Opening a second Drawer while one is open dismisses the first. */
 export const OneAtATime = meta.story({
   tags: ['component-test'],
-  parameters: { surface: false },
+  parameters: { surface: false, chromatic: { disableSnapshot: true } },
   render: args => (
     <Stack space={8} alignX="left">
       <Drawer.Trigger>
@@ -352,7 +359,11 @@ export const OneAtATime = meta.story({
       </Drawer.Trigger>
     </Stack>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+OneAtATime.test(
+  'Opening a second drawer dismisses the first',
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open A' }));
     expect(await canvas.findByText('Title A')).toBeInTheDocument();
 
@@ -368,8 +379,8 @@ export const OneAtATime = meta.story({
     await waitFor(() =>
       expect(canvas.queryByText('Title B')).not.toBeInTheDocument()
     );
-  },
-});
+  }
+);
 
 /**
  * DST-1407: A trigger nested inside an open Drawer opens a second Drawer over
@@ -379,7 +390,7 @@ export const OneAtATime = meta.story({
  */
 export const OneAtATimeNested = meta.story({
   tags: ['component-test'],
-  parameters: { surface: false },
+  parameters: { surface: false, chromatic: { disableSnapshot: true } },
   render: args => (
     <Drawer.Trigger>
       <Button>Open A</Button>
@@ -397,7 +408,11 @@ export const OneAtATimeNested = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+OneAtATimeNested.test(
+  'A nested drawer stacks over its parent',
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open A' }));
     expect(await canvas.findByText('Title A')).toBeInTheDocument();
 
@@ -413,8 +428,8 @@ export const OneAtATimeNested = meta.story({
       expect(canvas.queryByText('Title B')).not.toBeInTheDocument()
     );
     expect(canvas.getByText('Title A')).toBeInTheDocument();
-  },
-});
+  }
+);
 
 /**
  * The slot-aware primitives `<Title>` / `<Description>` and the action
@@ -424,6 +439,7 @@ export const OneAtATimeNested = meta.story({
  */
 export const SlotPrimitives = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Drawer.Trigger>
       <Button>Open Drawer</Button>
@@ -458,7 +474,14 @@ export const SlotPrimitives = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+SlotPrimitives.test(
+  'Renders slot primitives with grouped actions',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open Drawer' }));
     await waitFor(() =>
       expect(canvas.getByText('Manage event')).toBeInTheDocument()
@@ -473,8 +496,8 @@ export const SlotPrimitives = meta.story({
     expect(
       canvas.getByRole('toolbar', { name: 'Event actions' })
     ).toBeInTheDocument();
-  },
-});
+  }
+);
 
 /**
  * A bare `<Title slot="title">` (no `<Drawer.Header>`, no description) labels
@@ -482,6 +505,7 @@ export const SlotPrimitives = meta.story({
  */
 export const TitleOnlyWithoutHeader = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Drawer.Trigger>
       <Button>Open Drawer</Button>
@@ -491,7 +515,14 @@ export const TitleOnlyWithoutHeader = meta.story({
       </Drawer>
     </Drawer.Trigger>
   ),
-  play: async ({ canvas, userEvent }) => {
+});
+
+TitleOnlyWithoutHeader.test(
+  'Labels the drawer with a bare Title',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open Drawer' }));
 
     const drawer = await waitFor(() =>
@@ -501,5 +532,5 @@ export const TitleOnlyWithoutHeader = meta.story({
 
     expect(title.tagName).toBe('H2');
     expect(drawer).toHaveAttribute('aria-labelledby', title.id);
-  },
-});
+  }
+);

--- a/packages/components/src/Icons.stories.tsx
+++ b/packages/components/src/Icons.stories.tsx
@@ -41,7 +41,7 @@ const meta = preview.meta({
   title: 'Icons/Icon',
   component: DesignTicket,
   parameters: {
-    parameters: { chromatic: { disableSnapshot: true } },
+    chromatic: { disableSnapshot: true },
     surface: false,
   },
   argTypes: {

--- a/packages/components/src/Icons.stories.tsx
+++ b/packages/components/src/Icons.stories.tsx
@@ -41,6 +41,7 @@ const meta = preview.meta({
   title: 'Icons/Icon',
   component: DesignTicket,
   parameters: {
+    parameters: { chromatic: { disableSnapshot: true } },
     surface: false,
   },
   argTypes: {

--- a/packages/components/src/Inline/Inline.stories.tsx
+++ b/packages/components/src/Inline/Inline.stories.tsx
@@ -65,7 +65,7 @@ export const Basic = meta.story({
     alignX: 'left',
   },
   render: args => (
-    <Inline {...args}>
+    <Inline {...args} data-testid="inline">
       <Block>Lirum</Block>
       <Block>
         Larum
@@ -79,8 +79,22 @@ export const Basic = meta.story({
   ),
 });
 
+Basic.test(
+  'collapses the gap between children to zero',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: {
+      space: 'collapsed',
+    },
+  },
+  async ({ canvas }) => {
+    const inline = canvas.getByTestId('inline');
+
+    expect(getComputedStyle(inline).gap).toBe('0px');
+  }
+);
+
 export const InputButtonAlignment = meta.story({
-  tags: ['component-test'],
   args: {
     alignY: 'input',
     space: 6,
@@ -109,27 +123,6 @@ export const InputButtonAlignment = meta.story({
         </Inline>
       </Stack>
     );
-  },
-});
-
-export const Collapsed = meta.story({
-  tags: ['component-test'],
-  parameters: {
-    surface: false,
-  },
-  args: {
-    space: 'collapsed',
-  },
-  render: args => (
-    <Inline data-testid="inline" {...args}>
-      <Block>Lirum</Block>
-      <Block>Larum</Block>
-      <Block>Löffelstiel!</Block>
-    </Inline>
-  ),
-  play: async ({ canvas }) => {
-    const inline = canvas.getByTestId('inline');
-    expect(getComputedStyle(inline).gap).toBe('0px');
   },
 });
 

--- a/packages/components/src/Inset/Inset.stories.tsx
+++ b/packages/components/src/Inset/Inset.stories.tsx
@@ -72,9 +72,10 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
   render: args => (
     <div className="bg-muted rounded-md">
-      <Inset {...args}>
+      <Inset {...args} data-testid="inset">
         <Headline level={3}>The Giggle Grounds</Headline>
         <Inline>
           <Text fontStyle="italic">Laughville | Outdoor Amphitheater</Text>
@@ -88,18 +89,16 @@ export const Basic = meta.story({
   ),
 });
 
-export const Collapsed = meta.story({
-  tags: ['component-test'],
-  args: {
-    p: 'collapsed',
+Basic.test(
+  'collapses the padding to zero',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: {
+      p: 'collapsed',
+    },
   },
-  render: args => (
-    <Inset {...args}>
-      <Text>Flush content</Text>
-    </Inset>
-  ),
-  play: async ({ canvas }) => {
-    const inset = canvas.getByText('Flush content').parentElement!;
+  async ({ canvas }) => {
+    const inset = canvas.getByTestId('inset');
     expect(getComputedStyle(inset).padding).toBe('0px');
-  },
-});
+  }
+);

--- a/packages/components/src/LinkButton/LinkButton.stories.tsx
+++ b/packages/components/src/LinkButton/LinkButton.stories.tsx
@@ -93,6 +93,7 @@ export const InButtonGroup = meta.story({
 });
 
 export const InButtonContext = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     children: undefined,
     href: undefined,

--- a/packages/components/src/ListBox/ListBox.stories.tsx
+++ b/packages/components/src/ListBox/ListBox.stories.tsx
@@ -42,7 +42,14 @@ export const WithDescription = meta.story({
       </ListBox.Item>
     </ListBox>
   ),
-  play: async ({ canvas }: any) => {
+});
+
+WithDescription.test(
+  'links each item to its description via aria-describedby',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
     const item = canvas.getByRole('option', { name: /Restricted/ });
     const description = canvas.getByText('Only people you invite can view.');
 
@@ -50,8 +57,8 @@ export const WithDescription = meta.story({
     expect(item.getAttribute('aria-describedby') ?? '').toContain(
       description.id
     );
-  },
-});
+  }
+);
 
 export const WithSections = meta.story({
   render: args => (

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -3,8 +3,6 @@ import { expect, spyOn, userEvent, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Key } from '@react-types/shared';
 import { Delete } from '@marigold/icons';
-import { Description } from '../Description/Description';
-import { TextValue } from '../TextValue/TextValue';
 import { ActionMenu } from './ActionMenu';
 import { Menu } from './Menu';
 

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -101,6 +101,9 @@ export const Basic = meta.story({
 
 Basic.test(
   'renders a labelled region with the Title as accessible name',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
   async ({ canvas }) => {
     const title = canvas.getByRole('heading', { name: 'Organizer Profile' });
     const region = canvas.getByRole('region', { name: 'Organizer Profile' });
@@ -112,8 +115,9 @@ Basic.test(
 );
 
 export const TitleOnlyWithoutHeader = meta.story({
-  args: { children: null as never },
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: { children: null as never },
   render: args => (
     <Panel {...args}>
       <Title>Quick Settings</Title>
@@ -295,8 +299,8 @@ export const WithHeaderActions = meta.story(() => (
 ));
 
 export const SlotsButtonGroup = meta.story({
-  args: { children: null as never },
   tags: ['component-test'],
+  args: { children: null as never },
   render: args => (
     <Panel {...args}>
       <Panel.Header>
@@ -326,6 +330,9 @@ export const SlotsButtonGroup = meta.story({
 
 SlotsButtonGroup.test(
   'renders as a toolbar inside the actions grid cell',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
   async ({ canvas }) => {
     const toolbar = canvas.getByRole('toolbar', {
       name: 'Integration actions',
@@ -337,6 +344,9 @@ SlotsButtonGroup.test(
 
 SlotsButtonGroup.test(
   'cycles focus between actions with arrow keys',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
   async ({ canvas }) => {
     const reconnect = canvas.getByRole('button', { name: 'Reconnect' });
     const refresh = canvas.getByRole('button', { name: 'Refresh' });
@@ -355,6 +365,9 @@ SlotsButtonGroup.test(
 
 SlotsButtonGroup.test(
   'individual Buttons inside the group do NOT carry the actions grid-area',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
   async ({ canvas }) => {
     const reconnect = canvas.getByRole('button', { name: 'Reconnect' });
 
@@ -363,8 +376,8 @@ SlotsButtonGroup.test(
 );
 
 export const WithCollapsible = meta.story({
-  args: { children: null as never },
   tags: ['component-test'],
+  args: { children: null as never },
   render: args => (
     <Panel {...args}>
       <Panel.Header>
@@ -396,6 +409,9 @@ export const WithCollapsible = meta.story({
 
 WithCollapsible.test(
   'toggles aria-expanded and body visibility via click, Enter, and Space',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
   async ({ canvas }) => {
     const trigger = canvas.getByRole('button', { name: /Advanced Options/ });
     const body = canvas.getByLabelText('Custom URL Slug');
@@ -431,6 +447,7 @@ WithCollapsible.test(
 
 export const ControlledCollapsible = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: function Render() {
     const [expanded, setExpanded] = useState(false);
     return (
@@ -466,19 +483,25 @@ ControlledCollapsible.test(
   }
 );
 
-export const AriaLabeled = meta.story(() => (
-  <Panel aria-label="Collapsible-only panel">
-    <Panel.Content>
-      <Text>
-        A Panel can be labelled with <code>aria-label</code> when there is no
-        visible title — useful for collapsible-only sections.
-      </Text>
-    </Panel.Content>
-  </Panel>
-));
+export const AriaLabeled = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function Render() {
+    return (
+      <Panel aria-label="Collapsible-only panel">
+        <Panel.Content>
+          <Text>
+            A Panel can be labelled with <code>aria-label</code> when there is
+            no visible title — useful for collapsible-only sections.
+          </Text>
+        </Panel.Content>
+      </Panel>
+    );
+  },
+});
 
 export const CollapsibleDefaultExpanded = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Panel>
       <Panel.Header>

--- a/packages/components/src/SectionMessage/SectionMessage.stories.tsx
+++ b/packages/components/src/SectionMessage/SectionMessage.stories.tsx
@@ -1,6 +1,7 @@
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
-import { Button, Stack } from '@marigold/components';
+import { Button } from '../Button/Button';
+import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { SectionMessage } from './SectionMessage';
 

--- a/packages/components/src/SectionMessage/SectionMessage.stories.tsx
+++ b/packages/components/src/SectionMessage/SectionMessage.stories.tsx
@@ -1,5 +1,6 @@
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
+import { Button, Stack } from '@marigold/components';
 import { Text } from '../Text/Text';
 import { SectionMessage } from './SectionMessage';
 
@@ -37,6 +38,11 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    surface: false,
+  },
   render: args => (
     <SectionMessage closeButton {...args}>
       <SectionMessage.Title>Danger Zone!</SectionMessage.Title>
@@ -47,7 +53,21 @@ export const Basic = meta.story({
   ),
 });
 
+Basic.test(
+  'renders the Title as a real heading element',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
+    const heading = canvas.getByRole('heading', { name: 'Danger Zone!' });
+    await expect(heading).toBeInTheDocument();
+    // Default `headingLevel` is 3.
+    await expect(heading.tagName).toBe('H3');
+  }
+);
+
 export const WithDescription = meta.story({
+  tags: ['component-test'],
   render: args => (
     <SectionMessage {...args}>
       <SectionMessage.Title>Backup completed</SectionMessage.Title>
@@ -61,59 +81,18 @@ export const WithDescription = meta.story({
   ),
 });
 
-export const WithAction = meta.story({
-  render: args => (
-    <SectionMessage {...args}>
-      <SectionMessage.Title>Storage almost full</SectionMessage.Title>
-      <SectionMessage.Content>
-        <Stack space={2} alignX="left">
-          <Text>You are using 95% of your available storage.</Text>
-          <Button variant="primary" size="small">
-            Upgrade plan
-          </Button>
-        </Stack>
-      </SectionMessage.Content>
-    </SectionMessage>
-  ),
-});
-
-export const TitleIsSemanticHeading = meta.story({
-  tags: ['component-test'],
-  parameters: { surface: false },
-  render: args => (
-    <SectionMessage {...args}>
-      <SectionMessage.Title>Semantic title</SectionMessage.Title>
-      <SectionMessage.Content>
-        The title above renders as a real heading element.
-      </SectionMessage.Content>
-    </SectionMessage>
-  ),
-  play: async ({ canvas }) => {
-    const heading = canvas.getByRole('heading', { name: 'Semantic title' });
-    await expect(heading).toBeInTheDocument();
-    // Default `headingLevel` is 3.
-    await expect(heading.tagName).toBe('H3');
+WithDescription.test(
+  'renders the Description through the muted description slot',
+  {
+    parameters: { chromatic: { disableSnapshot: true }, surface: false },
   },
-});
-
-export const DescriptionRendersInSlot = meta.story({
-  tags: ['component-test'],
-  parameters: { surface: false },
-  render: args => (
-    <SectionMessage {...args} headingLevel={2}>
-      <SectionMessage.Title>Backup completed</SectionMessage.Title>
-      <SectionMessage.Description>
-        All files were copied to the archive.
-      </SectionMessage.Description>
-    </SectionMessage>
-  ),
-  play: async ({ canvas }) => {
+  async ({ canvas }) => {
     const heading = canvas.getByRole('heading', { name: 'Backup completed' });
-    await expect(heading.tagName).toBe('H2');
-
     const description = canvas.getByText(
       'All files were copied to the archive.'
     );
+
+    await expect(heading.tagName).toBe('H3');
     await expect(description).toBeInTheDocument();
     // Element type comes from the root's `TextContext` slot config.
     await expect(description.tagName).toBe('P');
@@ -136,7 +115,24 @@ export const DescriptionRendersInSlot = meta.story({
         .getPropertyValue('--section-message-description')
         .trim()
     ).not.toBe('currentColor');
-  },
+  }
+);
+
+export const WithAction = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: args => (
+    <SectionMessage {...args}>
+      <SectionMessage.Title>Storage almost full</SectionMessage.Title>
+      <SectionMessage.Content>
+        <Stack space={2} alignX="left">
+          <Text>You are using 95% of your available storage.</Text>
+          <Button variant="primary" size="small">
+            Upgrade plan
+          </Button>
+        </Stack>
+      </SectionMessage.Content>
+    </SectionMessage>
+  ),
 });
 
 export const MultiLineTitle = meta.story({

--- a/packages/components/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/components/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -80,17 +80,25 @@ export const Basic = meta.story({
       <SegmentedControl.Option value="drafts">Drafts</SegmentedControl.Option>
     </SegmentedControl>
   ),
-  play: async ({ canvas }) => {
+});
+
+Basic.test(
+  'selects an option on click',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
     const past = canvas.getByRole('radio', { name: 'Past' });
 
     await userEvent.click(past);
 
     await expect(past).toBeChecked();
-  },
-});
+  }
+);
 
 export const Controlled = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     label: 'Layout',
   },
@@ -107,14 +115,18 @@ export const Controlled = meta.story({
       </Stack>
     );
   },
-  play: async ({ canvas }) => {
+});
+
+Controlled.test(
+  'reflects the selected value in controlled mode',
+  async ({ canvas }) => {
     const grid = canvas.getByRole('radio', { name: 'Grid' });
 
     await userEvent.click(grid);
 
     await expect(canvas.getByText('Selected: grid')).toBeVisible();
-  },
-});
+  }
+);
 
 export const DisabledOption = meta.story({
   tags: ['component-test'],
@@ -129,15 +141,22 @@ export const DisabledOption = meta.story({
       </SegmentedControl.Option>
     </SegmentedControl>
   ),
-  play: async ({ canvas }) => {
+});
+
+DisabledOption.test(
+  'does not select a disabled option',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
     const grid = canvas.getByRole('radio', { name: 'Grid' });
 
     await userEvent.click(grid);
 
     await expect(grid).toBeDisabled();
     await expect(canvas.getByRole('radio', { name: 'List' })).toBeChecked();
-  },
-});
+  }
+);
 
 // Stress test only: this intentionally exceeds the recommended 2–5 options
 // (see the docs' "Number of options" guideline) to exercise the horizontal
@@ -161,7 +180,14 @@ export const Overflow = meta.story({
       </SegmentedControl>
     </div>
   ),
-  play: async ({ canvas, canvasElement }) => {
+});
+
+Overflow.test(
+  'keeps the selected option in view when overflowing',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, canvasElement }) => {
     const presentation = canvasElement.querySelector(
       '[role="presentation"]'
     ) as HTMLElement;
@@ -173,8 +199,8 @@ export const Overflow = meta.story({
     await waitFor(() => expect(scroller.scrollLeft).toBeGreaterThan(0));
     expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
     expect(august).toBeChecked();
-  },
-});
+  }
+);
 
 // Regression guard for the 320px overflow report (DST-765). Pinned to the
 // 320px viewport and rendered without a width wrapper so the segments overflow
@@ -199,7 +225,14 @@ export const OverflowSmallScreen = meta.story({
       ))}
     </SegmentedControl>
   ),
-  play: async ({ canvas, canvasElement }) => {
+});
+
+OverflowSmallScreen.test(
+  'scrolls inside the track without bleeding past its edges',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, canvasElement }) => {
     const track = canvasElement.querySelector(
       '[role="presentation"]'
     ) as HTMLElement;
@@ -220,8 +253,8 @@ export const OverflowSmallScreen = meta.story({
     const august = canvas.getByRole('radio', { name: 'Aug' });
     await userEvent.click(august);
     await expect(august).toBeChecked();
-  },
-});
+  }
+);
 
 export const WithError = meta.story({
   tags: ['component-test'],
@@ -239,7 +272,14 @@ export const WithError = meta.story({
       <SegmentedControl.Option value="private">Private</SegmentedControl.Option>
     </SegmentedControl>
   ),
-  play: async ({ canvas, args }) => {
+});
+
+WithError.test(
+  'exposes the error message and aria-invalid',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, args }) => {
     const group = canvas.getByRole('radiogroup');
 
     await waitFor(() =>
@@ -247,11 +287,12 @@ export const WithError = meta.story({
     );
 
     expect(group).toHaveAttribute('aria-invalid', 'true');
-  },
-});
+  }
+);
 
 export const InForm = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     label: 'Status',
   },
@@ -281,7 +322,14 @@ export const InForm = meta.story({
       </Form>
     );
   },
-  play: async ({ canvas }) => {
+});
+
+InForm.test(
+  'submits the selected value as form data',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
     const archived = canvas.getByRole('radio', { name: 'Archived' });
 
     await userEvent.click(archived);
@@ -290,7 +338,7 @@ export const InForm = meta.story({
     await waitFor(() =>
       expect(canvas.getByText('Submitted: archived')).toBeVisible()
     );
-  },
-});
+  }
+);
 
 export default meta;

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -236,6 +236,7 @@ Basic.test(
   'Opens the list grouped into sections',
   {
     parameters: { chromatic: { disableSnapshot: false } },
+    args: { defaultValue: 'harry-potter' },
     render: args => (
       <Select {...args}>
         <Select.Section header="Fantasy">
@@ -263,10 +264,20 @@ Basic.test(
       </Select>
     ),
   },
-  async ({ args, canvas }) => {
-    await userEvent.click(
-      canvas.getByLabelText(new RegExp(`${args.label}`, 'i'))
+  async ({ args, canvas, step }) => {
+    const trigger = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
+
+    await step(
+      'Default trigger shows the text value but hides the description slot',
+      () => {
+        expect(within(trigger).getByText('Harry Potter')).toBeVisible();
+        expect(
+          within(trigger).getByText('About the boy who lived')
+        ).not.toBeVisible();
+      }
     );
+
+    await userEvent.click(trigger);
 
     const listbox = await canvas.findByRole('listbox');
     expect(within(listbox).getByText('Fantasy')).toBeVisible();

--- a/packages/components/src/Select/Select.stories.tsx
+++ b/packages/components/src/Select/Select.stories.tsx
@@ -557,6 +557,7 @@ const renderUserOption = (person: (typeof people)[number]) => (
 
 export const WithRenderValue = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     label: 'Assign to',
     placeholder: 'Select a user',
@@ -567,7 +568,11 @@ export const WithRenderValue = meta.story({
       {renderUserOption}
     </Select>
   ),
-  play: async ({ args, canvas, step }) => {
+});
+
+WithRenderValue.test(
+  'renders the selected value with a custom renderValue',
+  async ({ args, canvas, step }) => {
     const trigger = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
 
     await step('Trigger shows placeholder when nothing selected', async () => {
@@ -596,8 +601,8 @@ export const WithRenderValue = meta.story({
         within(trigger).queryByText('Senior Developer')
       ).not.toBeInTheDocument();
     });
-  },
-});
+  }
+);
 
 /**
  * Mobile counterpart of {@link WithRenderValue}: below the `sm` breakpoint the
@@ -608,6 +613,7 @@ export const WithRenderValue = meta.story({
  */
 export const WithRenderValueMobile = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   globals: {
     viewport: { value: 'smallScreen' },
   },
@@ -621,7 +627,11 @@ export const WithRenderValueMobile = meta.story({
       {renderUserOption}
     </Select>
   ),
-  play: async ({ args, canvas, step }) => {
+});
+
+WithRenderValueMobile.test(
+  'renders the selected value with a custom renderValue in the tray',
+  async ({ args, canvas, step }) => {
     // Fail loudly if the mobile viewport did not take effect, rather than
     // passing a test that never exercised the tray branch.
     expect(window.innerWidth).toBeLessThan(640);
@@ -652,11 +662,12 @@ export const WithRenderValueMobile = meta.story({
         within(trigger).queryByText('Senior Developer')
       ).not.toBeInTheDocument();
     });
-  },
-});
+  }
+);
 
 export const MultiSelectSummary = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     label: 'Formatting',
     width: 64,
@@ -678,7 +689,12 @@ export const MultiSelectSummary = meta.story({
       <Select.Option id="underline">Underline</Select.Option>
     </Select>
   ),
-  play: async ({ args, canvas }) => {
+});
+
+MultiSelectSummary.test(
+  'collapses multiple selections into a compact count summary',
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ args, canvas }) => {
     const trigger = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
 
     await userEvent.click(trigger);
@@ -696,8 +712,8 @@ export const MultiSelectSummary = meta.story({
     // Two selections collapse to a compact "N selected" summary, rather than
     // listing every value on the trigger.
     expect(within(trigger).getByText('2 selected')).toBeVisible();
-  },
-});
+  }
+);
 
 /**
  * Mobile counterpart of {@link MultiSelectSummary}: the `count`-based summary
@@ -708,6 +724,7 @@ export const MultiSelectSummary = meta.story({
  */
 export const MultiSelectSummaryMobile = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   globals: {
     viewport: { value: 'smallScreen' },
   },
@@ -728,7 +745,12 @@ export const MultiSelectSummaryMobile = meta.story({
       <Select.Option id="underline">Underline</Select.Option>
     </Select>
   ),
-  play: async ({ args, canvas, step }) => {
+});
+
+MultiSelectSummaryMobile.test(
+  'shows the compact count summary from the tray branch',
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ args, canvas, step }) => {
     expect(window.innerWidth).toBeLessThan(640);
 
     const trigger = canvas.getByLabelText(new RegExp(`${args.label}`, 'i'));
@@ -756,8 +778,8 @@ export const MultiSelectSummaryMobile = meta.story({
     await step('Trigger shows the compact count summary', () => {
       expect(within(trigger).getByText('2 selected')).toBeVisible();
     });
-  },
-});
+  }
+);
 
 /**
  * Quick-filter pattern: a multi-select whose trigger always shows the filter's
@@ -773,6 +795,7 @@ export const MultiSelectSummaryMobile = meta.story({
  */
 export const QuickFilter = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => (
     <Select
       aria-label="Status"
@@ -797,7 +820,12 @@ export const QuickFilter = meta.story({
       <Select.Option id="archived">Archived</Select.Option>
     </Select>
   ),
-  play: async ({ canvas }) => {
+});
+
+QuickFilter.test(
+  'keeps the dimension label and reflects the active count in a badge',
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ canvas }) => {
     const trigger = canvas.getByRole('button', { name: /Status/i });
 
     // Until something is selected, the trigger shows the bare label and no badge.
@@ -825,8 +853,8 @@ export const QuickFilter = meta.story({
     expect(
       canvas.getByRole('button', { name: /2 selected/i })
     ).toBeInTheDocument();
-  },
-});
+  }
+);
 
 export const Mobile = meta.story({
   tags: ['component-test'],

--- a/packages/components/src/Select/Select.test.tsx
+++ b/packages/components/src/Select/Select.test.tsx
@@ -2,12 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { RefObject } from 'react';
 import { mockMatchMedia, renderWithOverlay } from '../test.utils';
-import {
-  Basic,
-  MultiSelectSummary,
-  Sections,
-  WithRenderValue,
-} from './Select.stories';
+import { Basic, MultiSelectSummary, WithRenderValue } from './Select.stories';
 
 const user = userEvent.setup();
 
@@ -168,16 +163,4 @@ test('renderValue count reflects a single selection with static children', async
   await user.click(await screen.findByRole('option', { name: 'Bold' }));
 
   await waitFor(() => expect(button).toHaveTextContent(/1 selected/));
-});
-
-test('default trigger render hides description slot', () => {
-  renderWithOverlay(
-    <Sections.Component label="Label" defaultValue="harry-potter" />
-  );
-
-  const description = within(screen.getByRole('button')).getByText(
-    'About the boy who lived'
-  );
-
-  expect(description).not.toBeVisible();
 });

--- a/packages/components/src/SelectList/SelectList.stories.tsx
+++ b/packages/components/src/SelectList/SelectList.stories.tsx
@@ -219,7 +219,14 @@ export const Basic = meta.story({
       </SelectList.Option>
     </SelectList>
   ),
-  play: async ({ args, canvas, step }) => {
+});
+
+Basic.test(
+  'selects a single option and notifies onChange',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ args, canvas, step }) => {
     const creditRow = await canvas.findByRole('row', { name: /credit card/i });
     const paypalRow = canvas.getByRole('row', { name: /paypal/i });
 
@@ -249,11 +256,12 @@ export const Basic = meta.story({
         expect(args.onChange).not.toHaveBeenCalled();
       }
     );
-  },
-});
+  }
+);
 
 export const WithMultiSelection = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     selectionMode: 'multiple',
     onChange: fn(),
@@ -282,20 +290,30 @@ export const WithMultiSelection = meta.story({
       </SelectList.Option>
     </SelectList>
   ),
-  play: async ({ args, canvas, step }) => {
+});
+
+WithMultiSelection.test(
+  'toggles multiple options independently',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ args, canvas, step }) => {
     const insuranceRow = await canvas.findByRole('row', {
       name: /parcel insurance/i,
     });
     const giftWrapRow = canvas.getByRole('row', { name: /gift wrap/i });
+    const notify = canvas.getByRole('row', { name: /sms notifications/i });
 
     await step('clicking selects multiple rows independently', async () => {
       await userEvent.click(insuranceRow);
       await userEvent.click(giftWrapRow);
+      await userEvent.click(notify);
 
       expect(insuranceRow).toHaveAttribute('aria-selected', 'true');
       expect(giftWrapRow).toHaveAttribute('aria-selected', 'true');
+      expect(notify).toHaveAttribute('aria-selected', 'true');
       expect(args.onChange).toHaveBeenLastCalledWith(
-        expect.arrayContaining(['insurance', 'gift-wrap'])
+        expect.arrayContaining(['insurance', 'gift-wrap', 'notify'])
       );
     });
 
@@ -304,10 +322,11 @@ export const WithMultiSelection = meta.story({
 
       expect(insuranceRow).toHaveAttribute('aria-selected', 'false');
       expect(giftWrapRow).toHaveAttribute('aria-selected', 'true');
-      expect(args.onChange).toHaveBeenLastCalledWith(['gift-wrap']);
+      expect(notify).toHaveAttribute('aria-selected', 'true');
+      expect(args.onChange).toHaveBeenLastCalledWith(['gift-wrap', 'notify']);
     });
-  },
-});
+  }
+);
 
 const paymentMethods = [
   {
@@ -360,7 +379,14 @@ export const WithIconAction = meta.story({
       )}
     </SelectList>
   ),
-  play: async ({ canvas, step }) => {
+});
+
+WithIconAction.test(
+  'fires the row action without toggling selection',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, step }) => {
     const button = await canvas.findByRole('button', {
       name: 'Learn more about Credit card',
     });
@@ -378,8 +404,8 @@ export const WithIconAction = meta.story({
     });
 
     alertSpy.mockRestore();
-  },
-});
+  }
+);
 
 const savedPayments = [
   {
@@ -435,7 +461,14 @@ export const WithActionMenu = meta.story({
       )}
     </SelectList>
   ),
-  play: async ({ canvas, step }) => {
+});
+
+WithActionMenu.test(
+  'opens the row menu without toggling selection',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, step }) => {
     const trigger = await canvas.findByRole('button', {
       name: 'Manage Visa ending in 4242',
     });
@@ -457,10 +490,11 @@ export const WithActionMenu = meta.story({
     await step('opening the menu does not toggle the row', () => {
       expect(row).toHaveAttribute('aria-selected', 'false');
     });
-  },
-});
+  }
+);
 
 export const Horizontal = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     orientation: 'horizontal',
   },
@@ -563,7 +597,14 @@ export const HorizontalResponsive = meta.story({
       </div>
     </Stack>
   ),
-  play: async ({ canvas, step }) => {
+});
+
+HorizontalResponsive.test(
+  'flips horizontal options to a vertical stack in a narrow container',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas, step }) => {
     const wide = canvas.getByTestId('wide-container');
     const medium = canvas.getByTestId('medium-container');
     const narrow = canvas.getByTestId('narrow-container');
@@ -588,8 +629,8 @@ export const HorizontalResponsive = meta.story({
         expect(listWidth).toBeLessThanOrEqual(containerWidth);
       }
     );
-  },
-});
+  }
+);
 
 const borderedMethods = [
   {
@@ -648,6 +689,7 @@ export const Bordered = meta.story({
 
 export const WithCustomPadding = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     p: 'square-loose',
   },
@@ -672,7 +714,14 @@ export const WithCustomPadding = meta.story({
       </SelectList.Option>
     </SelectList>
   ),
-  play: async ({ canvas }) => {
+});
+
+WithCustomPadding.test(
+  'applies the inset padding tokens to each option',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ canvas }) => {
     const standardRow = await canvas.findByRole('row', { name: /standard/i });
     expect(standardRow).toHaveClass(
       'px-(--selectlist-item-px)',
@@ -685,8 +734,8 @@ export const WithCustomPadding = meta.story({
     expect(list.style.getPropertyValue('--selectlist-item-py')).toBe(
       'var(--spacing-square-loose-y)'
     );
-  },
-});
+  }
+);
 
 export const EmptyState = meta.story({
   args: {
@@ -740,14 +789,21 @@ export const Disabled = meta.story({
       </SelectList.Option>
     </SelectList>
   ),
-  play: async ({ args, canvas }) => {
+});
+
+Disabled.test(
+  'ignores clicks while disabled',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+  },
+  async ({ args, canvas }) => {
     const expressRow = await canvas.findByRole('row', { name: /express/i });
 
     await userEvent.click(expressRow);
 
     expect(args.onChange).not.toHaveBeenCalled();
-  },
-});
+  }
+);
 
 export const WithError = meta.story({
   render: args => (
@@ -779,6 +835,7 @@ export const WithError = meta.story({
 
 export const WithForm = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     selectionMode: 'multiple',
   },
@@ -820,7 +877,11 @@ export const WithForm = meta.story({
       </Stack>
     </Form>
   ),
-  play: async ({ canvas }) => {
+});
+
+WithForm.test(
+  'submits the selected values as form data',
+  async ({ canvas }) => {
     await userEvent.click(
       await canvas.findByRole('row', { name: /parcel insurance/i })
     );
@@ -831,5 +892,5 @@ export const WithForm = meta.story({
         'submitted: insurance,gift-wrap'
       );
     });
-  },
-});
+  }
+);

--- a/packages/components/src/Stack/Stack.stories.tsx
+++ b/packages/components/src/Stack/Stack.stories.tsx
@@ -1,4 +1,3 @@
-import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
 import { alignment } from '@marigold/system';
 import { Headline } from '../Headline/Headline';

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -77,6 +77,14 @@ export const Basic = meta.story({
   tags: ['component-test'],
 });
 
+export const Settings = meta.story({
+  args: {
+    variant: 'settings',
+    label: 'Email notifications',
+    description: 'Receive email notifications when someone mentions you',
+  },
+});
+
 Basic.test('Toggles on when clicked', async ({ canvas, userEvent }) => {
   const button = canvas.getByRole('switch');
 

--- a/packages/components/src/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/Tabs/Tabs.stories.tsx
@@ -197,9 +197,6 @@ export const Mobile = meta.story({
   globals: {
     viewport: { value: 'extraSmallScreen' },
   },
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
   render: args => (
     <Tabs aria-label="tabs" {...args}>
       <Tabs.List aria-label="Workspace settings">
@@ -216,7 +213,16 @@ export const Mobile = meta.story({
       ))}
     </Tabs>
   ),
-  play: async ({ canvas, step }) => {
+});
+
+Mobile.test(
+  'scrolls the tab row and activates an overflowed tab',
+  {
+    parameters: {
+      chromatic: { disableSnapshot: true },
+    },
+  },
+  async ({ canvas, userEvent, step }) => {
     let lastTab: HTMLElement;
 
     await step('Arrange', async () => {
@@ -241,5 +247,5 @@ export const Mobile = meta.story({
       );
       await expect(indicator).toBeVisible();
     });
-  },
-});
+  }
+);

--- a/packages/components/src/TagField/TagField.stories.tsx
+++ b/packages/components/src/TagField/TagField.stories.tsx
@@ -221,20 +221,6 @@ LargeDataset.test(
   }
 );
 
-export const Disabled = Basic.extend({
-  tags: ['component-test'],
-  args: {
-    disabled: true,
-  },
-});
-
-Disabled.test('shows not-allowed cursor when disabled', async ({ canvas }) => {
-  const trigger = canvas.getByRole('button');
-  const style = window.getComputedStyle(trigger);
-
-  await expect(style.cursor).toBe('not-allowed');
-});
-
 export const DisabledItems = Basic.extend({
   tags: ['component-test'],
   parameters: { chromatic: { disableSnapshot: true } },
@@ -279,8 +265,22 @@ DisabledItems.test(
   }
 );
 
+DisabledItems.test(
+  'shows not-allowed cursor when disabled',
+  {
+    args: { disabled: true },
+  },
+  async ({ canvas }) => {
+    const trigger = canvas.getByRole('button');
+    const style = window.getComputedStyle(trigger);
+
+    await expect(style.cursor).toBe('not-allowed');
+  }
+);
+
 export const Mobile = Basic.extend({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   globals: {
     viewport: { value: 'smallScreen' },
   },

--- a/packages/components/src/TagGroup/TagGroup.stories.tsx
+++ b/packages/components/src/TagGroup/TagGroup.stories.tsx
@@ -206,6 +206,7 @@ export const WithError = meta.story({
 
 export const WithForm = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Form
       onSubmit={e => {
@@ -236,7 +237,12 @@ export const WithForm = meta.story({
       </Stack>
     </Form>
   ),
-  play: async ({ canvas }) => {
+});
+
+WithForm.test(
+  'submits the selected tags as form data',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     await userEvent.click(await canvas.findByText('Travel'));
     await userEvent.click(canvas.getByText('Gaming'));
     await userEvent.click(canvas.getByRole('button', { name: /submit/i }));
@@ -246,8 +252,8 @@ export const WithForm = meta.story({
         'submitted: travel,gaming'
       );
     });
-  },
-});
+  }
+);
 
 export const Required = meta.story({
   tags: ['component-test'],
@@ -273,7 +279,12 @@ export const Required = meta.story({
       </Stack>
     </Form>
   ),
-  play: async ({ canvas }) => {
+});
+
+Required.test(
+  'shows the validation error when submitted without a selection',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: /submit/i }));
 
     await waitFor(() =>
@@ -281,5 +292,5 @@ export const Required = meta.story({
         canvas.getByText('Pick at least one category.')
       ).toBeInTheDocument()
     );
-  },
-});
+  }
+);

--- a/packages/components/src/TextValue/TextValue.stories.tsx
+++ b/packages/components/src/TextValue/TextValue.stories.tsx
@@ -40,12 +40,17 @@ export const InsideListBoxItem = meta.story({
       </ListBoxItem>
     </ListBox>
   ),
-  play: async ({ canvas }) => {
+});
+
+InsideListBoxItem.test(
+  'resolves each option accessible name from its TextValue',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     await expect(
       await canvas.findByRole('option', { name: 'Apple' })
     ).toBeInTheDocument();
     await expect(
       canvas.getByRole('option', { name: 'Banana' })
     ).toBeInTheDocument();
-  },
-});
+  }
+);

--- a/packages/components/src/Title/Title.stories.tsx
+++ b/packages/components/src/Title/Title.stories.tsx
@@ -19,28 +19,47 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  tags: ['component-test'],
   args: {
     children: 'Panel title',
   },
   render: ({ children, ...args }) => <Title {...args}>{children}</Title>,
 });
 
-export const Levels = meta.story({
-  render: () => (
-    <Stack space={2}>
-      <Title level={1}>Title rendered as h1</Title>
-      <Title level={2}>Title rendered as h2 (default)</Title>
-      <Title level={3}>Title rendered as h3</Title>
-    </Stack>
-  ),
-});
-
-export const Renders = meta.story({
-  tags: ['component-test'],
-  render: () => <Title>Panel title</Title>,
-  play: async ({ canvas }) => {
+Basic.test(
+  'renders as a level-2 heading by default',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
     await expect(
       canvas.getByRole('heading', { level: 2, name: 'Panel title' })
     ).toBeInTheDocument();
+  }
+);
+
+Basic.test(
+  'renders at each configured heading level',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    render: () => (
+      <Stack space={2}>
+        <Title level={1}>Title rendered as h1</Title>
+        <Title level={2}>Title rendered as h2 (default)</Title>
+        <Title level={3}>Title rendered as h3</Title>
+      </Stack>
+    ),
   },
-});
+  async ({ canvas }) => {
+    await expect(
+      canvas.getByRole('heading', { level: 1, name: 'Title rendered as h1' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', {
+        level: 2,
+        name: 'Title rendered as h2 (default)',
+      })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { level: 3, name: 'Title rendered as h3' })
+    ).toBeInTheDocument();
+  }
+);

--- a/packages/components/src/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/components/src/ToggleButton/ToggleButton.stories.tsx
@@ -81,8 +81,30 @@ Basic.test(
   }
 );
 
+Basic.test(
+  'applies the selected foreground styling when toggled on',
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ canvas }) => {
+    const button = canvas.getByRole('button');
+
+    // The selected appearance is wired to react-aria's `data-selected` via the
+    // theme's `selected:*` utilities on the button.
+    expect(button).toHaveClass('selected:text-selected-bold-foreground');
+
+    const colorWhenUnselected = getComputedStyle(button).color;
+
+    await userEvent.click(button);
+
+    expect(button).toHaveAttribute('data-selected', 'true');
+    // Selecting swaps the text colour to the bold selected foreground, so the
+    // resolved colour must actually change.
+    expect(getComputedStyle(button).color).not.toBe(colorWhenUnselected);
+  }
+);
+
 export const BothSurfaces = meta.story({
   parameters: {
+    chromatic: { disableSnapshot: true },
     surface: 'both',
   },
   render: args => <ToggleButton {...args}>Toggle</ToggleButton>,

--- a/packages/components/src/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/components/src/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -120,7 +120,7 @@ Basic.test(
 
 export const BothSurfaces = meta.story({
   parameters: {
-    parameters: { chromatic: { disableSnapshot: true } },
+    chromatic: { disableSnapshot: true },
     surface: 'both',
   },
   args: {

--- a/packages/components/src/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/components/src/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -120,6 +120,7 @@ Basic.test(
 
 export const BothSurfaces = meta.story({
   parameters: {
+    parameters: { chromatic: { disableSnapshot: true } },
     surface: 'both',
   },
   args: {

--- a/packages/components/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/Tooltip/Tooltip.stories.tsx
@@ -1,3 +1,4 @@
+import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Tooltip } from './Tooltip';
@@ -64,6 +65,8 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  tags: ['component-test'],
   render: args => {
     return (
       <div className="ms-auto me-auto flex w-[min(100%-3rem,60ch)] gap-2 pt-32">
@@ -78,3 +81,19 @@ export const Basic = meta.story({
     );
   },
 });
+
+// Opens the tooltip (focus-visible) and re-enables the snapshot the base story
+// disables, so Chromatic captures the tooltip in its open state.
+Basic.test(
+  'shows the tooltip on focus',
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ canvas, userEvent }) => {
+    await userEvent.tab();
+
+    const tooltip = await waitFor(() => canvas.getByRole('tooltip'));
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toHaveTextContent(
+      'I am a much more longer tooltip you know!'
+    );
+  }
+);

--- a/packages/components/src/Tooltip/TooltipTrigger.stories.tsx
+++ b/packages/components/src/Tooltip/TooltipTrigger.stories.tsx
@@ -78,6 +78,7 @@ const meta = preview.meta({
 });
 
 export const Trigger = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => {
     return (
       <div className="ms-auto me-auto flex w-[min(100%_-_3rem,60ch)] gap-2 pt-32">
@@ -98,6 +99,7 @@ export const Trigger = meta.story({
 });
 
 export const ControlledTooltipTrigger = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => {
     const [open, setOpen] = useState(false);
     return (
@@ -116,6 +118,7 @@ export const ControlledTooltipTrigger = meta.story({
 });
 
 export const Single = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   args: {
     delay: 0,
   },

--- a/packages/components/src/Tray/Tray.stories.tsx
+++ b/packages/components/src/Tray/Tray.stories.tsx
@@ -165,7 +165,6 @@ export const DismissControlsWithCallbacks = meta.story({
 
 DismissControlsWithCallbacks.test(
   'Dismiss controls and callback hooks',
-  { parameters: { chromatic: { disableSnapshot: true } } },
   async ({ canvas, step }) => {
     await step('Shows closed state initially', async () => {
       expect(canvas.getByText('Tray is closed')).toBeInTheDocument();
@@ -221,6 +220,7 @@ DismissControlsWithCallbacks.test(
  */
 export const SlotPrimitives = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Tray.Trigger>
       <Button>Open Tray</Button>
@@ -249,7 +249,14 @@ export const SlotPrimitives = meta.story({
       </Tray>
     </Tray.Trigger>
   ),
-  play: async ({ canvas }) => {
+});
+
+SlotPrimitives.test(
+  'Renders slot primitives with grouped actions',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open Tray' }));
     await waitFor(() =>
       expect(canvas.getByText('Manage event')).toBeInTheDocument()
@@ -264,8 +271,8 @@ export const SlotPrimitives = meta.story({
     expect(
       canvas.getByRole('toolbar', { name: 'Event actions' })
     ).toBeInTheDocument();
-  },
-});
+  }
+);
 
 /**
  * A bare `<Title slot="title">` (no `<Tray.Header>`, no description) labels the
@@ -273,6 +280,7 @@ export const SlotPrimitives = meta.story({
  */
 export const TitleOnlyWithoutHeader = meta.story({
   tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
   render: args => (
     <Tray.Trigger>
       <Button>Open Tray</Button>
@@ -286,7 +294,11 @@ export const TitleOnlyWithoutHeader = meta.story({
       </Tray>
     </Tray.Trigger>
   ),
-  play: async ({ canvas }) => {
+});
+
+TitleOnlyWithoutHeader.test(
+  'Labels the tray with a bare Title',
+  async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Open Tray' }));
 
     const tray = await waitFor(() =>
@@ -296,5 +308,5 @@ export const TitleOnlyWithoutHeader = meta.story({
 
     expect(title.tagName).toBe('H2');
     expect(tray).toHaveAttribute('aria-labelledby', title.id);
-  },
-});
+  }
+);


### PR DESCRIPTION
# Description

Adjusts the component stories on `beta-release` that still used the old `play`-function style so they use the `.test()` API, matching the DST-1562 story cleanup already on `main`. This resolves the divergence called out in the ticket and gets the beta branch's typecheck and test suites fully green.

Along the way it also fixes the pre-existing failures those suites were already carrying (unrelated to the conversion but blocking a clean run):

- **Converted `play` → `.test()`**: ButtonGroup, Description, Dialog, Drawer, Inline, Inset, ListBox, SectionMessage, SegmentedControl, Select, SelectList, Tabs, TagGroup, TextValue, Title, ToggleButton, Tooltip, Tray (plus Card, Icons, LinkButton, TagField, ToggleButtonGroup, TooltipTrigger).
- **Restored missing story fixtures** imported by unit tests: `Switch.Settings`, `ContextualHelp.WithDescription`.
- **Fixed stale/contradictory tests**: the ContextualHelp title assertion, the Button "add icon" test, and a contradictory Card `aria-label` unit test.
- **Relocated one Select unit test**: `default trigger render hides description slot` imported the `Sections` story fixture, which no longer exists as an export on `beta-release` (it was folded into a `Basic.test()` before this PR). The assertion now lives in the `Opens the list grouped into sections` story test, which selects a default value and verifies the trigger shows the `TextValue` while its description slot stays hidden.
- **Guarded intentional invalid-prop tests** (`width="fit"`) with `@ts-expect-error`.
- **Removed dead imports** (Button, Menu, Stack) and the **orphan empty `Multiselect.stories.tsx`** stub (the component was removed in DST-1283).

Result: `pnpm typecheck:only` → 0 errors · full unit suite → 1350 passed · full Storybook suite → 378 passed.

Closes DST-1592

## Visual regression / Chromatic

No component or theme source changed — this is a test/story refactor, not a visual redesign. Chromatic will show snapshot-count deltas because a few purely-visual stories were collapsed into `.test()` cases and some interaction tests toggle `disableSnapshot`. These are expected, not visual regressions. The Select `Opens the list grouped into sections` snapshot additionally changes because the trigger now renders a default selection ("Harry Potter") instead of the placeholder.

## Test Instructions

1. `pnpm install`
2. `pnpm typecheck:only` — expect 0 errors
3. `pnpm test:unit --run` — expect all passing
4. `pnpm test:sb --run` — expect all passing

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`) — N/A, story/test-only (nothing published changes)
