### PR TITLE
fix(DST-1556): rename SectionMessage's controlled close prop to open

### DIFF
--- a/.changeset/section-message-open-prop.md
+++ b/.changeset/section-message-open-prop.md
@@ -1,0 +1,15 @@
+---
+'@marigold/components': major
+---
+
+fix(DST-1556): rename SectionMessage's controlled visibility prop from `close` to `open`
+
+`<SectionMessage>`'s controlled visibility prop was named `close` but its truthiness meant *visible* ,  `close={true}` showed the message and `close={false}` hid it, the opposite of what the name and docs implied. It's now `open`, matching the polarity used by `<Dialog>`, `<Drawer>`, `<Tray>`, and `<Sidebar>`.
+
+| Before                                           | After                                                          |
+| ------------------------------------------------- | ----------------------------------------------------------------- |
+| `close={isVisible}` (truthy = visible)             | `open={isVisible}` (truthy = visible)                              |
+| `close={!isDismissed}`                             | `open={!isDismissed}`                                              |
+| `onCloseChange={setX}` (receives current value)    | `onOpenChange={(open) => ...}` (receives `false` on dismiss)       |
+
+A new `defaultOpen` prop (default `true`) sets the initial visibility in uncontrolled mode. The uncontrolled default behavior (visible, self-dismisses via the close button) is unchanged.

--- a/docs/content/components/content/section-message/index.mdx
+++ b/docs/content/components/content/section-message/index.mdx
@@ -85,7 +85,7 @@ To allow dismissal, set the `closeButton` property on the `<SectionMessage>`.
 
 <ComponentDemo name="section-message-dismissable" />
 
-For full control over when the message is shown or hidden, use the `close` and `onClose` properties.
+For full control over when the message is shown or hidden, use the `open` and `onOpenChange` properties.
 
 When the user dismisses the message, make sure keyboard focus moves to a useful destination: the control that triggered the message, the preceding heading, or the next interactive element. Losing focus leaves keyboard and screen reader users disoriented.
 

--- a/packages/components/src/SectionMessage/SectionMessage.stories.tsx
+++ b/packages/components/src/SectionMessage/SectionMessage.stories.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
+import { Button } from '../Button/Button';
+import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
 import { SectionMessage } from './SectionMessage';
 
@@ -152,4 +155,31 @@ export const MultiLineTitle = meta.story({
       </SectionMessage>
     </div>
   ),
+});
+
+export const ControlledSectionMessage = meta.story({
+  render: args => {
+    const [deleted, setDeleted] = useState(false);
+
+    return (
+      <Stack space={4} alignX="left">
+        <Button variant="secondary" onPress={() => setDeleted(true)}>
+          Delete item
+        </Button>
+        <SectionMessage
+          {...args}
+          variant="success"
+          closeButton
+          open={deleted}
+          onOpenChange={setDeleted}
+        >
+          <SectionMessage.Title>Item deleted</SectionMessage.Title>
+          <SectionMessage.Content>
+            The item was removed successfully. Dismiss this message or delete
+            again to bring it back.
+          </SectionMessage.Content>
+        </SectionMessage>
+      </Stack>
+    );
+  },
 });

--- a/packages/components/src/SectionMessage/SectionMessage.test.tsx
+++ b/packages/components/src/SectionMessage/SectionMessage.test.tsx
@@ -154,14 +154,14 @@ test('allow to close message with button in message', async () => {
 
 test('support controlled dismiss message', async () => {
   const Controlled = () => {
-    const [close, setClose] = useState(false);
+    const [open, setOpen] = useState(true);
 
     return (
       <Basic.Component
         data-testid="messages"
         closeButton
-        close={!close}
-        onCloseChange={setClose}
+        open={open}
+        onOpenChange={setOpen}
       />
     );
   };

--- a/packages/components/src/SectionMessage/SectionMessage.tsx
+++ b/packages/components/src/SectionMessage/SectionMessage.tsx
@@ -48,16 +48,21 @@ export interface SectionMessageProps {
    */
   closeButton?: boolean;
   /**
-   * Handler that is called when you need to control the dismissable message to close.
+   * Whether the message is open/visible (controlled). Pass `false` to hide the message.
    */
-  onCloseChange?: (close: boolean) => void;
+  open?: boolean;
   /**
-   * If the message should be closed/dismissed (controlled).
+   * Whether the message is open/visible by default (uncontrolled).
+   * @default true
    */
-  close?: boolean;
+  defaultOpen?: boolean;
+  /**
+   * Handler that is called when the user dismisses the message. Called with `false`.
+   */
+  onOpenChange?: (open: boolean) => void;
   /**
    * Announce the message to assistive technology when it appears.
-   * Fires on mount and whenever controlled visibility (`close`) transitions
+   * Fires on mount and whenever controlled visibility (`open`) transitions
    * from hidden to visible. Priority is `assertive` for `variant="error"` and
    * `polite` for all other variants. To re-announce the same message without a
    * visibility change, remount the component with a changing `key`.
@@ -79,8 +84,9 @@ export const SectionMessage = ({
   size,
   children,
   closeButton,
-  close,
-  onCloseChange,
+  open,
+  defaultOpen = true,
+  onOpenChange,
   announce: announceProp,
   headingLevel = 3,
   ...props
@@ -125,13 +131,13 @@ export const SectionMessage = ({
     [classNames.description]
   );
 
-  const [internalVisible, setInternalVisible] = useState(true);
-  const isCurrentlyVisible = close ?? internalVisible;
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isOpen = open ?? internalOpen;
 
   // Re-announce on each hidden -> visible transition. Same-content re-announce
   // without a visibility change still needs a `key` remount.
   useEffect(() => {
-    if (!isCurrentlyVisible) return;
+    if (!isOpen) return;
     const shouldAnnounce = announceProp ?? variant === 'error';
     if (!shouldAnnounce) return;
     const text = containerRef.current?.textContent?.trim();
@@ -139,17 +145,17 @@ export const SectionMessage = ({
     const priority = variant === 'error' ? 'assertive' : 'polite';
     announce(text, priority);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCurrentlyVisible]);
+  }, [isOpen]);
 
   const handleClose = () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    onCloseChange && close && onCloseChange(close);
-    if (close === undefined) {
-      setInternalVisible(false);
+    if (onOpenChange) {
+      onOpenChange(false);
+    } else {
+      setInternalOpen(false);
     }
   };
 
-  if (!isCurrentlyVisible) return null;
+  if (!isOpen) return null;
 
   return (
     <SectionMessageContext value={{ classNames }}>


### PR DESCRIPTION
# Description

`<SectionMessage>`'s controlled visibility prop was named `close`, but its truthiness meant *visible* — `close={true}` showed the message and `close={false}` hid it, the opposite of what the name and docs implied. The codebase's own usages disagreed on how to read it (some treated it as "visible", others inverted it as "dismissed"), which was the clearest symptom of the bug.

Renamed the prop to `open`/`onOpenChange` (plus a new `defaultOpen` prop for the uncontrolled case), matching the positive polarity already used by `<Dialog>`, `<Drawer>`, `<Tray>`, and `<Sidebar>`. `onOpenChange` now fires with `false` on dismiss instead of the stale current value. The uncontrolled default behavior (visible, self-dismisses via the close button) is unchanged.

Also added a `ControlledSectionMessage` story exercising the new API (a "Delete item" action surfaces a dismissible success message), and fixed a couple of missing `Button`/`Stack` imports in `SectionMessage.stories.tsx` that were blocking typecheck.

Migration:

| Before | After |
| ------ | ----- |
| `close={isVisible}` (truthy = visible) | `open={isVisible}` (truthy = visible) |
| `close={!isDismissed}` | `open={!isDismissed}` |
| `onCloseChange={setX}` (receives current value) | `onOpenChange={(open) => ...}` (receives `false` on dismiss) |

Closes DST-1556

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. Open Storybook → `Components/SectionMessage`
2. Check the `ControlledSectionMessage` story: click "Delete item" to open the message, dismiss it via the close button, then click "Delete item" again to confirm it reopens.
3. Run `pnpm test:unit` and `pnpm test:sb` for `SectionMessage` — all should pass.

## Breaking Changes

Yes — `close`/`onCloseChange` are removed in favor of `open`/`onOpenChange`/`defaultOpen`, with corrected (positive) polarity. See migration table above and the changeset for full details.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)