### PR TITLE
docs(DST-1595): add release notes for v17.7.0, v17.8.0 and v17.9.0

### DIFF
--- a/docs/content/releases/blog/release-2026-06-15.mdx
+++ b/docs/content/releases/blog/release-2026-06-15.mdx
@@ -1,0 +1,80 @@
+---
+title: Marigold v17.7.0
+date: 2026-06-15
+type: Blog
+changed:
+  - components/overlay/dialog
+  - components/overlay/toast
+  - components/navigation/pagination
+  - components/form/select
+---
+
+v17.7.0 is a classic mid-cycle release. You get two small features you'll actually use, a wider `<Dialog>` and sensible auto-dismiss defaults for toasts, plus a batch of bug fixes that goes after a whole class of sneaky dependency-resolution problems. If your mobile `<Select>` ever opened an empty bottom sheet, or your app quietly ignored the locale you set, this one is for you.
+
+## Components
+
+### Dialog gets a `large` size
+
+[`<Dialog>`](/components/overlay/dialog) (and `<ConfirmationDialog>`, which inherits the prop) now accepts `size="large"`. It caps the dialog width at `1024px`, the same as the Tailwind `lg` breakpoint. Reach for it when content doesn't fit the `medium` cap of `768px`, for example multi-month calendars or wider forms.
+
+```tsx
+<Dialog size="large">
+  <Dialog.Title>Plan your stay</Dialog.Title>
+  <Dialog.Content>{/* room for a two-month calendar */}</Dialog.Content>
+</Dialog>
+```
+
+The existing `min()` width formula still applies, so a large dialog stays viewport-safe on smaller screens.
+
+### Toasts auto-dismiss by default
+
+`addToast` now picks a default `timeout` based on `variant` when you don't pass one. Reassuring toasts (`success`, `info`, and the default variant) auto-dismiss after 5 seconds. Higher-severity ones (`warning` and `error`) stay until the user dismisses them.
+
+```tsx
+// Auto-dismisses after 5 seconds
+addToast({ title: 'Changes saved', variant: 'success' });
+
+// Stays until dismissed
+addToast({ title: 'Import failed', variant: 'error' });
+
+// Opt out of auto-dismiss
+addToast({ title: 'Changes saved', variant: 'success', timeout: 0 });
+```
+
+An explicit `timeout` still wins, though anything below 5000ms gets bumped up to that minimum so a toast never disappears before anyone can read it. **This is a behavior change.** `success`, `info`, and default toasts that used to stay on screen now auto-dismiss after 5 seconds. Pass `timeout: 0` to restore the old behavior. The [Toast docs](/components/overlay/toast) have the full timeout rules.
+
+## Bug fixes
+
+### Mobile Select tray could select nothing
+
+On touch viewports, [`<Select>`](/components/form/select) (and other components that fall back to a `<Tray>`) could open an empty bottom sheet next to the real one. Tapping an option selected nothing, the trigger kept showing the placeholder, and the page stayed inert until a reload.
+
+The root cause was dependency resolution, not component logic. `<Tray>` and react-aria-components read the same internal context through different dependency edges. When a consumer's lockfile resolved those edges to two different copies of `react-aria`, the two sides stopped agreeing, a duplicate (and empty) tray modal leaked into the DOM, and the two modals made each other inert.
+
+`<Tray>` now verifies react-aria's hidden collection pass through the DOM itself. The fix holds no matter how your lockfile resolves `react-aria`, and it keeps holding for future react-aria releases that would re-arm the split. Desktop popovers were never affected.
+
+### Locales no longer get lost
+
+The same failure class with a different symptom. Marigold re-exported `I18nProvider` from `@react-aria/i18n`, so a lockfile with two `react-aria` copies could split the locale context. The locale you set through Marigold's `I18nProvider` landed in one copy while the components rendering your UI read the other. Aria labels, date and number formatting, and RTL detection all fell back silently to the default locale.
+
+The re-export now comes from `react-aria-components`, which makes provider and consumers share one context by construction. You don't have to change anything.
+
+### Pagination follows the controlled `page` prop
+
+Previously, the `page` prop on [`<Pagination>`](/components/navigation/pagination) only seeded internal state. External updates, for example resetting to page 1 when a filter changes, had no effect, and the page indicator kept showing the stale page. `page` is now a proper controlled prop. When set, it is the single source of truth, `onChange` reports requested page changes, and `defaultPage` remains the uncontrolled initial value.
+
+Two related cleanups ride along. `onChange` no longer fires when the active page is selected again, and the reset-to-page-1 behavior only triggers when `pageSize` actually changed.
+
+### CLI ships its compiled files again
+
+If you installed `@marigold/cli` right after last release and the `marigold` command pointed at a missing entry file, sorry about that. The release build filter excluded the CLI package, so the published tarball shipped without its `dist/` output. We now build the CLI before publishing, and a fresh install works as advertised.
+
+## Documentation
+
+### Usage with AI, expanded
+
+The [Usage with AI](/getting-started/usage-with-ai) page now covers the three ways to feed Marigold docs to an AI agent. You can point it at the marigold-docs MCP server, at the public `manifest.json` and per-page `.md` endpoints, or at the `@marigold/cli`. New sections collect prompting tips (the renamed-prop gotcha, naming Marigold explicitly, nudging the agent toward the MCP), introduce the Reservix AI helpers from rx-ai-suite, and set honest expectations about what the tooling can and cannot do.
+
+---
+
+That's v17.7.0. The tray and locale fixes close out a bug class that had been biting apps through their lockfiles rather than their code. Those are our favorite kind of fixes, the kind you never have to think about again. Let us know how it lands.

--- a/docs/content/releases/blog/release-2026-06-18.mdx
+++ b/docs/content/releases/blog/release-2026-06-18.mdx
@@ -1,0 +1,72 @@
+---
+title: Marigold v17.8.0
+date: 2026-06-18
+type: Blog
+changed:
+  - components/collection/table
+  - foundations/responsive
+---
+
+This one is all about what you _don't_ ship. `@marigold/components` is now fully tree-shakeable, so your bundler only keeps the components you actually import. Alongside it, editable table cells now work in server-rendered apps, the CLI learns about examples and non-component docs pages, and there is a new Responsive Design foundations page.
+
+## Tree-shaking that actually works
+
+Until now, `@marigold/components` shipped its entire ESM build as one concatenated barrel, a single `index.mjs` that re-exported all 74-plus components. Because every export lived in one module, bundlers could not statically prove which parts were unused, so importing a single leaf component pulled in essentially the whole library. On rspack, a `Stack + Text + Card` import cost about 57 kB, roughly 82% of the library, for three layout primitives.
+
+The build now emits one file per source module, and your bundler gets to drop the rest. That same `Stack + Text + Card` import drops to about 0.8 kB. A single `Button` import goes from about 57 kB to about 1.7 kB.
+
+Nothing changes on your side. The barrel import stays fully backward compatible, so `import { Button } from '@marigold/components'` keeps working exactly as before.
+
+### Why this took more than a build flag
+
+Flipping the unbundle switch exposed everything the old concatenated build had been hiding, so a handful of source changes had to land before tree-shaking could deliver.
+
+- **The toast queue lost its module-scope side effect.** Importing the Toast module used to create the queue immediately and touch `document`. That contradicted the package's `sideEffects: false` promise and could break SSR. The queue is now created lazily on first use.
+- **Animated components dropped the `motion` proxy.** The `motion.*` proxy is by design not tree-shakeable. Referencing `motion.div` drags in the whole renderer, around 34 kB. `ActionBar`, `Tabs`, and `Tray` now use the lightweight `m` components and load the full feature set through a `LazyMotion` boundary in its own async chunk, so the animation code only loads when an animated component actually renders.
+- **`react-select` moved out of the bundle.** The build silently copied it into the dist, all 2 MB of it including `@emotion`, even though it was never a declared dependency. It is now external and properly declared. Only the deprecated `<Multiselect>` uses it, and both leave together in the next major.
+- **A `size-limit` budget gate now runs in CI.** It keeps these wins from silently regressing.
+
+## Bug fixes
+
+### Editable table cells work after SSR hydration
+
+In a server-rendered app, for example Next.js, [`<Table.EditableCell>`](/components/collection/table) was inert after hydration. Clicking a cell did not open its inline editor until an unrelated re-render, such as a window resize, happened to occur. React Aria builds the table collection in a separate render pass, and the editing state lived in that build pass, so the rendered cell content stayed bound to the server pass's closures. The editing state and overlay now live inside the cell's content pass, the same structure React Spectrum's `TableView` uses, and interaction reconnects on its own after hydration.
+
+## CLI
+
+The CLI keeps growing into the terminal-side companion to the docs site.
+
+### `marigold examples`
+
+Two new commands expose Marigold's application-level reference patterns from the terminal.
+
+```bash
+# What reference patterns exist?
+marigold examples list
+
+# Fetch one, e.g. the filtering pattern
+marigold examples get filter --format json
+```
+
+Examples ship for the `filter`, `form`, and `inventory` patterns, with the same `--format`, `--fresh`, and `--offline` flags as the other commands. There is also a framework-transformation note (`marigold docs getting-started/examples-for-agents`) that documents porting the examples from the Next.js App Router to other stacks once, instead of per example.
+
+### Docs pages beyond components
+
+`marigold docs` now resolves any docs page, not just components. You can reach Foundations, Patterns, and Getting Started pages by slug or by name.
+
+```bash
+marigold docs foundations/accessibility
+marigold docs installation
+```
+
+`marigold list` groups those pages under matching headings and accepts `--category foundations|patterns|getting-started`, and shell completion suggests page slugs. For agents, the `--format json` payload gains an additive top-level `pages` array. The existing `categories` shape is unchanged.
+
+## Documentation
+
+### Responsive Design foundations page
+
+A new [Responsive Design](/foundations/responsive) page documents Marigold's mobile-first breakpoint scale, the `useResponsiveValue` and `useSmallScreen` hooks, and the 320px minimum supported width, which is a support floor rather than a breakpoint. Storybook gains a matching "Extra Small Screen (320px)" viewport so you can test layouts at the floor.
+
+---
+
+That's v17.8.0. If your app imports a handful of Marigold components, your users just got a smaller bundle and you didn't have to change a single line. Check your bundle analyzer and tell us what the numbers look like on your end.

--- a/docs/content/releases/blog/release-2026-07-07.mdx
+++ b/docs/content/releases/blog/release-2026-07-07.mdx
@@ -1,0 +1,77 @@
+---
+title: Marigold v17.9.0
+date: 2026-07-07
+type: Blog
+changed:
+  - components/form/daterangepicker
+  - components/form/calendar
+  - components/form/rangecalendar
+  - components/form/select
+  - components/overlay/menu
+  - components/overlay/drawer
+  - components/navigation/tabs
+---
+
+Back in v17.5.0 we shipped `<RangeCalendar>`. Now it gets the field it was waiting for. v17.9.0 introduces `<DateRangePicker>` and completes Marigold's date family. The CLI story continues too. `marigold search` finds components by what their docs actually say, so you (and your agents) can stop guessing names.
+
+## Components
+
+### DateRangePicker
+
+The new [`<DateRangePicker>`](/components/form/daterangepicker) lets users enter or select a start and end date through a single field. It mirrors [`<DatePicker>`](/components/form/datepicker)'s API and behavior. Two date inputs sit in one field group with a calendar button that opens a [`<RangeCalendar>`](/components/form/rangecalendar) in a popover on desktop and a tray on small screens.
+
+```tsx
+<DateRangePicker
+  label="Stay"
+  visibleDuration={{ months: 2 }}
+  minValue={today(getLocalTimeZone())}
+/>
+```
+
+It supports the usual Marigold field props (`disabled`, `readOnly`, `required`, `error`, `errorMessage`, `description`, `minValue`, `maxValue`, `dateUnavailable`, `width`, `variant`, and `size`). Beyond that, each input accepts pasted dates in ISO, EU, and US formats, `granularity` adds inline time segments, and `visibleDuration` renders up to three months side by side. A matching `DateRangePicker` theme entry ships in `theme-rui`.
+
+### Calendar year dropdown, rebuilt on react-aria
+
+In v17.6.0 we made the year picker in [`<Calendar>`](/components/form/calendar) and [`<RangeCalendar>`](/components/form/rangecalendar) derive its year list from `minValue` and `maxValue`, with a hand-rolled list under the hood. That hand-rolled part is now gone. The year dropdown consumes react-aria's `CalendarYearPicker` render prop, just like the month dropdown already consumes `CalendarMonthPicker`. A June react-aria fix made `maxValue` inclusive, which unblocked this cleanup and makes the boundary year reachable.
+
+Behavior stays the same or gets better. Unbounded calendars keep the plus-minus 20-year window, bounded ranges stay fully reachable at both ends, and when only one bound is set, the open side now widens to keep that bound reachable instead of staying at a fixed 20 years.
+
+## CLI
+
+### `marigold search`
+
+`marigold docs` answers "what does this component do?", but you had to know the component's name first. Discovery meant running `list`, guessing, fetching docs, and retrying, a loop that AI agents run three to five calls deep. The new `search` command collapses that loop into a single call.
+
+```bash
+marigold search "field validation"
+
+# Structured, ranked results for agents
+marigold search "field validation" --format json
+```
+
+The command ranks results by matching your query against the docs content (title, description, section headings, and section prose), not just the component name. Each hit comes with snippets and deep links into the docs. The usual `--limit`, `--format`, `--fresh`, and `--offline` flags apply, and tab completion covers the new command.
+
+The CLI also has a proper home on the docs site now. A new [CLI page](/getting-started/cli) under Getting Started covers installation, every command with flags and examples, and configuration.
+
+## Bug fixes
+
+### Select and Menu trays open above Drawer
+
+On small screens, [`<Select>`](/components/form/select) and [`<Menu>`](/components/overlay/menu) render their options in a tray, the bottom sheet that slides up from the edge of the screen. The tray overlay sat at a lower z-index than the [`<Drawer>`](/components/overlay/drawer) overlay, so opening a Select inside a drawer put the options behind the drawer where nobody could reach them. The tray now stacks at the same level as the drawer. Since it always mounts later, it correctly appears on top.
+
+### Tabs `size` no longer advertises values that don't exist
+
+The `size` prop on [`<Tabs>`](/components/navigation/tabs) still offered `'small' | 'medium' | 'large'` literals, even though no theme has backed them for a long time. `size` now accepts a plain string, the same as `Label` and `HelpText`. The prop stays in place as a theme hook, so a consumer theme can define its own size variants without a misleading built-in union.
+
+## Design
+
+- **Rounded range-calendar highlights.** Days outside the selected range in [`<RangeCalendar>`](/components/form/rangecalendar) now round their hover and focus highlight to match the selected state, instead of showing a square highlight against the rounded endpoints. In-range cells stay square so the range fill still connects.
+
+## Under the hood
+
+- **`Checkbox`, `Switch`, and `Radio` moved to the new react-aria composition.** The three components migrated off the deprecated react-aria-components single-element exports to the `*Field` + `*Button` composition introduced in `react-aria-components@1.18.0`. The public API, behavior, and visual output stay the same. This just clears the deprecation warnings.
+- **`theme-rui` padding safelist corrected.** The `@source inline` safelist in `styles.css` still used a pre-rename spacing vocabulary, so some inset-padding utilities (like `p-squish-relaxed`) didn't resolve in places the Tailwind scanner can't see. The safelist now covers the real `square`, `squish`, and `stretch` families with the current size names.
+
+---
+
+That's v17.9.0. The date family is complete, with field, picker, and calendar components in both single-date and range flavors. And with `search`, the CLI now covers the step before `docs`, which is finding the right component in the first place. Try both and tell us what you think.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

Adds the release blog posts that were missed for v17.7.0 (2026-06-15) and v17.8.0 (2026-06-18), plus the post for the upcoming v17.9.0 release. Content is compiled from the package changelogs and the changesets release PR #5541, and follows the structure and voice of the existing posts. Per house style, the prose avoids em/en dashes, semicolons, and colons.

Patch releases 17.0.1 and 17.2.1 were dependency-only bumps and the 17.5.1 Drawer fix is already covered in the v17.6.0 post, so those get no posts.

Note for the reviewer: the v17.9.0 post is dated 2026-07-07. If the release ships on a different day, the file needs to be renamed and its `date` frontmatter updated.

Closes DST-1595

## Test Instructions

1. Run `pnpm start` and open `http://localhost:3000/releases/overview`
2. Verify the three new posts (v17.7.0, v17.8.0, v17.9.0) show up in the release notes list
3. Open each post and check that code samples, component links, and the `changed` frontmatter pages render correctly

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)