### PR TITLE
docs: remove stale new/updated badges from unchanged doc pages

### DIFF
--- a/docs/content/components/overlay/drawer/index.mdx
+++ b/docs/content/components/overlay/drawer/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Drawer
 description: Component for showing additional content alongside the main page.
-badge: updated
 ---
 
 import { DrawerAnatomy } from './drawer-anatomy';

--- a/docs/content/getting-started/recommended-libraries/index.mdx
+++ b/docs/content/getting-started/recommended-libraries/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Recommended Third-party Libraries
 description: Third-party libraries we recommend pairing with Marigold.
-badge: new
 ---
 
 Marigold gives you accessible, themeable components, but a real application needs


### PR DESCRIPTION
# Description

As part of the release cadence, doc pages carry a `new` or `updated` frontmatter badge to highlight recent additions/changes. This PR removes those badges from pages whose content has **not** changed in the last 4 weeks (cutoff 2026-06-09), so the badges keep signalling genuinely fresh content.

Removed:

- **Drawer** (`components/overlay/drawer`) — `badge: updated`; last content change 2026-05-11 (~8 weeks ago)
- **Recommended Third-party Libraries** (`getting-started/recommended-libraries`) — `badge: new`; last content change 2026-06-02 (~5 weeks ago)

Pages kept (content changed within the last 4 weeks): `foundations/responsive` (2026-06-18), `getting-started/usage-with-ai` (2026-06-19), `getting-started/cli` (2026-06-19), `getting-started/examples-for-agents` (2026-06-16).

Out of scope: `releases/**` pages (their `badge: new` is a template default, not a freshness signal) and `beta`/`alpha`/`deprecated` badges.

## Test Instructions

1. Run `pnpm start` and open the docs site.
2. Navigate to **Components → Drawer** and **Getting Started → Recommended Third-party Libraries**; confirm the "updated"/"new" badge no longer appears in the nav/page header.
3. Confirm the four recently-changed pages listed above still show their badge.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`) — N/A, docs-only change