### PR TITLE
docs(DST-1465): position Card among Collection components

### DIFF
--- a/.changeset/dst-1465-card-collection-positioning.md
+++ b/.changeset/dst-1465-card-collection-positioning.md
@@ -1,0 +1,7 @@
+---
+'@marigold/docs': patch
+---
+
+docs(DST-1465): position Card among Collection components and link out to alternatives
+
+Reframes the Card docs to lead with Card's Collection identity. Adds a `Card vs Table` in-category comparison with a new `CardVsTableMockup` illustration, a `When the content isn't a collection` section pointing to Panel, Stack, and Tiles, and a top-level `Alternative components` section that links out to the right component for each case.

--- a/docs/content/components/collection/card/card-usage-guidelines.tsx
+++ b/docs/content/components/collection/card/card-usage-guidelines.tsx
@@ -116,3 +116,168 @@ export const DontNestedMockup = () => (
     })}
   </svg>
 );
+
+/**
+ * "Card vs Table" comparison: a grid of identity-per-item cards on the left,
+ * a row-shaped data table on the right. Mirrors the PanelVsCard comparison mockup.
+ */
+export const CardVsTableMockup = () => {
+  const columns = [
+    [446, 70],
+    [536, 60],
+    [616, 60],
+    [696, 48],
+  ];
+
+  return (
+    <svg
+      viewBox="0 0 800 330"
+      className="mx-auto h-auto w-full max-w-[90%]"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="A grid of cards on the left compared with a data table on the right"
+    >
+      {/* Heading: Card */}
+      <text
+        x="205"
+        y="28"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="14"
+        fontWeight="600"
+        textAnchor="middle"
+        className="fill-fd-primary transition-colors duration-300"
+      >
+        Card
+      </text>
+
+      {/* Card grid: 2x2 items, each with media + title + body */}
+      {[
+        [50, 50],
+        [210, 50],
+        [50, 180],
+        [210, 180],
+      ].map(([ox, oy]) => (
+        <g key={`card-${ox}-${oy}`}>
+          <rect
+            x={ox}
+            y={oy}
+            width="150"
+            height="120"
+            rx="8"
+            className="fill-fd-card stroke-fd-border transition-colors duration-300"
+            strokeWidth="2"
+          />
+          <rect
+            x={ox + 12}
+            y={oy + 12}
+            width="126"
+            height="44"
+            rx="4"
+            className="fill-fd-muted-foreground/30 transition-colors duration-300"
+          />
+          <rect
+            x={ox + 12}
+            y={oy + 68}
+            width="90"
+            height="8"
+            rx="2"
+            className="fill-fd-foreground transition-colors duration-300"
+          />
+          <rect
+            x={ox + 12}
+            y={oy + 84}
+            width="110"
+            height="6"
+            rx="2"
+            className="fill-fd-muted-foreground/50 transition-colors duration-300"
+          />
+          <rect
+            x={ox + 12}
+            y={oy + 96}
+            width="70"
+            height="6"
+            rx="2"
+            className="fill-fd-muted-foreground/40 transition-colors duration-300"
+          />
+        </g>
+      ))}
+
+      {/* Heading: Table */}
+      <text
+        x="595"
+        y="28"
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        fontSize="14"
+        fontWeight="600"
+        textAnchor="middle"
+        className="fill-fd-primary transition-colors duration-300"
+      >
+        Table
+      </text>
+
+      {/* Table container */}
+      <rect
+        x="430"
+        y="50"
+        width="330"
+        height="250"
+        rx="8"
+        className="fill-fd-card stroke-fd-border transition-colors duration-300"
+        strokeWidth="2"
+      />
+
+      {/* Header cells */}
+      {columns.map(([cx, cw]) => (
+        <rect
+          key={`head-${cx}`}
+          x={cx}
+          y="70"
+          width={cw}
+          height="8"
+          rx="2"
+          className="fill-fd-foreground transition-colors duration-300"
+        />
+      ))}
+
+      {/* Header divider */}
+      <line
+        x1="446"
+        y1="92"
+        x2="744"
+        y2="92"
+        strokeWidth="1"
+        className="stroke-fd-border transition-colors duration-300"
+      />
+
+      {/* Data rows */}
+      {[0, 1, 2, 3, 4].map(row => {
+        const y = 108 + row * 36;
+        return (
+          <g key={`row-${row}`}>
+            {columns.map(([cx, cw]) => (
+              <rect
+                key={`cell-${row}-${cx}`}
+                x={cx}
+                y={y}
+                width={cw}
+                height="7"
+                rx="2"
+                className="fill-fd-muted-foreground/50 transition-colors duration-300"
+              />
+            ))}
+            {row < 4 && (
+              <line
+                x1="446"
+                y1={y + 20}
+                x2="744"
+                y2={y + 20}
+                strokeWidth="1"
+                className="stroke-fd-border transition-colors duration-300"
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+};

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -63,7 +63,7 @@ Reach for selectable cards when the user has to pick from a set of card-shaped o
 
 ### When the content isn't a collection
 
-When your content doesn't repeat as a set of like items, a Collection component is the wrong family. Reach for a Layout primitive instead. Use [`<Panel>`](../../layout/panel) for a unique, named page region like "Billing" or "Team members". Use [`<Stack>`](../../layout/stack) for content that shares a topic but has no per-item identity. Use [`<Tiles>`](../../layout/tiles) for a flexible grid of layout blocks rather than collection items.
+If your content doesn't repeat as a set of like items, no Collection component fits. Reach for a Layout primitive instead. A unique, named region of a page (a "Billing" section, a "Team members" block) belongs in [`<Panel>`](../../layout/panel). Content that hangs together by topic, where no single entry stands on its own, suits [`<Stack>`](../../layout/stack). And a free-flowing grid of layout blocks, rather than repeating items, is what [`<Tiles>`](../../layout/tiles) is for.
 
 Panel documents the inverse of this comparison in its [Panel vs Card](../../layout/panel#panel-vs-card) section.
 
@@ -214,7 +214,7 @@ When your content isn't a good fit for a card, one of these is usually the right
 
 <ul>
   <li>
-    [`<Table>`](../table): The other Collection component. Reach for it when
+    [`<Table>`](/components/collection/table): The other Collection component. Reach for it when
     items share the same fields and the task is comparison, sorting, or bulk
     action.
   </li>
@@ -224,19 +224,19 @@ When your content isn't a good fit for a card, one of these is usually the right
 
 <ul>
   <li>
-    [`<Panel>`](../../layout/panel): A unique, named page region like "Billing"
+    [`<Panel>`](/components/layout/panel): A unique, named page region like "Billing"
     or "Team members".
   </li>
   <li>
-    [`<Stack>`](../../layout/stack): Content that shares a topic but has no
+    [`<Stack>`](/components/layout/stack): Content that shares a topic but has no
     per-item identity.
   </li>
   <li>
-    [`<Tiles>`](../../layout/tiles): A reflowing grid of layout blocks rather
+    [`<Tiles>`](/components/layout/tiles): A reflowing grid of layout blocks rather
     than collection items.
   </li>
   <li>
-    [`<List>`](../../content/list): A simple ordered or unordered list of items.
+    [`<List>`](/components/content/list): A simple ordered or unordered list of items.
   </li>
 </ul>
 
@@ -244,7 +244,7 @@ When your content isn't a good fit for a card, one of these is usually the right
 
 <ul>
   <li>
-    [`<SelectList>`](../../form/selectlist#options-as-cards): Card-shaped options
+    [`<SelectList>`](/components/form/selectlist#options-as-cards): Card-shaped options
     the user selects in a form, with selection state and keyboard support built
     in.
   </li>

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -4,7 +4,11 @@ description: Represents one item in a collection.
 ---
 
 import { CardAnatomy } from './card-anatomy';
-import { DoNestedMockup, DontNestedMockup } from './card-usage-guidelines';
+import {
+  CardVsTableMockup,
+  DoNestedMockup,
+  DontNestedMockup,
+} from './card-usage-guidelines';
 
 A `<Card>` represents one item in a collection, such as an event preview, a venue tile, or a product summary, that repeats next to similar siblings in a grid or list. Each card groups related content (image, title, content, actions) into a single, self-contained unit and sets it apart from the page through elevation or tinting.
 
@@ -37,7 +41,17 @@ The card component supports variants for general content grouping as well as acc
 
 ## Usage
 
-A card represents one item in a set. Reach for it when the same type of item repeats in a grid or list (events, products, venues, team members) and each entry links to its own detail view. Repetition is the core case. If the element doesn't repeat, a card is probably the wrong tool. If the items need sorting, filtering, or bulk actions, [`<Table>`](../table) is a better fit. For a named, non-repeating page region like "Billing" or "Team members", use [`<Panel>`](../../layout/panel) instead.
+A `<Card>` displays one item in a repeating set, such as an event, a product, a venue, or a team member, where each entry has its own visual identity and links to its own detail view. Repetition is the core case. If the element doesn't repeat, a card is probably the wrong tool.
+
+`<Card>` is one of Marigold's Collection components, alongside [`<Table>`](../table). The rest of this section helps you decide when a card is the right choice, when another Collection component or a Layout primitive fits better, and how to build and lay out cards once you've settled on one.
+
+### Card vs Table
+
+`<Card>` and [`<Table>`](../table) are both Collection components. They both display one item in a repeating set, so the choice between them is about display shape, not category.
+
+<CardVsTableMockup />
+
+Reach for [`<Table>`](../table) when items share the same fields and the user's task is comparison, sorting, filtering, or bulk action. Reach for `<Card>` when each item is recognized by its own visuals and links to a detail view, not by its position in a row.
 
 ### Selectable cards
 
@@ -46,6 +60,12 @@ Reach for selectable cards when the user has to pick from a set of card-shaped o
 `<Card>` cannot do any of that. It renders a non-interactive `<article>` meant for grouping content, so making it selectable means rebuilding the whole selection layer by hand: tracking which card is active, wiring a hidden radio or checkbox so the value posts with the form, adding roving arrow-key focus across the grid, and setting the ARIA roles a screen reader needs to announce a card as "selected." That is a lot of accessibility-critical behaviour to reinvent, and it is easy to get subtly wrong.
 
 [`<SelectList>`](../../form/selectlist#options-as-cards) with `variant="bordered"` is exactly that machinery, already built and tested. Each option renders as its own outlined card, so you keep the card look while the component owns selection state, form integration, keyboard navigation, and the "selected" announcements. Use `selectionMode="single"` for a plan or payment-method picker where one card wins, or `selectionMode="multiple"` when several cards can be active at once, such as add-ons or notification channels.
+
+### When the content isn't a collection
+
+When your content doesn't repeat as a set of like items, a Collection component is the wrong family. Reach for a Layout primitive instead. Use [`<Panel>`](../../layout/panel) for a unique, named page region like "Billing" or "Team members". Use [`<Stack>`](../../layout/stack) for content that shares a topic but has no per-item identity. Use [`<Tiles>`](../../layout/tiles) for a flexible grid of layout blocks rather than collection items.
+
+Panel documents the inverse of this comparison in its [Panel vs Card](../../layout/panel#panel-vs-card) section.
 
 ### Header
 
@@ -185,6 +205,50 @@ Every slot is inset with `p="square-regular"`, mirroring `Panel`. Use `square-lo
 ### Card.Footer
 
 <AutoTypeTable path="Card/CardFooter" name="CardFooterProps" />
+
+## Alternative components
+
+When your content isn't a good fit for a card, one of these is usually the right answer.
+
+**Another Collection component**
+
+<ul>
+  <li>
+    [`<Table>`](../table): The other Collection component. Reach for it when
+    items share the same fields and the task is comparison, sorting, or bulk
+    action.
+  </li>
+</ul>
+
+**When the content isn't a collection**
+
+<ul>
+  <li>
+    [`<Panel>`](../../layout/panel): A unique, named page region like "Billing"
+    or "Team members".
+  </li>
+  <li>
+    [`<Stack>`](../../layout/stack): Content that shares a topic but has no
+    per-item identity.
+  </li>
+  <li>
+    [`<Tiles>`](../../layout/tiles): A reflowing grid of layout blocks rather
+    than collection items.
+  </li>
+  <li>
+    [`<List>`](../../content/list): A simple ordered or unordered list of items.
+  </li>
+</ul>
+
+**When cards are selectable options**
+
+<ul>
+  <li>
+    [`<SelectList>`](../../form/selectlist#options-as-cards): Card-shaped options
+    the user selects in a form, with selection state and keyboard support built
+    in.
+  </li>
+</ul>
 
 ## Related
 

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Card
 description: Represents one item in a collection.
+badge: updated
 ---
 
 import { CardAnatomy } from './card-anatomy';

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -46,6 +46,24 @@ A `<Card>` displays one item in a repeating set, such as an event, a product, a 
 
 `<Card>` is one of Marigold's Collection components, alongside [`<Table>`](../table). The rest of this section helps you decide when a card is the right choice, when another Collection component or a Layout primitive fits better, and how to build and lay out cards once you've settled on one.
 
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Use a Layout primitive for content that doesn't repeat: [`<Panel>`](../../layout/panel)
+      for a named region like "Billing", [`<Stack>`](../../layout/stack) for topic-grouped
+      content, [`<Tiles>`](../../layout/tiles) for a reflowing grid of blocks.
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't reach for `<Card>` when the content isn't a collection. A single,
+      non-repeating region isn't a card.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
+Panel covers the reverse in its [Panel vs Card](../../layout/panel#panel-vs-card) section.
+
 ### Card vs Table
 
 `<Card>` and [`<Table>`](../table) are both Collection components. They both display one item in a repeating set, so the choice between them is about display shape, not category.
@@ -61,12 +79,6 @@ Reach for selectable cards when the user has to pick from a set of card-shaped o
 `<Card>` cannot do any of that. It renders a non-interactive `<article>` meant for grouping content, so making it selectable means rebuilding the whole selection layer by hand: tracking which card is active, wiring a hidden radio or checkbox so the value posts with the form, adding roving arrow-key focus across the grid, and setting the ARIA roles a screen reader needs to announce a card as "selected." That is a lot of accessibility-critical behaviour to reinvent, and it is easy to get subtly wrong.
 
 [`<SelectList>`](../../form/selectlist#options-as-cards) with `variant="bordered"` is exactly that machinery, already built and tested. Each option renders as its own outlined card, so you keep the card look while the component owns selection state, form integration, keyboard navigation, and the "selected" announcements. Use `selectionMode="single"` for a plan or payment-method picker where one card wins, or `selectionMode="multiple"` when several cards can be active at once, such as add-ons or notification channels.
-
-### When the content isn't a collection
-
-If your content doesn't repeat as a set of like items, no Collection component fits. Reach for a Layout primitive instead. A unique, named region of a page (a "Billing" section, a "Team members" block) belongs in [`<Panel>`](../../layout/panel). Content that hangs together by topic, where no single entry stands on its own, suits [`<Stack>`](../../layout/stack). And a free-flowing grid of layout blocks, rather than repeating items, is what [`<Tiles>`](../../layout/tiles) is for.
-
-Panel documents the inverse of this comparison in its [Panel vs Card](../../layout/panel#panel-vs-card) section.
 
 ### Header
 


### PR DESCRIPTION
# Description

Repositions the Card docs so the page reads as one of Marigold's Collection components, not just a build-a-card guide. Reframes the Usage intro to lead with Card's Collection identity, adds a `Card vs Table` in-category comparison (with a new `CardVsTableMockup` SVG), a `When the content isn't a collection` section that points to Panel/Stack/Tiles, and a top-level `Alternative components` section linking out to the right component for each case. Mirrors the existing `Panel vs Card` narrative from the Panel docs.

Closes DST-1465

## Scope notes

Two items from the ticket scope were intentionally handled as plain prose rather than `<Callout>` components:

- Scope item 2 (`Card vs Table` rule-of-thumb) is written as a prose paragraph instead of a `<Callout title="Rule of thumb">`.
- Scope item 4 (`### Choosing the right component` decision-tree callout) was dropped. The inline guidance plus the `Alternative components` list cover the same decision without a separate callout.

## Test Instructions

1. Run `pnpm start` and open `/components/collection/card`.
2. Confirm the new `Card vs Table`, `When the content isn't a collection`, and `Alternative components` sections render, including the `CardVsTableMockup` illustration.
3. Click each cross-reference link (Table, Panel, Stack, Tiles, List, SelectList, and the `Panel vs Card` anchor) and confirm it resolves.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, docs content only
- [x] Changeset added (`pnpm changeset`) — N/A, docs-content-only change