### PR TITLE
fix(DSTSUP-267): append files across selections when FileField is multiple

### DIFF
--- a/.changeset/dstsup-267-filefield-append-multiple.md
+++ b/.changeset/dstsup-267-filefield-append-multiple.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-267): `FileField` appends files across selections when `multiple` is set
+
+Previously, when `multiple` was set, selecting or dropping files in a second interaction replaced the existing selection instead of adding to it — only files chosen in a single action were kept. `FileField` now accumulates files across separate selections and drops, de-duplicating identical files (matched by name, size, and last-modified time). Behavior with `multiple` unset is unchanged: the latest single file still wins.

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -5,6 +5,16 @@ import { I18nProvider } from 'react-aria-components/I18nProvider';
 import { Basic, UploadFile } from './FileField.stories';
 import { makeFile } from './makeFile';
 
+const dropFiles = (dropzone: Element, files: File[]) => {
+  const dataTransfer = new DataTransfer();
+  files.forEach(file => dataTransfer.items.add(file));
+  for (const type of ['dragenter', 'dragover', 'drop']) {
+    dropzone.dispatchEvent(
+      new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer })
+    );
+  }
+};
+
 test('renders default labels (en) for dropzone and button', () => {
   render(<Basic.Component label="Label" />);
 
@@ -42,6 +52,63 @@ test('when multiple is false, only first file is kept', async () => {
   expect(items.length).toBe(1);
   expect(screen.getByText('doc.pdf')).toBeInTheDocument();
   expect(screen.queryByText('pic.jpg')).not.toBeInTheDocument();
+});
+
+test('when multiple, files selected in separate interactions accumulate', async () => {
+  const user = userEvent.setup();
+  render(<UploadFile.Component multiple />);
+
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+
+  const fileA = makeFile('a.pdf', 'application/pdf');
+  const fileB = makeFile('b.pdf', 'application/pdf');
+
+  await user.upload(input, [fileA]);
+  await user.upload(input, [fileB]);
+
+  const items = screen.getAllByRole('button', { name: 'Remove file' });
+  expect(items.length).toBe(2);
+  expect(screen.getByText('a.pdf')).toBeInTheDocument();
+  expect(screen.getByText('b.pdf')).toBeInTheDocument();
+});
+
+test('when multiple, re-selecting the same file does not duplicate it', async () => {
+  const user = userEvent.setup();
+  render(<UploadFile.Component multiple />);
+
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+
+  const file = makeFile('a.pdf', 'application/pdf');
+
+  await user.upload(input, [file]);
+  await user.upload(input, [file]);
+
+  const items = screen.getAllByRole('button', { name: 'Remove file' });
+  expect(items.length).toBe(1);
+});
+
+test('when multiple is false, a later selection replaces the previous one', async () => {
+  const user = userEvent.setup();
+  render(<Basic.Component />);
+
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+
+  const fileA = makeFile('a.pdf', 'application/pdf');
+  const fileB = makeFile('b.pdf', 'application/pdf');
+
+  await user.upload(input, [fileA]);
+  await user.upload(input, [fileB]);
+
+  const items = screen.getAllByRole('button', { name: 'Remove file' });
+  expect(items.length).toBe(1);
+  expect(screen.getByText('b.pdf')).toBeInTheDocument();
+  expect(screen.queryByText('a.pdf')).not.toBeInTheDocument();
 });
 
 test('accepts prop filters files', async () => {
@@ -178,30 +245,31 @@ test('handles file drop on dropzone', async () => {
   const dropzone = screen.getByTestId('dropzone');
   const file = makeFile('dropped.pdf', 'application/pdf');
 
-  const dataTransfer = new DataTransfer();
-  dataTransfer.items.add(file);
-
-  const dragEnter = new DragEvent('dragenter', {
-    bubbles: true,
-    cancelable: true,
-    dataTransfer,
-  });
-  const dragOver = new DragEvent('dragover', {
-    bubbles: true,
-    cancelable: true,
-    dataTransfer,
-  });
-  const drop = new DragEvent('drop', {
-    bubbles: true,
-    cancelable: true,
-    dataTransfer,
-  });
-
-  dropzone.dispatchEvent(dragEnter);
-  dropzone.dispatchEvent(dragOver);
-  dropzone.dispatchEvent(drop);
+  dropFiles(dropzone, [file]);
 
   await waitFor(() => {
     expect(screen.getByText('dropped.pdf')).toBeInTheDocument();
   });
+});
+
+test('when multiple, a dropped file is added to already selected files', async () => {
+  const user = userEvent.setup();
+  render(<UploadFile.Component label="Label" multiple />);
+
+  const input = document.querySelector(
+    'input[type="file"]:not([hidden])'
+  ) as HTMLInputElement;
+
+  const selected = makeFile('selected.pdf', 'application/pdf');
+  await user.upload(input, [selected]);
+
+  const dropzone = screen.getByTestId('dropzone');
+  const dropped = makeFile('dropped.pdf', 'application/pdf');
+
+  dropFiles(dropzone, [dropped]);
+
+  await waitFor(() => {
+    expect(screen.getByText('dropped.pdf')).toBeInTheDocument();
+  });
+  expect(screen.getByText('selected.pdf')).toBeInTheDocument();
 });

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -80,16 +80,25 @@ export const FileField = ({
 
   // Single place that mutates the selection: keeps the hidden input in sync
   // with state so no mutation site has to remember to do it separately.
-  const commitFiles = (next: File[]) => {
-    setFiles(next);
-    syncHiddenInput(next);
+  // Takes an updater so it derives from the latest state, not a stale
+  // closure - async drops that resolve concurrently can't clobber each other.
+  const updateFiles = (update: (prev: File[]) => File[]) => {
+    setFiles(prev => {
+      const next = update(prev ?? []);
+      syncHiddenInput(next);
+      return next;
+    });
   };
 
   const mergeFiles = (incoming: File[]) => {
     // When multiple is set, add to the existing selection instead of
     // replacing it, so files picked in separate interactions accumulate.
-    const combined = multiple ? [...(files ?? []), ...incoming] : incoming;
-    commitFiles(normalizeAndLimitFiles(combined, { accept, multiple }));
+    updateFiles(prev =>
+      normalizeAndLimitFiles(multiple ? [...prev, ...incoming] : incoming, {
+        accept,
+        multiple,
+      })
+    );
   };
 
   const handleSelect: RAC.FileTriggerProps['onSelect'] = files => {
@@ -149,7 +158,7 @@ export const FileField = ({
         <FileField.Item
           key={index}
           onRemove={() =>
-            commitFiles((files ?? []).filter((_, i) => i !== index))
+            updateFiles(prev => prev.filter((_, i) => i !== index))
           }
         >
           <div className={cn('[grid-area:label]', classNames.itemLabel)}>

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import RAC, { DropZone } from 'react-aria-components';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { WidthProp, cn, useClassNames } from '@marigold/system';
@@ -6,7 +6,7 @@ import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 import { intlMessages } from '../intl/messages';
 import { FileFieldItem } from './FileFieldItem';
 import { FileTrigger } from './FileTrigger';
-import { isFileDropItem, normalizeAndLimitFiles } from './fileUtils';
+import { fileKey, isFileDropItem, normalizeAndLimitFiles } from './fileUtils';
 
 type RemovedProps =
   | 'className'
@@ -70,25 +70,23 @@ export const FileField = ({
   const dropZoneLabel = stringFormatter.format('dropZoneLabel');
   const buttonLabel = stringFormatter.format('uploadLabel');
 
-  const syncHiddenInput = (newFiles: File[] | null) => {
+  // Single place that mutates the selection. Takes an updater so it derives
+  // from the latest state, not a stale closure - concurrent async drops can't
+  // clobber each other. The hidden input is synced from `files` in an effect
+  // below, so this updater stays pure.
+  const updateFiles = (update: (prev: File[]) => File[]) => {
+    setFiles(prev => update(prev ?? []));
+  };
+
+  // Mirror the current selection onto the hidden form input whenever it
+  // changes, driven by the committed `files` state (single source of truth).
+  useEffect(() => {
     if (!hiddenInputRef.current || !name || typeof DataTransfer === 'undefined')
       return;
     const dt = new DataTransfer();
-    newFiles?.forEach(f => dt.items.add(f));
+    files?.forEach(f => dt.items.add(f));
     hiddenInputRef.current.files = dt.files;
-  };
-
-  // Single place that mutates the selection: keeps the hidden input in sync
-  // with state so no mutation site has to remember to do it separately.
-  // Takes an updater so it derives from the latest state, not a stale
-  // closure - async drops that resolve concurrently can't clobber each other.
-  const updateFiles = (update: (prev: File[]) => File[]) => {
-    setFiles(prev => {
-      const next = update(prev ?? []);
-      syncHiddenInput(next);
-      return next;
-    });
-  };
+  }, [files, name]);
 
   const mergeFiles = (incoming: File[]) => {
     // When multiple is set, add to the existing selection instead of
@@ -154,11 +152,11 @@ export const FileField = ({
           />
         </div>
       </DropZone>
-      {files?.map((file, index) => (
+      {files?.map(file => (
         <FileField.Item
-          key={index}
+          key={fileKey(file)}
           onRemove={() =>
-            updateFiles(prev => prev.filter((_, i) => i !== index))
+            updateFiles(prev => prev.filter(f => fileKey(f) !== fileKey(file)))
           }
         >
           <div className={cn('[grid-area:label]', classNames.itemLabel)}>

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -78,11 +78,22 @@ export const FileField = ({
     hiddenInputRef.current.files = dt.files;
   };
 
+  // Single place that mutates the selection: keeps the hidden input in sync
+  // with state so no mutation site has to remember to do it separately.
+  const commitFiles = (next: File[]) => {
+    setFiles(next);
+    syncHiddenInput(next);
+  };
+
+  const mergeFiles = (incoming: File[]) => {
+    // When multiple is set, add to the existing selection instead of
+    // replacing it, so files picked in separate interactions accumulate.
+    const combined = multiple ? [...(files ?? []), ...incoming] : incoming;
+    commitFiles(normalizeAndLimitFiles(combined, { accept, multiple }));
+  };
+
   const handleSelect: RAC.FileTriggerProps['onSelect'] = files => {
-    const list = files ? Array.from(files) : [];
-    const normalized = normalizeAndLimitFiles(list, { accept, multiple });
-    setFiles(normalized);
-    syncHiddenInput(normalized);
+    mergeFiles(files ? Array.from(files) : []);
   };
 
   const handleDrop: RAC.DropZoneProps['onDrop'] = async e => {
@@ -92,9 +103,7 @@ export const FileField = ({
         .map(item => (item as RAC.FileDropItem).getFile());
       const raw = await Promise.all(filePromises);
       const files = raw.filter(Boolean) as File[];
-      const normalized = normalizeAndLimitFiles(files, { accept, multiple });
-      setFiles(normalized);
-      syncHiddenInput(normalized);
+      mergeFiles(files);
     } catch {
       // Intentionally ignore - dropped files that can't be read are skipped.
       // User sees no file appear, which is acceptable UX for invalid drops.
@@ -139,11 +148,9 @@ export const FileField = ({
       {files?.map((file, index) => (
         <FileField.Item
           key={index}
-          onRemove={() => {
-            const updated = (files ?? []).filter((_, i) => i !== index);
-            setFiles(updated);
-            syncHiddenInput(updated);
-          }}
+          onRemove={() =>
+            commitFiles((files ?? []).filter((_, i) => i !== index))
+          }
         >
           <div className={cn('[grid-area:label]', classNames.itemLabel)}>
             {file.name}

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,10 +56,15 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
+// Identity of a file for de-duplication and removal: two files with the same
+// name, size, and last-modified time are treated as the same file.
+export const fileKey = (file: File): string =>
+  `${file.name}:${file.size}:${file.lastModified}`;
+
 const dedupeFiles = (files: File[]): File[] => {
   const seen = new Set<string>();
   return files.filter(file => {
-    const key = `${file.name}:${file.size}:${file.lastModified}`;
+    const key = fileKey(file);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,6 +56,16 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
+const dedupeFiles = (files: File[]): File[] => {
+  const seen = new Set<string>();
+  return files.filter(file => {
+    const key = `${file.name}:${file.size}:${file.lastModified}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
 export const normalizeAndLimitFiles = (
   files: File[],
   {
@@ -66,7 +76,7 @@ export const normalizeAndLimitFiles = (
     multiple?: boolean;
   }
 ): File[] => {
-  const accepted = filterAcceptedFiles(files, accept);
+  const accepted = dedupeFiles(filterAcceptedFiles(files, accept));
 
   return multiple ? accepted : accepted.slice(0, 1);
 };


### PR DESCRIPTION
# Description

Fixes `FileField` dropping previously selected files when `multiple` is set. Previously, selecting or dropping files in a second interaction replaced the existing selection instead of adding to it, so only files chosen in a single action were kept. `FileField` now accumulates files across separate selections and drops, de-duplicating identical files (matched by name, size, and last-modified time). Behavior with `multiple` unset is unchanged: the latest single file still wins.

All selection mutations (select, drop, remove) are routed through a single functional state updater, so the next selection is derived from the latest state rather than a stale closure — concurrent async drops can no longer clobber each other.

Closes DSTSUP-267

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Open Storybook → `Components/FileField`, use the `UploadFile` story with `multiple` set.
2. Select a file, then open the picker again and select a different file — confirm both remain listed.
3. Re-select an identical file — confirm it is not duplicated.
4. Drop a file onto the dropzone while files are already selected — confirm it is appended, not replaced.
5. With `multiple` unset (`Basic` story), select two files in turn — confirm the latest replaces the previous.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)