### PR TITLE
fix(DSTSUP-266): render required asterisk via ui-required-indicator utility

### DIFF
--- a/.changeset/dstsup-266-required-indicator.md
+++ b/.changeset/dstsup-266-required-indicator.md
@@ -2,8 +2,8 @@
 '@marigold/theme-rui': patch
 ---
 
-fix(DSTSUP-266): render the required-field asterisk via a `util-required-indicator` utility
+fix(DSTSUP-266): render the required-field asterisk via a `ui-required-indicator` utility
 
 The required indicator (the red `*` after a label) was defined inline as `after:content-["*"]`. That quoted arbitrary value does not survive JS compilation into an extractable class name (`content-["*"]` becomes `content-[\"*\"]`), so consumers that regenerate Tailwind by scanning the compiled theme packages (the Marigold starter, StackBlitz, `@reservix/core`) never generated a rule for it and the asterisk was invisible. It kept working in Storybook and the docs because those read the source or the pre-built CSS.
 
-The indicator is now a named `util-required-indicator` utility with its value defined in CSS. The class name is quote-free, so it survives compilation and renders regardless of how a consumer builds its styles.
+The indicator is now a named `ui-required-indicator` utility with its value defined in CSS (`ui.css`). The class name is quote-free, so it survives compilation and renders regardless of how a consumer builds its styles.

--- a/.changeset/dstsup-266-required-indicator.md
+++ b/.changeset/dstsup-266-required-indicator.md
@@ -1,0 +1,9 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DSTSUP-266): render the required-field asterisk via a `util-required-indicator` utility
+
+The required indicator (the red `*` after a label) was defined inline as `after:content-["*"]`. That quoted arbitrary value does not survive JS compilation into an extractable class name (`content-["*"]` becomes `content-[\"*\"]`), so consumers that regenerate Tailwind by scanning the compiled theme packages (the Marigold starter, StackBlitz, `@reservix/core`) never generated a rule for it and the asterisk was invisible. It kept working in Storybook and the docs because those read the source or the pre-built CSS.
+
+The indicator is now a named `util-required-indicator` utility with its value defined in CSS. The class name is quote-free, so it survives compilation and renders regardless of how a consumer builds its styles.

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -31,7 +31,7 @@ test('check classname slots', () => {
     `"group/field flex min-w-0 flex-col w-auto"`
   );
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
 });
 

--- a/packages/components/src/ComboBox/ComboBox.test.tsx
+++ b/packages/components/src/ComboBox/ComboBox.test.tsx
@@ -31,7 +31,7 @@ test('check classname slots', () => {
     `"group/field flex min-w-0 flex-col w-auto"`
   );
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:ui-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
 });
 

--- a/packages/components/src/DateField/DateField.test.tsx
+++ b/packages/components/src/DateField/DateField.test.tsx
@@ -55,7 +55,7 @@ test('renders correctly', () => {
       style="--container-width: 100%; --field-width: 100%;"
     >
       <span
-        class="items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"
+        class="items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:ui-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"
         id="react-aria-_r_1_"
       >
         My Label

--- a/packages/components/src/DateField/DateField.test.tsx
+++ b/packages/components/src/DateField/DateField.test.tsx
@@ -55,7 +55,7 @@ test('renders correctly', () => {
       style="--container-width: 100%; --field-width: 100%;"
     >
       <span
-        class="items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"
+        class="items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"
         id="react-aria-_r_1_"
       >
         My Label

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -25,7 +25,7 @@ test('supports base styling', () => {
   const { label, container, track, thumb } = getSwitchParts();
 
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:ui-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
   expect(container.className).toMatchInlineSnapshot(
     `"group/switch flex w-full items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
@@ -50,7 +50,7 @@ test('allows to set width via prop', () => {
   const { label } = getSwitchParts();
 
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:ui-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
 });
 

--- a/packages/components/src/Switch/Switch.test.tsx
+++ b/packages/components/src/Switch/Switch.test.tsx
@@ -25,7 +25,7 @@ test('supports base styling', () => {
   const { label, container, track, thumb } = getSwitchParts();
 
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
   expect(container.className).toMatchInlineSnapshot(
     `"group/switch flex w-full items-center gap-[1ch] disabled:cursor-not-allowed disabled:text-disabled-foreground"`
@@ -50,7 +50,7 @@ test('allows to set width via prop', () => {
   const { label } = getSwitchParts();
 
   expect(label.className).toMatchInlineSnapshot(
-    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:content-["*"] group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
+    `"items-center gap-1 text-sm font-medium leading-none text-foreground group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground group-required/field:after:util-required-indicator group-required/field:after:-ml-1 group-required/field:after:text-destructive in-field:mb-1.5 inline-flex"`
   );
 });
 

--- a/themes/theme-rui/src/components/Label.styles.ts
+++ b/themes/theme-rui/src/components/Label.styles.ts
@@ -7,7 +7,7 @@ export const Label: ThemeComponent<'Label'> = cva({
     'group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground',
 
     // required indicator
-    'group-required/field:after:util-required-indicator',
+    'group-required/field:after:ui-required-indicator',
     'group-required/field:after:-ml-1',
     'group-required/field:after:text-destructive',
   ],

--- a/themes/theme-rui/src/components/Label.styles.ts
+++ b/themes/theme-rui/src/components/Label.styles.ts
@@ -7,7 +7,7 @@ export const Label: ThemeComponent<'Label'> = cva({
     'group-disabled/field:cursor-not-allowed group-disabled/field:text-disabled-foreground',
 
     // required indicator
-    'group-required/field:after:content-["*"]',
+    'group-required/field:after:util-required-indicator',
     'group-required/field:after:-ml-1',
     'group-required/field:after:text-destructive',
   ],

--- a/themes/theme-rui/src/ui.css
+++ b/themes/theme-rui/src/ui.css
@@ -21,6 +21,21 @@
 }
 
 /* ========================= */
+/*    Form field indicators  */
+/* ========================= */
+
+/*
+ * Required-field indicator (the red "*" after a label). Kept as a named
+ * utility, not inline as `after:content-["*"]`: quoted arbitrary values don't
+ * survive JS compilation as extractable classes, so consumers that rescan the
+ * compiled packages never generate the rule and the asterisk vanishes. See
+ * DSTSUP-266.
+ */
+@utility ui-required-indicator {
+  content: '*';
+}
+
+/* ========================= */
 /*          Surface          */
 /* ========================= */
 

--- a/themes/theme-rui/src/utils.css
+++ b/themes/theme-rui/src/utils.css
@@ -6,22 +6,6 @@
  */
 
 /* ========================= */
-/*    Form field indicators  */
-/* ========================= */
-
-/*
- * Required-field indicator (the red "*" after a label). Kept as a named
- * utility, not inline as `after:content-["*"]`: quoted arbitrary values don't
- * survive JS compilation as extractable classes, so consumers that rescan the
- * compiled packages never generate the rule and the asterisk vanishes. See
- * DSTSUP-266.
- */
-@utility util-required-indicator {
-  --tw-content: '*';
-  content: var(--tw-content);
-}
-
-/* ========================= */
 /*    Surface & Elevation    */
 /* ========================= */
 

--- a/themes/theme-rui/src/utils.css
+++ b/themes/theme-rui/src/utils.css
@@ -6,6 +6,22 @@
  */
 
 /* ========================= */
+/*    Form field indicators  */
+/* ========================= */
+
+/*
+ * Required-field indicator (the red "*" after a label). Kept as a named
+ * utility, not inline as `after:content-["*"]`: quoted arbitrary values don't
+ * survive JS compilation as extractable classes, so consumers that rescan the
+ * compiled packages never generate the rule and the asterisk vanishes. See
+ * DSTSUP-266.
+ */
+@utility util-required-indicator {
+  --tw-content: '*';
+  content: var(--tw-content);
+}
+
+/* ========================= */
 /*    Surface & Elevation    */
 /* ========================= */
 


### PR DESCRIPTION
# Description

The required-field indicator (the red `*` after a label) was defined inline as `after:content-["*"]`. That double-quoted arbitrary value does not survive JS compilation into an extractable class name (`content-["*"]` compiles to `content-[\"*\"]`), so consumers that regenerate Tailwind by scanning the compiled theme packages (the Marigold starter, StackBlitz, `@reservix/core`) never generated a rule for it and the asterisk was invisible. It kept working in Storybook and the docs because those read the source or the pre-built CSS.

The indicator is now a named `ui-required-indicator` utility with its value defined in CSS (`themes/theme-rui/src/ui.css`), following the existing `ui-*` convention for UI component utilities in that file. The class name is quote-free, so it survives compilation and renders regardless of how a consumer builds its styles. Behavior and appearance are unchanged.

Note: `LegacyTable.styles.ts` uses the same double-quoted `content-[""]` pattern and has the identical compilation issue, but it is knowingly left unchanged because LegacyTable is no longer supported.

Closes DSTSUP-266

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

> [!IMPORTANT]
> Storybook, the docs, and `pnpm test` all read the **source** (or the pre-built CSS), so the asterisk renders there whether or not this fix is present. They cannot prove the bug is gone. The bug only reproduces in a consumer that **regenerates Tailwind by scanning the compiled `dist/`**, so verify against the starter with the package linked.

**1. Build the theme in this repo**

```bash
pnpm install
pnpm --filter @marigold/theme-rui build
```

**2. Link the built package into the Marigold starter**

Clone the starter next to this repo (or use an existing checkout), then symlink this repo's theme over the starter's dependency:

```bash
git clone https://github.com/marigold-ui/starter.git
cd starter
pnpm install
pnpm add link:../marigold/themes/theme-rui   # adjust the path to this repo if needed
```

The symlink resolves `@marigold/theme-rui` straight into this repo's `dist/`, so after any rebuild the starter picks it up on the next dev restart. No re-pack or reinstall needed.

The starter already ships `@source "../node_modules/@marigold/theme-rui/dist";` in its CSS, which is what makes Tailwind scan the compiled package. If you test in a bare Vite app instead, add that `@source` line yourself. Tailwind v4 does not scan `node_modules` automatically and respects `.gitignore` (where `dist/` lives), so without it no rule is generated and the asterisk stays invisible for the wrong reason.

**3. Render a required field and start the starter**

```tsx
<TextField label="Name" required />
```

```bash
pnpm dev
```

Confirm the red `*` now appears after the label. To watch the bug reproduce, repeat step 1 on `main`, rebuild, and restart the starter. The asterisk disappears.

**4. Unit snapshots**

```bash
pnpm test:unit
```

The `ComboBox`, `DateField`, and `Switch` label snapshots reflect the new `ui-required-indicator` class.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
