### PR TITLE
fix(DST-1621): keep Accordion stickyHeader pinned when the header has actions

### DIFF
--- a/.changeset/dst-1621-accordion-sticky-header.md
+++ b/.changeset/dst-1621-accordion-sticky-header.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': minor
+---
+
+fix(DST-1621): keep `Accordion` `stickyHeader` pinned when the header has actions
+
+`Accordion.Header` now accepts an `actions` prop for content shown next to the title, such as buttons. Previously actions were added by wrapping `Accordion.Header` in a layout component, which shrank the sticky header's containing block to the header row so `stickyHeader` could no longer pin the header while scrolling. Passing actions through `actions` keeps the sticky wrapper a direct child of the item, so the header stays pinned together with its actions.

--- a/docs/content/components/navigation/accordion/accordion-sticky.demo.tsx
+++ b/docs/content/components/navigation/accordion/accordion-sticky.demo.tsx
@@ -1,0 +1,66 @@
+import { Accordion, Button, Inline, Stack, Text } from '@marigold/components';
+
+const actions = (
+  <Inline space={2}>
+    <Button size="small" onPress={() => {}}>
+      Edit
+    </Button>
+    <Button size="small" onPress={() => {}}>
+      Delete
+    </Button>
+  </Inline>
+);
+
+const body = (
+  <Stack space={4}>
+    <Text>
+      Scroll inside this box: the header stays pinned to the top while the text
+      below moves underneath it.
+    </Text>
+    <Text>
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+      eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+      voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+      clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit
+      amet.
+    </Text>
+    <Text>
+      Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse
+      molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero
+      eros et accumsan et iusto odio dignissim qui blandit praesent luptatum
+      zzril delenit augue duis dolore te feugait nulla facilisi.
+    </Text>
+    <Text>
+      Nam liber tempor cum soluta nobis eleifend option congue nihil imperdiet
+      doming id quod mazim placerat facer possim assum. Ut wisi enim ad minim
+      veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut
+      aliquip ex ea commodo consequat.
+    </Text>
+  </Stack>
+);
+
+export default () => {
+  return (
+    <div style={{ height: 300, overflowY: 'auto', padding: '4px' }}>
+      <Accordion
+        stickyHeader
+        iconPosition="left"
+        allowsMultipleExpanded
+        defaultExpandedKeys={['1', '2']}
+      >
+        <Accordion.Item id="1">
+          <Accordion.Header actions={actions}>
+            Subscription 2025/2026
+          </Accordion.Header>
+          <Accordion.Content>{body}</Accordion.Content>
+        </Accordion.Item>
+        <Accordion.Item id="2">
+          <Accordion.Header actions={actions}>
+            Season Pass 2026/2027
+          </Accordion.Header>
+          <Accordion.Content>{body}</Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  );
+};

--- a/docs/content/components/navigation/accordion/accordion-sticky.demo.tsx
+++ b/docs/content/components/navigation/accordion/accordion-sticky.demo.tsx
@@ -2,12 +2,8 @@ import { Accordion, Button, Inline, Stack, Text } from '@marigold/components';
 
 const actions = (
   <Inline space={2}>
-    <Button size="small" onPress={() => {}}>
-      Edit
-    </Button>
-    <Button size="small" onPress={() => {}}>
-      Delete
-    </Button>
+    <Button onPress={() => {}}>Edit</Button>
+    <Button onPress={() => {}}>Delete</Button>
   </Inline>
 );
 

--- a/docs/content/components/navigation/accordion/index.mdx
+++ b/docs/content/components/navigation/accordion/index.mdx
@@ -86,3 +86,7 @@ The icon position also applied to the whole Accordion: `<Accordion iconPosition=
 ### Accordion.Item
 
 <AutoTypeTable path="Accordion/AccordionItem" name="DisclosureProps" />
+
+### Accordion.Header
+
+<AutoTypeTable path="Accordion/AccordionHeader" name="AccordionHeaderProps" />

--- a/docs/content/components/navigation/accordion/index.mdx
+++ b/docs/content/components/navigation/accordion/index.mdx
@@ -60,8 +60,13 @@ A controlled `Accordion` can be expanded and collapsed using expandedKeys and on
 
 ### Long-form content
 
-For Accordions with a lot of content inside it is handy to use the prop `stickyHeader` to provide context. While scrolling through the content the headline stays fixed at the top of the viewport.
-The `stickyHeader` applies to the entire Accordion: `<Accordion stickyHeader={true}>...</Accordion>`.
+For Accordions with a lot of content, enable `stickyHeader` so the header keeps giving context while you scroll. The header stays pinned to the top of the nearest scroll container (the page or a scrollable ancestor) while the item content scrolls underneath it.
+
+The `stickyHeader` applies to the entire Accordion: `<Accordion stickyHeader>...</Accordion>`.
+
+When a header needs actions such as buttons, pass them to the `actions` prop of `Accordion.Header` rather than wrapping the header in a layout component. That keeps the actions inside the sticky header so they stay pinned together with the title.
+
+<ComponentDemo name="accordion-sticky" />
 
 ### Icon position
 

--- a/packages/components/src/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/Accordion/Accordion.stories.tsx
@@ -11,6 +11,7 @@ import { Columns } from '../Columns/Columns';
 import { Headline } from '../Headline/Headline';
 import { Inline } from '../Inline/Inline';
 import { NumberField } from '../NumberField/NumberField';
+import { Scrollable } from '../Scrollable/Scrollable';
 import { Split } from '../Split/Split';
 import { Stack } from '../Stack/Stack';
 import { Text } from '../Text/Text';
@@ -276,6 +277,9 @@ const stickyHeaderActions = (
     <Button onPress={() => alert('Do NOT click! Come on!')}>Edit</Button>
   </Inline>
 );
+
+const stickyScrollParagraph =
+  'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
 
 export const StickyHeader = meta.story({
   parameters: {
@@ -869,6 +873,73 @@ export const StickyHeader = meta.story({
     </Accordion>
   ),
 });
+
+export const StickyHeaderScrollContainer = meta.story({
+  tags: ['component-test'],
+  parameters: {
+    controls: { exclude: ['iconPosition'] },
+    chromatic: { disableSnapshot: true },
+  },
+  render: args => (
+    <Scrollable height="150px">
+      <Accordion
+        {...args}
+        stickyHeader
+        iconPosition="left"
+        defaultExpandedKeys={['1']}
+      >
+        <Accordion.Item id="1">
+          <Accordion.Header actions={stickyHeaderActions}>
+            Symfonie Abo 2025/2026
+          </Accordion.Header>
+          <Accordion.Content>
+            <Stack space={4}>
+              <Text>
+                Scroll inside this box: the header stays pinned to the top while
+                the text below moves underneath it.
+              </Text>
+              <Text>{stickyScrollParagraph}</Text>
+              <Text>{stickyScrollParagraph}</Text>
+              <Text>{stickyScrollParagraph}</Text>
+              <Text>{stickyScrollParagraph}</Text>
+              <Text>{stickyScrollParagraph}</Text>
+              <Text>{stickyScrollParagraph}</Text>
+            </Stack>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </Scrollable>
+  ),
+});
+
+StickyHeaderScrollContainer.test(
+  'keeps the header pinned to the top of the scroll container while scrolling',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
+    const trigger = canvas.getByRole('button', {
+      name: /Symfonie Abo 2025\/2026/i,
+    });
+
+    // `Scrollable` is the nearest `.overflow-auto` ancestor; the accordion's
+    // own header wrapper is the nearest `.sticky` ancestor (closer than
+    // `Scrollable`, which also carries `sticky`).
+    const scrollContainer = trigger.closest('.overflow-auto') as HTMLElement;
+    const stickyWrapper = trigger.closest('.sticky') as HTMLElement;
+
+    expect(scrollContainer.scrollHeight).toBeGreaterThan(
+      scrollContainer.clientHeight
+    );
+
+    scrollContainer.scrollTop = 120;
+    expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+
+    // With the fix the header clamps to the top of the scroll viewport instead
+    // of scrolling away with the panel content.
+    const headerTop = stickyWrapper.getBoundingClientRect().top;
+    const containerTop = scrollContainer.getBoundingClientRect().top;
+    expect(Math.abs(headerTop - containerTop)).toBeLessThan(5);
+  }
+);
 
 export const IconPositionLeft = meta.story({
   parameters: {

--- a/packages/components/src/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/Accordion/Accordion.stories.tsx
@@ -270,6 +270,13 @@ export const Disabled = meta.story({
   ),
 });
 
+const stickyHeaderActions = (
+  <Inline space={2}>
+    <Button onPress={() => alert('Do NOT click! Come on!')}>Delete</Button>
+    <Button onPress={() => alert('Do NOT click! Come on!')}>Edit</Button>
+  </Inline>
+);
+
 export const StickyHeader = meta.story({
   parameters: {
     controls: { exclude: ['iconPosition'] },
@@ -282,17 +289,9 @@ export const StickyHeader = meta.story({
       iconPosition={'left'}
     >
       <Accordion.Item id="1">
-        <Inline alignX="between">
-          <Accordion.Header>Symfonie Abo 2025/2026</Accordion.Header>
-          <Inline space={2}>
-            <Button onPress={() => alert('Do NOT click! Come on!')}>
-              Delete
-            </Button>
-            <Button onPress={() => alert('Do NOT click! Come on!')}>
-              Edit
-            </Button>
-          </Inline>
-        </Inline>
+        <Accordion.Header actions={stickyHeaderActions}>
+          Symfonie Abo 2025/2026
+        </Accordion.Header>
         <Accordion.Content>
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
           nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
@@ -742,17 +741,9 @@ export const StickyHeader = meta.story({
         </Accordion.Content>
       </Accordion.Item>
       <Accordion.Item id="2">
-        <Inline alignX="between">
-          <Accordion.Header>Scroll Me Abo Season 25/26</Accordion.Header>
-          <Inline space={2}>
-            <Button onPress={() => alert('Do NOT click! Come on!')}>
-              Delete
-            </Button>
-            <Button onPress={() => alert('Do NOT click! Come on!')}>
-              Edit
-            </Button>
-          </Inline>
-        </Inline>
+        <Accordion.Header actions={stickyHeaderActions}>
+          Scroll Me Abo Season 25/26
+        </Accordion.Header>
         <Accordion.Content>
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
           nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,

--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -77,13 +77,33 @@ test('renders sticky header wrapper with expected utility classes', () => {
   });
 
   // eslint-disable-next-line testing-library/no-node-access
-  const stickyWrapper = trigger.closest('div');
+  const stickyWrapper = trigger.closest('.sticky');
 
   expect(stickyWrapper).toHaveClass('sticky');
   expect(stickyWrapper).toHaveClass('top-0');
   expect(stickyWrapper).toHaveClass('z-1');
-  expect(stickyWrapper).toHaveClass('backdrop-blur-xs');
-  expect(stickyWrapper).toHaveClass('bg-background/90');
+  expect(stickyWrapper).toHaveClass('bg-surface/90');
+});
+
+test('sticky header wrapper and its panel share the same accordion item', () => {
+  render(<StickyHeader.Component />);
+
+  const trigger = screen.getByRole('button', {
+    name: /Symfonie Abo 2025\/2026/i,
+  });
+  const panelId = trigger.getAttribute('aria-controls');
+
+  // eslint-disable-next-line testing-library/no-node-access
+  const stickyWrapper = trigger.closest('.sticky');
+  // eslint-disable-next-line testing-library/no-node-access
+  const panel = panelId ? document.getElementById(panelId) : null;
+
+  // `position: sticky` only pins while its containing block (the parent) stays
+  // in view. Header actions must live inside `Accordion.Header` so the sticky
+  // wrapper's parent is the item that also holds the scrollable panel, rather
+  // than a short action row.
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(stickyWrapper?.parentElement).toContainElement(panel);
 });
 
 test('supports iconPosition left', () => {

--- a/packages/components/src/Accordion/Accordion.test.tsx
+++ b/packages/components/src/Accordion/Accordion.test.tsx
@@ -106,6 +106,16 @@ test('sticky header wrapper and its panel share the same accordion item', () => 
   expect(stickyWrapper?.parentElement).toContainElement(panel);
 });
 
+test('header actions adopt the ghost/small ButtonContext cascade', () => {
+  render(<StickyHeader.Component />);
+
+  const [deleteButton] = screen.getAllByRole('button', { name: 'Delete' });
+
+  // `size="small"` resolves to `text-xs` (the default size is `text-sm`), so
+  // this confirms the header's `ButtonContext` reached a bare `<Button>`.
+  expect(deleteButton).toHaveClass('text-xs');
+});
+
 test('supports iconPosition left', () => {
   render(<IconPositionLeft.Component />);
 

--- a/packages/components/src/Accordion/AccordionHeader.tsx
+++ b/packages/components/src/Accordion/AccordionHeader.tsx
@@ -8,39 +8,55 @@ import { useAccordionContext } from './AccordionContext';
 
 export interface AccordionHeaderProps {
   children?: ReactNode;
+  /**
+   * Content rendered next to the title, inside the same header row (e.g. action
+   * buttons). Use this instead of wrapping `Accordion.Header` in a layout
+   * component, otherwise `stickyHeader` cannot keep the header pinned.
+   */
+  actions?: ReactNode;
 }
 
-export const AccordionHeader = ({ children }: AccordionHeaderProps) => {
+export const AccordionHeader = ({
+  children,
+  actions,
+}: AccordionHeaderProps) => {
   const { classNames, stickyHeader, iconPosition } = useAccordionContext();
   const { isExpanded } = use(DisclosureStateContext)!;
 
+  const heading = (
+    <Heading slot={noSlot} className={actions ? 'min-w-0 flex-1' : undefined}>
+      <Button slot="trigger" className={classNames.header}>
+        {iconPosition === 'left' && (
+          <MorphCaret
+            size="16"
+            expanded={isExpanded}
+            className={classNames.icon}
+          />
+        )}
+        <div className="flex-1 items-center">{children}</div>
+        {iconPosition === 'right' && (
+          <MorphCaret
+            size="16"
+            expanded={isExpanded}
+            className={classNames.icon}
+          />
+        )}
+      </Button>
+    </Heading>
+  );
+
   return (
     <div
-      className={
-        stickyHeader
-          ? 'bg-background/90 sticky top-0 z-1 backdrop-blur-xs'
-          : undefined
-      }
+      className={stickyHeader ? 'bg-surface/90 sticky top-0 z-1' : undefined}
     >
-      <Heading slot={noSlot}>
-        <Button slot="trigger" className={classNames.header}>
-          {iconPosition === 'left' && (
-            <MorphCaret
-              size="16"
-              expanded={isExpanded}
-              className={classNames.icon}
-            />
-          )}
-          <div className="flex-1 items-center">{children}</div>
-          {iconPosition === 'right' && (
-            <MorphCaret
-              size="16"
-              expanded={isExpanded}
-              className={classNames.icon}
-            />
-          )}
-        </Button>
-      </Heading>
+      {actions ? (
+        <div className="flex items-center">
+          {heading}
+          <div className="shrink-0">{actions}</div>
+        </div>
+      ) : (
+        heading
+      )}
     </div>
   );
 };

--- a/packages/components/src/Accordion/AccordionHeader.tsx
+++ b/packages/components/src/Accordion/AccordionHeader.tsx
@@ -2,6 +2,9 @@ import { ReactNode, use } from 'react';
 import { Button } from 'react-aria-components/Button';
 import { DisclosureStateContext } from 'react-aria-components/Disclosure';
 import { Heading } from 'react-aria-components/Heading';
+import { Provider } from 'react-aria-components/slots';
+import { cn } from '@marigold/system';
+import { ButtonContext } from '../Button/Context';
 import { MorphCaret } from '../icons/MorphCaret';
 import { noSlot } from '../utils/noSlot';
 import { useAccordionContext } from './AccordionContext';
@@ -10,11 +13,18 @@ export interface AccordionHeaderProps {
   children?: ReactNode;
   /**
    * Content rendered next to the title, inside the same header row (e.g. action
-   * buttons). Use this instead of wrapping `Accordion.Header` in a layout
-   * component, otherwise `stickyHeader` cannot keep the header pinned.
+   * buttons, a `<ButtonGroup>`, or an `<ActionMenu>`). Use this instead of
+   * wrapping `Accordion.Header` in a layout component, otherwise `stickyHeader`
+   * cannot keep the header pinned. Actions are slot-aware: a bare `<Button>`
+   * adopts the header's ghost/small treatment (matching `Panel.Header`), so an
+   * icon-only action sets `size="icon"` to render as a square.
    */
   actions?: ReactNode;
 }
+
+// Cascades a low-emphasis ghost look to every header action, matching
+// `Panel.Header`. Icon-only actions opt into `size="icon"` themselves.
+const headerActionContext = { variant: 'ghost', size: 'small' } as const;
 
 export const AccordionHeader = ({
   children,
@@ -24,7 +34,7 @@ export const AccordionHeader = ({
   const { isExpanded } = use(DisclosureStateContext)!;
 
   const heading = (
-    <Heading slot={noSlot} className={actions ? 'min-w-0 flex-1' : undefined}>
+    <Heading slot={noSlot} className="min-w-0 flex-1">
       <Button slot="trigger" className={classNames.header}>
         {iconPosition === 'left' && (
           <MorphCaret
@@ -47,13 +57,20 @@ export const AccordionHeader = ({
 
   return (
     <div
-      className={stickyHeader ? 'bg-surface/90 sticky top-0 z-1' : undefined}
+      className={cn(
+        stickyHeader && 'bg-surface/90 sticky top-0 z-1',
+        actions && 'flex items-center gap-2'
+      )}
     >
       {actions ? (
-        <div className="flex items-center gap-2">
+        <>
           {heading}
-          <div className={classNames.actions}>{actions}</div>
-        </div>
+          <div className={classNames.actions}>
+            <Provider values={[[ButtonContext, headerActionContext]]}>
+              {actions}
+            </Provider>
+          </div>
+        </>
       ) : (
         heading
       )}

--- a/packages/components/src/Accordion/AccordionHeader.tsx
+++ b/packages/components/src/Accordion/AccordionHeader.tsx
@@ -50,9 +50,9 @@ export const AccordionHeader = ({
       className={stickyHeader ? 'bg-surface/90 sticky top-0 z-1' : undefined}
     >
       {actions ? (
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           {heading}
-          <div className="shrink-0">{actions}</div>
+          <div className={classNames.actions}>{actions}</div>
         </div>
       ) : (
         heading

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -43,7 +43,13 @@ export type Theme = {
   root?: ComponentStyleFunction;
   components: {
     Accordion?: Record<
-      'container' | 'item' | 'header' | 'panel' | 'content' | 'icon',
+      | 'container'
+      | 'item'
+      | 'header'
+      | 'panel'
+      | 'content'
+      | 'icon'
+      | 'actions',
       ComponentStyleFunction<string, string>
     >;
     ActionBar?: Record<

--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -60,4 +60,16 @@ export const Accordion: ThemeComponent<'Accordion'> = {
   icon: cva({
     base: 'pointer-events-none shrink-0 text-secondary transition-transform duration-250',
   }),
+  actions: cva({
+    base: 'shrink-0',
+    variants: {
+      variant: {
+        default: '',
+        card: 'pe-4',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }),
 };


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`Accordion`'s `stickyHeader` did not keep the header pinned when the header carried action buttons. Actions were composed by wrapping `Accordion.Header` in a layout component, which collapsed the sticky wrapper's containing block down to the short header row, so the header scrolled away with the content.

`Accordion.Header` now accepts an `actions` prop, so the header row (title plus actions) is owned by the component and the sticky wrapper stays a direct child of the item. The header now stays pinned together with its actions while the item content scrolls. The sticky fill also changes from `bg-background/90` with a backdrop blur to `bg-surface/90`, matching the Table sticky header so the pinned header no longer shows a grey tint. The docs "Long-form content" section is updated and a new sticky demo is added.

Closes DST-1621

## Screenshots / Preview

| Before | After |
| ------ | ----- |
| ![Before: the header scrolls away when the item content scrolls](https://raw.githubusercontent.com/marigold-ui/marigold/dst-1621-review-assets/review-DST-1621/01-before-scrolled.png) | ![After: the header stays pinned together with its Delete/Edit actions](https://raw.githubusercontent.com/marigold-ui/marigold/dst-1621-review-assets/review-DST-1621/02-after-scrolled.png) |

<sub>`Components/Accordion/StickyHeader`, viewport 1000×720, scrolled to `scrollY=400` inside the expanded item. Before: sticky wrapper sits at `top: -331px` (scrolled off, `bg-background/90` + blur). After: `top: 0px` (pinned, `bg-surface/90`).</sub>

## Test Instructions

1. Open Storybook and navigate to `Components/Accordion/StickyHeader`.
2. Shrink the viewport so the content scrolls, then scroll through an expanded item. The header, with its Delete and Edit actions, stays pinned to the top.
3. Confirm the pinned header uses the surface colour (no grey tint) and does not scroll horizontally.
4. Run `pnpm start`, open the Accordion docs page, and check the "Long-form content" sticky demo.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)