### PR TITLE
fix(DST-1624): place badge beside title in Card MasterAndAdmin story

### DIFF
--- a/packages/components/src/Card/Card.stories.tsx
+++ b/packages/components/src/Card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import { expect } from 'storybook/test';
 import preview from '.storybook/preview';
-import { Badge, Button, Stack, Text } from '@marigold/components';
+import { Badge, Button, Inline, Stack, Text } from '@marigold/components';
 import { Description } from '../Description/Description';
 import { Title } from '../Title/Title';
 import { Card } from './Card';
@@ -280,8 +280,10 @@ export const MasterAndAdmin = meta.story({
     <Stack space={5}>
       <Card {...args} variant="master">
         <Card.Header>
-          <Title>Master Access</Title>
-          <Badge variant="master">Master</Badge>
+          <Inline space={2} alignY="center">
+            <Title>Master Access</Title>
+            <Badge variant="master">Master</Badge>
+          </Inline>
         </Card.Header>
         <Card.Content>
           <Text>
@@ -293,8 +295,10 @@ export const MasterAndAdmin = meta.story({
       </Card>
       <Card {...args} variant="admin">
         <Card.Header>
-          <Title>Admin Access</Title>
-          <Badge variant="admin">Admin</Badge>
+          <Inline space={2} alignY="center">
+            <Title>Admin Access</Title>
+            <Badge variant="admin">Admin</Badge>
+          </Inline>
         </Card.Header>
         <Card.Content>
           <Text>


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

In the Card `MasterAndAdmin` story, the access `Badge` rendered on its own line **below** the `Title` on both the "Master Access" and "Admin Access" cards, instead of beside it.

`Card.Header` is intentionally a vertical stack of a `<Title>` plus an optional `<Description>`. The story dropped a `<Badge>` in as a direct sibling of `<Title>`, so the block-level heading took the full row and pushed the inline-flex badge onto the next line. This wraps the `<Title>` and `<Badge>` in `<Inline space={2} alignY="center">` so the badge sits beside the title, matching how `patterns/admin-master-mark.stories.tsx` already composes badges next to content. No component, theme, or API change.

Closes DST-1624

## Screenshots / Preview

| Before | After |
| ------ | ----- |
| Badge wraps to the line below the title | Badge sits beside the title, vertically centered |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. Story: Components/Card > Master And Admin -->

## Test Instructions

1. Run `pnpm sb` and open **Components/Card > Master And Admin**.
2. Confirm each badge ("Master", "Admin") now sits to the right of its title on the same row.
3. Open **Components/Card > Basic** and confirm the Title plus Description header still stacks vertically (no regression).
4. Run `pnpm test:unit packages/components/src/Card/Card.test.tsx` and confirm all tests pass.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)

<!-- Notes for reviewer:
- No changeset: story-only change, no published-package behavior changes.
- VRT: N/A for a PR into beta-release. The MasterAndAdmin Chromatic snapshot will shift intentionally.
-->