### PR TITLE
refactor(DST-1546): replace bespoke TagGroup "Remove all" wrapper with Button via ButtonContext

### DIFF
--- a/.changeset/dst-1546-taggroup-removeall-buttoncontext.md
+++ b/.changeset/dst-1546-taggroup-removeall-buttoncontext.md
@@ -1,0 +1,20 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+'@marigold/system': patch
+---
+
+refactor(DST-1546): replace the bespoke TagGroup "Remove all" wrapper with a plain `<Button>` via a `ButtonContext` cascade
+
+`TagGroup` now provides a `link`/`small` `ButtonContext` around its internal
+`RemoveAll` render, so the "Remove all" action is a bare Marigold `<Button>`
+instead of the raw react-aria `Button` with hand-rolled link styling. This
+mirrors the cascade pattern already used by `ActionBar` and `Panel.Header`.
+
+The change is internal-only. `TagGroupRemoveAll` is not part of the public API
+(`TagGroup` renders it itself), the authoring API (`removeAll` / `onRemove`) is
+unchanged, and there is no behavioral or accessibility change.
+
+The redundant `removeAll` theme style is removed from `Tag.styles.ts` (the
+`link` variant at `size="small"` reproduces it), and the now-unused `removeAll`
+key is dropped from the `Tag` theme type.

--- a/packages/components/src/TagGroup/TagGroup.tsx
+++ b/packages/components/src/TagGroup/TagGroup.tsx
@@ -15,6 +15,7 @@ import { useFormValidationState } from '@react-stately/form';
 import { useControlledState } from '@react-stately/utils';
 import type { Key, Selection, ValidationError } from '@react-types/shared';
 import { WidthProp, useClassNames } from '@marigold/system';
+import { ButtonContext } from '../Button/Context';
 import { FieldBase } from '../FieldBase/FieldBase';
 import { HiddenSelection } from '../HiddenSelection/HiddenSelection';
 import { TagGroupContext } from './Context';
@@ -117,6 +118,11 @@ export interface TagGroupProps
 const toSelection = (
   value: Selection | Iterable<Key> | undefined
 ): Selection => (value === 'all' ? 'all' : new Set(value ?? []));
+
+// Cascade the link look onto the bare `<Button>` that `TagGroupRemoveAll`
+// renders. Static config, so a module-level constant (no `useMemo`). Scoped to
+// the RemoveAll render below so it never reaches the per-tag `CloseButton`s.
+const removeAllButtonContext = { variant: 'link', size: 'small' } as const;
 
 // Component
 // ---------------
@@ -226,10 +232,9 @@ const _TagGroup = ({
               {children}
             </TagList>
             {onRemove && removeAll ? (
-              <TagGroupRemoveAll
-                className={classNames.removeAll}
-                onRemove={onRemove}
-              />
+              <Provider values={[[ButtonContext, removeAllButtonContext]]}>
+                <TagGroupRemoveAll onRemove={onRemove} />
+              </Provider>
             ) : null}
           </div>
         </RACTagGroup>

--- a/packages/components/src/TagGroup/TagGroupRemoveAll.tsx
+++ b/packages/components/src/TagGroup/TagGroupRemoveAll.tsx
@@ -1,21 +1,13 @@
 import { use } from 'react';
-import { Button } from 'react-aria-components/Button';
 import { ListStateContext } from 'react-aria-components/ListBox';
 import type { TagGroupProps } from 'react-aria-components/TagGroup';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { Button } from '../Button/Button';
 import { intlMessages } from '../intl/messages';
 
-export interface TagGroupRemoveAllProps extends Pick<
-  TagGroupProps,
-  'onRemove'
-> {
-  className?: string;
-}
+export type TagGroupRemoveAllProps = Pick<TagGroupProps, 'onRemove'>;
 
-export const TagGroupRemoveAll = ({
-  className,
-  onRemove,
-}: TagGroupRemoveAllProps) => {
+export const TagGroupRemoveAll = ({ onRemove }: TagGroupRemoveAllProps) => {
   const state = use(ListStateContext);
   const stringFormatter = useLocalizedStringFormatter(intlMessages, 'marigold');
 
@@ -24,10 +16,7 @@ export const TagGroupRemoveAll = ({
   }
 
   return (
-    <Button
-      onPress={() => onRemove?.(new Set(state?.collection.getKeys()))}
-      className={className}
-    >
+    <Button onPress={() => onRemove?.(new Set(state?.collection.getKeys()))}>
       {stringFormatter.format('removeAll')}
     </Button>
   );

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -233,7 +233,7 @@ export type Theme = {
       ComponentStyleFunction<string, string>
     >;
     Tag?: Record<
-      'container' | 'tag' | 'listItems' | 'closeButton' | 'removeAll',
+      'container' | 'tag' | 'listItems' | 'closeButton',
       ComponentStyleFunction<string, string>
     >;
     TagField?: Record<

--- a/themes/theme-rui/src/components/Tag.styles.ts
+++ b/themes/theme-rui/src/components/Tag.styles.ts
@@ -37,13 +37,4 @@ export const Tag: ThemeComponent<'Tag'> = {
       'mb-0',
     ],
   }),
-  removeAll: cva({
-    base: [
-      'inline whitespace-nowrap font-medium transition-[color,box-shadow,transform] rounded-md',
-      'ui-press',
-      'focus-visible:ui-state-focus outline-none',
-      'cursor-pointer',
-      'text-link text-xs ui-touch-hitbox',
-    ],
-  }),
 };


### PR DESCRIPTION
# Description

Internal refactor: `TagGroup` wraps its internal `TagGroupRemoveAll` render in a scoped `ButtonContext` (`variant: 'link'`, `size: 'small'`), so the "Remove all" action is a plain Marigold `<Button>` instead of a raw react-aria `Button` with hand-rolled link styling. This mirrors the cascade pattern already used by `ActionBar` and `Panel.Header`.

The redundant `removeAll` cva is removed from `Tag.styles.ts` (the `link` variant at `size="small"` reproduces it), and the now-unused `removeAll` key is dropped from the `Tag` theme type. No public API, behavioral, or accessibility change — `TagGroupRemoveAll` is internal (`TagGroup` renders it itself) and the `removeAll`/`onRemove` authoring API is unchanged.

Closes DST-1546

## Screenshots / Preview

Visual no-op: the "Remove all" link renders identically (link/small Button vs the removed bespoke cva).

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Open Storybook → `Components/TagGroup`, story with `removeAll` enabled.
2. Confirm "Remove all" renders as a small link-style button and clicking it clears all tags.
3. Confirm per-tag close buttons are unaffected (the `link` cascade is scoped to the Remove all render only).
4. `pnpm typecheck:only` passes.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)