### PR TITLE
docs(DST-1623): document mounting <ToastProvider> once

### DIFF
--- a/.changeset/toast-provider-mount-once.md
+++ b/.changeset/toast-provider-mount-once.md
@@ -1,0 +1,9 @@
+---
+'@marigold/docs': patch
+---
+
+docs(DST-1623): note that `<ToastProvider>` should be mounted once
+
+Every toast shares one global queue (React Aria's model: a single `ToastRegion` per queue), so one `<ToastProvider>` renders them all and `addToast` works from anywhere. Mounting more than one renders every toast per provider and creates duplicate notification `region` landmarks — React Aria surfaces this via its duplicate-landmark-label warning; it does not dedupe. Added a callout on the Toast page documenting the "mount once" guidance.
+
+[DST-1623](https://reservix.atlassian.net/browse/DST-1623)

--- a/.changeset/toast-provider-mount-once.md
+++ b/.changeset/toast-provider-mount-once.md
@@ -4,6 +4,6 @@
 
 docs(DST-1623): note that `<ToastProvider>` should be mounted once
 
-Every toast shares one global queue (React Aria's model: a single `ToastRegion` per queue), so one `<ToastProvider>` renders them all and `addToast` works from anywhere. Mounting more than one renders every toast per provider and creates duplicate notification `region` landmarks — React Aria surfaces this via its duplicate-landmark-label warning; it does not dedupe. Added a callout on the Toast page documenting the "mount once" guidance.
+Every toast shares one global queue (React Aria's model: a single `ToastRegion` per queue), so one `<ToastProvider>` renders them all and `addToast` works from anywhere. Mounting more than one renders every toast per provider and creates duplicate notification `region` landmarks. React Aria surfaces this via its duplicate-landmark-label warning and does not dedupe. Added a callout on the Toast page documenting the "mount once" guidance.
 
 [DST-1623](https://reservix.atlassian.net/browse/DST-1623)

--- a/docs/content/components/overlay/toast/index.mdx
+++ b/docs/content/components/overlay/toast/index.mdx
@@ -35,6 +35,14 @@ Each variant uses a distinct icon color to signal the nature of the notification
 
 The `<ToastProvider>` Component should be in the root of your application, so it can be used anywhere in your app. You can use the `addToast` function to add a Toast to the Toaster. The Toast will appear at the bottom right of the screen by default. With the position prop you can change the position of all Toasts.
 
+<Callout type="info" title="Mount the provider once">
+  Every toast shares one global queue, so `addToast` works from anywhere — you
+  don't need a provider nearby, and a single `<ToastProvider>` renders them all.
+  Mounting more than one renders every toast multiple times and creates
+  duplicate notification landmarks (React Aria warns about this in the console),
+  so keep it to a single instance at the root of your app.
+</Callout>
+
 ### Simple toast
 
 A Toast should be used when you want to give users quick, non-intrusive feedback after an action, such as saving, deleting, or uploading data. It appears on the edge of the screen. Because it doesn't interrupt the user's workflow, a Toast is ideal for success messages, notifications, or error alerts that don't need immediate interaction. The message should be clear, concise, and easy to read.

--- a/docs/content/components/overlay/toast/index.mdx
+++ b/docs/content/components/overlay/toast/index.mdx
@@ -36,11 +36,10 @@ Each variant uses a distinct icon color to signal the nature of the notification
 The `<ToastProvider>` Component should be in the root of your application, so it can be used anywhere in your app. You can use the `addToast` function to add a Toast to the Toaster. The Toast will appear at the bottom right of the screen by default. With the position prop you can change the position of all Toasts.
 
 <Callout type="info" title="Mount the provider once">
-  Every toast shares one global queue, so `addToast` works from anywhere — you
-  don't need a provider nearby, and a single `<ToastProvider>` renders them all.
-  Mounting more than one renders every toast multiple times and creates
-  duplicate notification landmarks (React Aria warns about this in the console),
-  so keep it to a single instance at the root of your app.
+  Because all toasts share one global queue, mounting more than one
+  `<ToastProvider>` renders every toast multiple times and creates duplicate
+  notification landmarks (React Aria warns about this in the console). Keep it to
+  a single instance.
 </Callout>
 
 ### Simple toast


### PR DESCRIPTION
# Description

Mounting more than one `<ToastProvider>` on a page renders every toast once per provider and creates duplicate `region` (notification) landmarks with identical labels — an a11y footgun. Found while building the bulk-actions pattern doc ([DST-1383](https://reservix.atlassian.net/browse/DST-1383)).

Closes DST-1623

## Why this deviates from the ticket

The ticket ([DST-1623](https://reservix.atlassian.net/browse/DST-1623)) is filed as a **bug** and its preferred fix is a **runtime guard** — a "singleton region" that tracks mounted instances so only the first `<ToastProvider>` renders, later ones render nothing, plus a dev warning and a test covering two mounted providers.

I built that guard first (a module registry + `useSyncExternalStore`, with a component test — all green). Before shipping it, I checked how React Aria — the layer Marigold's Toast wraps — handles this, and it changed the call:

- **React Aria ships no such guard, by design.** `ToastRegion` simply subscribes to its `queue` and portals `visibleToasts` to `document.body`; two regions on one queue produce two portals and two landmarks with **zero** deduplication. Its documented model is explicitly *one global queue → one `ToastRegion` mounted at the app root*. The mistake is surfaced by React Aria's own `LandmarkManager` **duplicate-landmark-label warning** — which is the exact console message quoted in the ticket — not prevented in code.
- **It's not a tracked upstream bug.** The only `ToastRegion` issues on `adobe/react-spectrum` are [#9056](https://github.com/adobe/react-spectrum/issues/9056) (ToastList animation API) and [#7917](https://github.com/adobe/react-spectrum/issues/7917) (queue replacing a visible toast). Upstream treats multiple regions as user error, mitigated by docs + the warning.
- **Marigold already matches the intended model** — `getToastQueue()` is the single global queue. The only reason the footgun is reachable is that we named the mount-once component `<ToastProvider>` (which reads like a context provider you'd mount per-subtree), where React Aria names it `<ToastRegion>` (obviously singular).

So adding a runtime guard would mean owning **more** behavior than the library it wraps — a registry, an external store, and the SSR / Strict Mode / concurrent-render edge cases that come with it — to prevent a mistake the underlying library already announces loudly and treats as a documentation matter. We chose to **align with React Aria's stance: document "mount once"** rather than engineer around it. This reframes DST-1623 from "bug" to "working as designed upstream, now documented."

(If we later decide the `<ToastProvider>` naming warrants stronger protection than React Aria's `<ToastRegion>`, the guard implementation is preserved in this PR's history and can be restored.)

## What changed

- **Toast page** (`components/overlay/toast`): a callout under *Usage* — mount `<ToastProvider>` **once**; one global queue renders through a single provider; `addToast` works from anywhere; extra providers duplicate toasts and notification landmarks.

The Table record management pattern demos each keep their own `<ToastProvider>` on purpose, so every example stays self-contained and readable. That page will log React Aria's duplicate-landmark warning — an accepted trade-off for teaching clarity, and exactly the behavior the new callout explains.

## Test Instructions

1. Read the Toast page *Usage* section — the "Mount the provider once" callout renders and states the guidance.
2. (Expected) On the Table record management pattern page, triggering a toast logs React Aria's duplicate-landmark warning, because both demos intentionally mount a provider. This is documented behavior, not a regression.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

<sub>Docs-only change (`@marigold/docs` patch) — no component code, so no unit/story tests or VRT.</sub>


[DST-1383]: https://reservix.atlassian.net/browse/DST-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DST-1623]: https://reservix.atlassian.net/browse/DST-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ