### PR TITLE
fix(DST-1622): respect consumer aria-label on ProgressCircle and Loader

### DIFF
--- a/.changeset/progresscircle-aria-label.md
+++ b/.changeset/progresscircle-aria-label.md
@@ -1,0 +1,19 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1622): `ProgressCircle` and `Loader` respect a consumer-provided `aria-label` / `aria-labelledby`.
+
+**What changed:**
+
+- `ProgressCircle` no longer overwrites a caller's accessible name. The built-in localized "loading" message is now only a fallback, applied solely when the consumer provides neither `aria-label` nor `aria-labelledby`.
+- `Loader` (`BaseLoader`) uses the same fallback: the localized message is applied only when there is no `aria-label`, `aria-labelledby`, or visible `children` label — and it no longer emits a redundant `aria-label` next to a consumer's `aria-labelledby`.
+
+**Why:**
+
+Previously the `aria-label` was set _after_ `{...props}` was spread, so a caller passing `aria-label` (or `aria-labelledby`) had no effect and every progress circle announced the same generic "Loading…" string. This prevented labelling a spinner for its context (e.g. "Sending reminders" in a bulk-action flow).
+
+**Impact:**
+
+- Callers that pass no label (e.g. the spinners inside `Button`, `ComboBox`, `SearchInput`) are unchanged — they still get the localized fallback.
+- Callers that pass `aria-label`/`aria-labelledby` now get their own accessible name.

--- a/.changeset/progresscircle-aria-label.md
+++ b/.changeset/progresscircle-aria-label.md
@@ -8,6 +8,7 @@ fix(DST-1622): `ProgressCircle` and `Loader` respect a consumer-provided `aria-l
 
 - `ProgressCircle` no longer overwrites a caller's accessible name. The built-in localized "loading" message is now only a fallback, applied solely when the consumer provides neither `aria-label` nor `aria-labelledby`.
 - `Loader` (`BaseLoader`) uses the same fallback: the localized message is applied only when there is no `aria-label`, `aria-labelledby`, or visible `children` label — and it no longer emits a redundant `aria-label` next to a consumer's `aria-labelledby`.
+- A fullscreen `Loader` now stays reliably named: when the consumer supplies their own `aria-labelledby`, the overlay `Dialog` references that element directly instead of the intermediate loader node (the accessible-name spec does not follow a second `aria-labelledby` hop, which otherwise left the modal unnamed).
 
 **Why:**
 

--- a/packages/components/src/Loader/BaseLoader.tsx
+++ b/packages/components/src/Loader/BaseLoader.tsx
@@ -195,10 +195,7 @@ export const BaseLoader = ({
   const stringFormatter = useLocalizedStringFormatter(intlMessages, 'marigold');
   const className = useClassNames({ component: 'Loader', variant, size });
 
-  // The localized "loading" message is only a fallback: apply it solely when the
-  // consumer supplies no accessible name of any kind (`aria-label`,
-  // `aria-labelledby`, or a visible `children` label). This keeps the consumer's
-  // label winning and avoids emitting a redundant `aria-label` next to it.
+  // Localized label is only a fallback; let a consumer's label win.
   const hasLabel = ariaLabel || ariaLabelledby || children;
 
   return (

--- a/packages/components/src/Loader/BaseLoader.tsx
+++ b/packages/components/src/Loader/BaseLoader.tsx
@@ -188,21 +188,27 @@ export const BaseLoader = ({
   size,
   children,
   'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
   loaderType = 'circle',
   ...props
 }: BaseLoaderProps) => {
   const stringFormatter = useLocalizedStringFormatter(intlMessages, 'marigold');
   const className = useClassNames({ component: 'Loader', variant, size });
 
+  // The localized "loading" message is only a fallback: apply it solely when the
+  // consumer supplies no accessible name of any kind (`aria-label`,
+  // `aria-labelledby`, or a visible `children` label). This keeps the consumer's
+  // label winning and avoids emitting a redundant `aria-label` next to it.
+  const hasLabel = ariaLabel || ariaLabelledby || children;
+
   return (
     <ProgressBar
       className={className.container}
       isIndeterminate
       aria-label={
-        ariaLabel || children
-          ? ariaLabel
-          : stringFormatter.format('loadingMessage')
+        hasLabel ? ariaLabel : stringFormatter.format('loadingMessage')
       }
+      aria-labelledby={ariaLabelledby}
       {...props}
     >
       {loaderType === 'xloader' ? (

--- a/packages/components/src/Loader/Loader.test.tsx
+++ b/packages/components/src/Loader/Loader.test.tsx
@@ -32,6 +32,20 @@ test('render custom label', () => {
   expect(label).toBeInTheDocument();
 });
 
+test('respects a consumer-provided aria-labelledby without a redundant aria-label', () => {
+  render(
+    <>
+      <span id="loader-label">Saving changes</span>
+      <Basic.Component aria-labelledby="loader-label" />
+    </>
+  );
+
+  const loader = screen.getByRole('progressbar');
+
+  expect(loader).toHaveAttribute('aria-labelledby', 'loader-label');
+  expect(loader).not.toHaveAttribute('aria-label');
+});
+
 test('inline uses "inverted" variant', () => {
   render(<Basic.Component mode="section">Loading...</Basic.Component>);
 

--- a/packages/components/src/Loader/Loader.test.tsx
+++ b/packages/components/src/Loader/Loader.test.tsx
@@ -92,6 +92,32 @@ test('renders fullscreen loader with modal overlay', () => {
   expect(dialog).toBeInTheDocument();
 });
 
+test('fullscreen dialog is named by the loader fallback when no label is given', () => {
+  renderWithOverlay(<Basic.Component mode="fullscreen" />);
+
+  // The Dialog references the loader node, which carries the localized
+  // fallback label — so the modal is never left unnamed.
+  const dialog = screen.getByRole('dialog');
+
+  expect(dialog).toHaveAccessibleName('Loading...');
+});
+
+test('fullscreen dialog is named by a consumer-provided aria-labelledby', () => {
+  renderWithOverlay(
+    <>
+      <span id="loader-label">Saving changes</span>
+      <Basic.Component mode="fullscreen" aria-labelledby="loader-label" />
+    </>
+  );
+
+  // A consumer `aria-labelledby` suppresses the loader's own `aria-label`, and
+  // the accname spec won't follow a second `labelledby` hop — so the Dialog
+  // must reference the consumer's element directly to stay named.
+  const dialog = screen.getByRole('dialog');
+
+  expect(dialog).toHaveAccessibleName('Saving changes');
+});
+
 test('renders loader with loaderType circle', () => {
   render(<Basic.Component loaderType="circle" />);
 

--- a/packages/components/src/Loader/Loader.tsx
+++ b/packages/components/src/Loader/Loader.tsx
@@ -25,14 +25,24 @@ export interface LoaderProps extends BaseLoaderProps {
 
 // Full Screen
 // ---------------
-const LoaderFullScreen = (props: BaseLoaderProps) => {
+const LoaderFullScreen = ({
+  'aria-labelledby': ariaLabelledby,
+  ...props
+}: BaseLoaderProps) => {
   const id = useId();
 
+  // The Dialog derives its accessible name from the loader. When the consumer
+  // supplies their own `aria-labelledby`, point the Dialog straight at that
+  // element: the intermediate loader node can't relay a second `labelledby`
+  // hop (the accessible-name spec does not follow `aria-labelledby` on a node
+  // reached via `aria-labelledby`), so referencing `id` would leave the Dialog
+  // unnamed. Otherwise reference the loader node, which carries the localized
+  // (or consumer `aria-label`) fallback.
   return (
     <Underlay defaultOpen keyboardDismissable variant="modal">
       <Modal className="grid h-(--visual-viewport-height) cursor-progress place-items-center">
-        <Dialog className="outline-0" aria-labelledby={id}>
-          <BaseLoader id={id} {...props} />
+        <Dialog className="outline-0" aria-labelledby={ariaLabelledby ?? id}>
+          <BaseLoader id={id} aria-labelledby={ariaLabelledby} {...props} />
         </Dialog>
       </Modal>
     </Underlay>

--- a/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
@@ -92,6 +92,17 @@ test('respects a consumer-provided aria-label', () => {
   expect(progressCircle).toHaveAttribute('aria-label', 'Sending reminders');
 });
 
+test('falls back to the localized label when aria-label is explicitly undefined', () => {
+  // A conditional label (`aria-label={cond ? '…' : undefined}`) puts the key
+  // `aria-label: undefined` into props. The fallback must still apply so the
+  // progressbar always has an accessible name.
+  render(<Basic.Component aria-label={undefined} />);
+
+  const progressCircle = screen.getByRole('progressbar');
+
+  expect(progressCircle).toHaveAttribute('aria-label', 'Loading...');
+});
+
 test('respects a consumer-provided aria-labelledby without a redundant aria-label', () => {
   render(
     <>

--- a/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.test.tsx
@@ -83,3 +83,25 @@ test('has aria label', () => {
 
   expect(progressCircle).toHaveAttribute('aria-label', 'Loading...');
 });
+
+test('respects a consumer-provided aria-label', () => {
+  render(<Basic.Component aria-label="Sending reminders" />);
+
+  const progressCircle = screen.getByRole('progressbar');
+
+  expect(progressCircle).toHaveAttribute('aria-label', 'Sending reminders');
+});
+
+test('respects a consumer-provided aria-labelledby without a redundant aria-label', () => {
+  render(
+    <>
+      <span id="progress-label">Sending reminders</span>
+      <Basic.Component aria-labelledby="progress-label" />
+    </>
+  );
+
+  const progressCircle = screen.getByRole('progressbar');
+
+  expect(progressCircle).toHaveAttribute('aria-labelledby', 'progress-label');
+  expect(progressCircle).not.toHaveAttribute('aria-label');
+});

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -90,10 +90,16 @@ export const ProgressCircle = ({
   ...props
 }: ProgressCircleProps) => {
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  // The localized "loading" message is only a fallback: it fills the accessible
+  // name when the consumer provides none. Placing it before `{...props}` lets a
+  // caller's `aria-label`/`aria-labelledby` win instead of being overwritten.
+  const hasLabel = props['aria-label'] || props['aria-labelledby'];
   return (
     <ProgressBar
+      aria-label={
+        hasLabel ? undefined : stringFormatter.format('loadingMessage')
+      }
       {...props}
-      aria-label={stringFormatter.format('loadingMessage')}
       isIndeterminate
     >
       <ProgressCircleSvg size={size} />

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -87,16 +87,19 @@ export const ProgressCircleSvg = ({
 
 export const ProgressCircle = ({
   size = '16',
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
   ...props
 }: ProgressCircleProps) => {
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
   // Localized label is only a fallback; let a consumer's label win.
-  const hasLabel = props['aria-label'] || props['aria-labelledby'];
+  const hasLabel = ariaLabel || ariaLabelledby;
   return (
     <ProgressBar
       aria-label={
-        hasLabel ? undefined : stringFormatter.format('loadingMessage')
+        hasLabel ? ariaLabel : stringFormatter.format('loadingMessage')
       }
+      aria-labelledby={ariaLabelledby}
       {...props}
       isIndeterminate
     >

--- a/packages/components/src/ProgressCircle/ProgressCircle.tsx
+++ b/packages/components/src/ProgressCircle/ProgressCircle.tsx
@@ -90,9 +90,7 @@ export const ProgressCircle = ({
   ...props
 }: ProgressCircleProps) => {
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
-  // The localized "loading" message is only a fallback: it fills the accessible
-  // name when the consumer provides none. Placing it before `{...props}` lets a
-  // caller's `aria-label`/`aria-labelledby` win instead of being overwritten.
+  // Localized label is only a fallback; let a consumer's label win.
   const hasLabel = props['aria-label'] || props['aria-labelledby'];
   return (
     <ProgressBar


### PR DESCRIPTION
# Description

`<ProgressCircle>` set its localized "loading" `aria-label` **after** spreading `{...props}`, so any consumer-provided `aria-label` / `aria-labelledby` was silently overwritten. Every spinner announced the same generic string regardless of context.

This makes the localized string a **fallback**: it is applied only when the caller provides no accessible name. Placing it before `{...props}` lets the consumer's label win.

- **`ProgressCircle`** — respects consumer `aria-label` / `aria-labelledby`; the localized message fills in only when neither is present.
- **`Loader` (`BaseLoader`)** — same fallback pattern, now also keyed off `aria-labelledby`, and it no longer emits a redundant `aria-label="Loading..."` next to a consumer's `aria-labelledby`.

**Current vs. new behavior:** before, `<ProgressCircle aria-label="Sending reminders" />` still announced "Loading…". Now it announces "Sending reminders". Spinners that pass no label (inside `Button`, `ComboBox`, `SearchInput`) are unchanged — they still get the localized fallback.

Closes DST-1622

## Screenshots / Preview

No visual change — accessible-name (a11y) fix only.

## Test Instructions

1. Render `<ProgressCircle aria-label="Sending reminders" />` and inspect the `progressbar` node — its `aria-label` is now `"Sending reminders"` (previously `"Loading..."`).
2. Render `<ProgressCircle />` with no label — it still falls back to the localized `"Loading..."`.
3. Render `<ProgressCircle aria-labelledby="…" />` — the `progressbar` carries `aria-labelledby` and no redundant `aria-label`.
4. `pnpm test:unit packages/components/src/ProgressCircle packages/components/src/Loader` — all pass (new assertions cover the above for both `ProgressCircle` and `Loader`).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
