### PR TITLE
docs(DST-1466): document card collection semantics & heading levels

### DIFF
--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -191,9 +191,41 @@ Every slot is inset with `p="square-regular"`, mirroring `Panel`. Use `square-lo
 
 ## Accessibility
 
-- `<Card>` renders an `<article>` landmark. When a `<Title>` is present, the article is automatically labelled by it (`aria-labelledby`). Otherwise pass `aria-label` to give the card an accessible name.
-- Always give a card an accessible name. A `<Card>` with neither a `<Title>` nor an `aria-label` produces an **unnamed** `article` landmark, which screen reader users cannot identify. In development, Card logs a `console.warn` when both are missing.
-- The heading level is configurable via the `headingLevel` prop on `<Card>` (default `3`). Choose the level that fits the card's depth in the document outline.
+Card renders an `<article>` and wires up its accessible name and heading level, so most of the work is handled for you. Give every card a name, pick the heading level that fits the page, and add list semantics when cards repeat in a grid.
+
+### Labeling
+
+`<Card>` renders an `<article>` landmark. When a `<Title>` is present, the article is automatically labelled by it (`aria-labelledby`). Otherwise pass `aria-label` on the `<Card>` to give it an accessible name.
+
+Always give a card a name. A `<Card>` with neither a `<Title>` nor an `aria-label` produces an **unnamed** `article` landmark, which screen reader users cannot identify. In development, Card logs a `console.warn` when both are missing.
+
+### Heading levels
+
+The card's heading level comes from the `headingLevel` prop on `<Card>` (default `3`). The default assumes a card grid living under a page-level `<h2>`, so a card title at `<h3>` keeps the document outline clean: page heading, then section heading, then card title.
+
+If the grid sits deeper in the page, inside a `<Tabs>` panel or a `<Panel headingLevel={3}>`, step the card title down with `<Card headingLevel={4}>` so the outline still nests correctly.
+
+### Collection semantics
+
+A card rarely appears alone. The canonical use is a grid of cards, and a repeating collection is semantically a list. Because `<Tiles>` accepts a `role` and an `aria-label`, mark the grid as a list and wrap each card in an element with `role="listitem"`. Assistive technology then announces the item count and lets the user step through the set:
+
+```tsx
+<Tiles
+  role="list"
+  aria-label="Venues"
+  space="regular"
+  tilesWidth="240px"
+  stretch
+>
+  {venues.map(venue => (
+    <div role="listitem" key={venue.id}>
+      <Card>…</Card>
+    </div>
+  ))}
+</Tiles>
+```
+
+The roles are set explicitly rather than on native `<ul>` and `<li>` tags. A `<ul>` styled as a grid usually carries `list-style: none`, and in Safari that removes the list's semantics. An explicit `role="list"` on the `<Tiles>` grid is not affected, so the list markup holds. Since `<Card>` is not polymorphic today, the list structure lives on the wrapper, not on the card. The card grid demo earlier on this page shows the per-card composition. Wrap that grid as shown here to add the collection semantics.
 
 ## Props
 

--- a/docs/content/components/collection/card/index.mdx
+++ b/docs/content/components/collection/card/index.mdx
@@ -13,7 +13,7 @@ import {
 
 A `<Card>` represents one item in a collection, such as an event preview, a venue tile, or a product summary, that repeats next to similar siblings in a grid or list. Each card groups related content (image, title, content, actions) into a single, self-contained unit and sets it apart from the page through fill or tinting: a white card sits on the gray page background with a quiet rim, not a drop shadow.
 
-`<Card>` renders an `<article>` landmark. When a `<Title>` is present, the card is automatically labelled by it via `aria-labelledby`. Otherwise pass `aria-label` to give the card an accessible name.
+`<Card>` renders an `<article>` landmark, labelled by its `<Title>` so the card stays identifiable to assistive tech.
 
 ## Anatomy
 
@@ -201,7 +201,7 @@ Always give a card a name. A `<Card>` with neither a `<Title>` nor an `aria-labe
 
 ### Heading levels
 
-The card's heading level comes from the `headingLevel` prop on `<Card>` (default `3`). The default assumes a card grid living under a page-level `<h2>`, so a card title at `<h3>` keeps the document outline clean: page heading, then section heading, then card title.
+The card's heading level comes from the `headingLevel` prop on `<Card>` (default `3`). The default assumes a card grid living under a section-level `<h2>`, so a card title at `<h3>` keeps the document outline clean: page heading, then section heading, then card title.
 
 If the grid sits deeper in the page, inside a `<Tabs>` panel or a `<Panel headingLevel={3}>`, step the card title down with `<Card headingLevel={4}>` so the outline still nests correctly.
 


### PR DESCRIPTION
# Description

Expands and restructures the Card docs' `## Accessibility` section into three parallel subsections — Labeling, Heading levels, Collection semantics — mirroring the sibling `Panel` doc. New guidance covers how to give a card grid list semantics (`role="list"` on `<Tiles>` plus a `role="listitem"` wrapper per card) and the rationale behind the default `headingLevel={3}`, including the nested step-down to `4`.

**Scope note:** DST-1466 was filed when `<Card>` was a bare `<div>` with no labeling or heading API. The later Card `<article>` rework already shipped the semantics, labeling, and heading-level guidance the ticket asked for, so this PR delivers only the one piece still missing — collection/grid semantics — plus the heading-level rationale, and tidies the section structure. No component, prop, demo, or type changes.

Closes DST-1466

## Test Instructions

1. Run `pnpm start` and open `http://localhost:3000/components/collection/card`
2. Scroll to **Accessibility**. Confirm it renders an intro plus three subsections: Labeling, Heading levels, Collection semantics.
3. Confirm the Collection semantics `tsx` code sample renders.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)