### PR TITLE
fix(DST-1629): apply SelectList action slot placement to trailing actions

### DIFF
--- a/.changeset/dst-1629-action-menu-size-spacing.md
+++ b/.changeset/dst-1629-action-menu-size-spacing.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1629): apply a `SelectList` item's `action` slot styling to a trailing Marigold `Button`, `LinkButton`, or `ActionMenu` so the action spans both rows and stays centered. The action slot className was only provided on RAC's `ButtonContext`, which Marigold's `Button` ignores, so the action auto-placed into the title row and stretched it, pushing the description down. The className now flows through the Marigold `ButtonContext` that these components read.

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -112,6 +112,20 @@ export const WithActionMenu = meta.story({
     <ButtonGroup aria-label="With ActionMenu" size="small" variant="ghost">
       <Button aria-label="Edit">Edit</Button>
       <Button aria-label="Duplicate">Duplicate</Button>
+      <ActionMenu aria-label="More actions">
+        <ActionMenu.Item id="archive">Archive</ActionMenu.Item>
+        <ActionMenu.Item id="delete">Delete</ActionMenu.Item>
+      </ActionMenu>
+    </ButtonGroup>
+  ),
+});
+
+// Not snapshotted: deliberately oversizes the trigger to exercise local-wins precedence (the default inheriting look lives in `WithActionMenu`).
+export const ActionMenuLocalSize = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: () => (
+    <ButtonGroup aria-label="Item actions" size="small" variant="ghost">
+      <Button aria-label="Edit">Edit</Button>
       <ActionMenu aria-label="More actions" size="large">
         <ActionMenu.Item id="archive">Archive</ActionMenu.Item>
         <ActionMenu.Item id="delete">Delete</ActionMenu.Item>

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -120,7 +120,9 @@ export const WithActionMenu = meta.story({
   ),
 });
 
-// Not snapshotted: deliberately oversizes the trigger to exercise local-wins precedence (the default inheriting look lives in `WithActionMenu`).
+// Fixture for the "local size wins" unit test, so not snapshotted. The ActionMenu
+// sets an explicit `size="large"` that must beat the group's `small`, which
+// `WithActionMenu` (its trigger inherits the group size) can't assert.
 export const ActionMenuLocalSize = meta.story({
   parameters: { chromatic: { disableSnapshot: true } },
   render: () => (

--- a/packages/components/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-aria-components/slots';
 import { Basic as ButtonBasic } from '../Button/Button.stories';
 import { ButtonContext } from '../Button/Context';
 import {
+  ActionMenuLocalSize,
   Basic,
   CascadePrecedence,
   DisabledCascade,
@@ -83,12 +84,22 @@ describe('cascade precedence (local always wins)', () => {
   });
 });
 
-test('ActionMenu trigger inside ButtonGroup follows local-wins size precedence', () => {
+test('ActionMenu trigger inside ButtonGroup inherits the group size', () => {
   render(<WithActionMenu.Component />);
 
   const menuTrigger = screen.getByRole('button', { name: 'More actions' });
 
-  // ActionMenu sets `size="large"` locally, which wins over the group's `small`.
+  // With no local size, the ActionMenu trigger inherits the group's `small`.
+  expect(menuTrigger).toHaveClass('h-control-small');
+  expect(menuTrigger).not.toHaveClass('h-control-large');
+});
+
+test('ActionMenu trigger inside ButtonGroup follows local-wins size precedence', () => {
+  render(<ActionMenuLocalSize.Component />);
+
+  const menuTrigger = screen.getByRole('button', { name: 'More actions' });
+
+  // An explicit local `size` on the ActionMenu wins over the group's `small`.
   expect(menuTrigger).toHaveClass('h-control-large');
   expect(menuTrigger).not.toHaveClass('h-control-small');
 });

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -6,6 +6,7 @@ import {
   Disabled,
   EmptyState,
   Horizontal,
+  WithActionMenu,
   WithError,
   WithIconAction,
   WithMultiSelection,
@@ -337,6 +338,15 @@ describe('SelectList', () => {
 
       // Action spans both rows so a tall control doesn't stretch the title row and gap the description.
       expect(action).toHaveClass('col-start-3', 'row-span-2');
+    });
+
+    test('applies the action slot placement to a trailing ActionMenu trigger', () => {
+      render(<WithActionMenu.Component />);
+
+      // ActionMenu's trigger reads the Marigold ButtonContext through a different chain than a plain Button.
+      const trigger = screen.getAllByRole('button', { name: /manage/i })[0];
+
+      expect(trigger).toHaveClass('col-start-3', 'row-span-2');
     });
   });
 

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -327,6 +327,17 @@ describe('SelectList', () => {
       expect(label).toBeInTheDocument();
       expect(row).toBeInTheDocument();
     });
+
+    test('applies the action slot placement to a trailing action button', () => {
+      render(<WithIconAction.Component />);
+
+      const action = screen.getByRole('button', {
+        name: /learn more about credit card/i,
+      });
+
+      // Action spans both rows so a tall control doesn't stretch the title row and gap the description.
+      expect(action).toHaveClass('col-start-3', 'row-span-2');
+    });
   });
 
   describe('item padding', () => {

--- a/packages/components/src/SelectList/SelectListOption.tsx
+++ b/packages/components/src/SelectList/SelectListOption.tsx
@@ -1,16 +1,12 @@
 import type { ReactNode, Ref } from 'react';
-import { use, useMemo } from 'react';
+import { useMemo } from 'react';
 import type RAC from 'react-aria-components';
-import { ButtonContext } from 'react-aria-components/Button';
 import { GridListItem as RACGridListItem } from 'react-aria-components/GridList';
 import { TextContext } from 'react-aria-components/Text';
 import { Provider } from 'react-aria-components/slots';
 import { cn } from '@marigold/system';
 import { ButtonContext as MarigoldButtonContext } from '../Button/Context';
-import {
-  type SlottedContextValue,
-  useMergedTextSlots,
-} from '../utils/useMergedTextSlots';
+import { useMergedTextSlots } from '../utils/useMergedTextSlots';
 import { useSelectListContext } from './Context';
 import { SelectionIndicator } from './SelectionIndicator';
 
@@ -36,42 +32,29 @@ interface OptionChildrenProps {
   actionClassName?: string;
 }
 
-// Stable identity so `buttonContextValue`'s `useMemo` isn't invalidated each
-// render when there's no parent context.
-const EMPTY_BUTTON_CTX: SlottedContextValue = {};
-
-// A trailing action in an option is low-emphasis chrome, so a nested Marigold
-// `<Button>`/`<LinkButton>`/`<ActionMenu>` defaults to `ghost` (a local
-// `variant` still wins).
-const OPTION_BUTTON_CASCADE = { variant: 'ghost' };
-
-// Merge (not replace) RAC's slot configs on Text/Button contexts so nested
-// slotted children pick up our theme classNames without losing RAC's wiring.
+// Inject the option's theme slot classNames: merge into RAC's TextContext (to keep aria wiring) and cascade the action slot class + `ghost` via Marigold's ButtonContext.
 const OptionChildren = ({
   children,
   labelClassName,
   descriptionClassName,
   actionClassName,
 }: OptionChildrenProps) => {
-  const parentButton = use(ButtonContext) as SlottedContextValue | undefined;
-  const parentButtonValue = parentButton ?? EMPTY_BUTTON_CTX;
-
   const textContextValue = useMergedTextSlots({
     label: labelClassName,
     description: descriptionClassName,
   });
 
-  const buttonContextValue = useMemo(
-    () => ({ ...parentButtonValue, className: actionClassName }),
-    [parentButtonValue, actionClassName]
+  // Marigold Button/LinkButton/ActionMenu read the Marigold ButtonContext, so the action slot className and the `ghost` default live here. A local `variant` still wins.
+  const marigoldButtonContextValue = useMemo(
+    () => ({ variant: 'ghost', className: actionClassName }),
+    [actionClassName]
   );
 
   return (
     <Provider
       values={[
         [TextContext, textContextValue],
-        [ButtonContext, buttonContextValue],
-        [MarigoldButtonContext, OPTION_BUTTON_CASCADE],
+        [MarigoldButtonContext, marigoldButtonContextValue],
       ]}
     >
       {children}


### PR DESCRIPTION
# Description

A trailing action inside a `SelectList` item (icon `Button` or `ActionMenu`) was not receiving the `action` slot's grid-placement classes, so it auto-placed into the title row and stretched it, opening a gap above the description.

Root cause: the action slot className was provided only on **RAC's** `ButtonContext`, but a Marigold `Button`/`LinkButton`/`ActionMenu` reads the **Marigold** `ButtonContext`. The fix routes the action className through the Marigold `ButtonContext` (the same cascade `Panel.Header` and `Page.Header` use), so the action now spans both rows and stays centered. The now-dead RAC `ButtonContext` branch was removed.

The ButtonGroup half was an example, not a component bug: the `WithActionMenu` story set `size="large"` on the ActionMenu, so its trigger rendered larger than the small sibling buttons. Dropped the override so the trigger inherits the group's size, and split the test into inherit-vs-local-wins coverage (with a snapshot-disabled fixture story for the override case).

Verified in a real browser: title→description gap is 0 and the action spans rows 1-2 for both the icon-action and ActionMenu stories.

Closes DST-1629

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm sb` and open **Components/SelectList → With Icon Action** and **With Action Menu**: the title and description sit tightly together and the action stays vertically centered. Action-less items are unchanged.
2. Open **Components/ButtonGroup → With Action Menu**: the "More actions" trigger matches the small Edit / Duplicate buttons.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)