### PR TITLE
fix(DST-1630): match the Panel collapsible caret to the Accordion chevron

### DIFF
--- a/.changeset/dst-1630-panel-collapsible-caret.md
+++ b/.changeset/dst-1630-panel-collapsible-caret.md
@@ -1,7 +1,7 @@
 ---
 '@marigold/components': patch
 '@marigold/theme-rui': patch
-'@marigold/system': patch
+'@marigold/system': minor
 ---
 
 fix(DST-1630): match the Panel collapsible header caret to the Accordion chevron. It rendered at the default 24px in the foreground color, while Accordion uses a 16px `text-secondary` caret, so the two collapsible patterns looked inconsistent. The Panel caret now renders at 16px and its color is driven by a new themeable `collapsibleIcon` slot (defaulting to `text-secondary` in the RUI theme).

--- a/.changeset/dst-1630-panel-collapsible-caret.md
+++ b/.changeset/dst-1630-panel-collapsible-caret.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+'@marigold/system': patch
+---
+
+fix(DST-1630): match the Panel collapsible header caret to the Accordion chevron. It rendered at the default 24px in the foreground color, while Accordion uses a 16px `text-secondary` caret, so the two collapsible patterns looked inconsistent. The Panel caret now renders at 16px and its color is driven by a new themeable `collapsibleIcon` slot (defaulting to `text-secondary` in the RUI theme).

--- a/packages/components/src/Panel/PanelCollapsible.test.tsx
+++ b/packages/components/src/Panel/PanelCollapsible.test.tsx
@@ -92,6 +92,16 @@ describe('Panel.CollapsibleHeader', () => {
     expect(title.tagName).toBe('SPAN');
     expect(description.tagName).toBe('SPAN');
   });
+
+  test('renders the caret at 16px and text-secondary to match the Accordion chevron', () => {
+    render(<WithCollapsible.Component />);
+
+    const trigger = screen.getByRole('button', { name: /Advanced Options/ });
+    const caret = trigger.querySelector('svg') as SVGSVGElement;
+
+    expect(caret).toHaveAttribute('width', '16');
+    expect(caret).toHaveClass('text-secondary');
+  });
 });
 
 describe('Panel.CollapsibleHeader heading level', () => {

--- a/packages/components/src/Panel/PanelCollapsible.test.tsx
+++ b/packages/components/src/Panel/PanelCollapsible.test.tsx
@@ -97,7 +97,7 @@ describe('Panel.CollapsibleHeader', () => {
     render(<WithCollapsible.Component />);
 
     const trigger = screen.getByRole('button', { name: /Advanced Options/ });
-    const caret = trigger.querySelector('svg') as SVGSVGElement;
+    const caret = trigger.querySelector('svg')!;
 
     expect(caret).toHaveAttribute('width', '16');
     expect(caret).toHaveClass('text-secondary');

--- a/packages/components/src/Panel/PanelCollapsibleHeader.tsx
+++ b/packages/components/src/Panel/PanelCollapsibleHeader.tsx
@@ -89,7 +89,11 @@ export const PanelCollapsibleHeader = ({
         >
           <span className="min-w-0 flex-1">{children}</span>
         </Provider>
-        <MorphCaret expanded={isExpanded} />
+        <MorphCaret
+          size="16"
+          expanded={isExpanded}
+          className={classNames.collapsibleIcon}
+        />
       </Button>
     </Heading>
   );

--- a/packages/system/src/types/theme.ts
+++ b/packages/system/src/types/theme.ts
@@ -174,6 +174,7 @@ export type Theme = {
       | 'collapsibleTitle'
       | 'collapsibleDescription'
       | 'collapsibleContent'
+      | 'collapsibleIcon'
       | 'footer',
       ComponentStyleFunction<string, string>
     >;

--- a/themes/theme-rui/src/components/Panel.styles.ts
+++ b/themes/theme-rui/src/components/Panel.styles.ts
@@ -54,5 +54,7 @@ export const Panel: ThemeComponent<'Panel'> = {
   collapsibleContent: cva({
     base: 'overflow-clip h-(--disclosure-panel-height) transition-[height] duration-250',
   }),
+  // Match the Accordion chevron: a muted caret. `MorphCaret` already bakes in `shrink-0`.
+  collapsibleIcon: cva({ base: 'pointer-events-none text-secondary' }),
   footer: cva({}),
 };


### PR DESCRIPTION
# Description

The Panel collapsible header caret didn't match the Accordion chevron: it rendered at the shared `MorphCaret`'s default **24px** in the **foreground** color, while Accordion renders a **16px** `text-secondary` caret. Side by side, the two collapsible patterns looked inconsistent.

The Panel caret now renders at 16px, and its color is driven by a new themeable **`collapsibleIcon`** slot (defaulting to `text-secondary` in the RUI theme) — mirroring how Accordion themes its chevron via its `icon` slot. Verified in the browser: both carets now render 16×16 in the identical `text-secondary` color.

Closes DST-1630

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm sb` and open **Components/Panel → With Collapsible** and any **Components/Accordion** story side by side. Confirm the Panel collapsible caret is now 16px and muted (`text-secondary`), matching the Accordion chevron.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)