### PR TITLE
fix(DST-1631): keep RangeCalendar within its container on small screens

### DIFF
--- a/.changeset/dst-1631-calendar-scrollable-overflow.md
+++ b/.changeset/dst-1631-calendar-scrollable-overflow.md
@@ -1,0 +1,5 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1631): keep the `RangeCalendar` within its container on small screens. Each month carried a hard `min-w-[250px]` with no breakpoint guard, so below `sm` (where the months stack) the calendar could not shrink and overflowed a narrow Panel. The floor is now gated to `sm` and up (`min-w-0 sm:min-w-[250px]`), letting the flexible-cell grid shrink to fit while the desktop two-across layout is unchanged.

--- a/packages/components/src/Scrollable/Scrollable.stories.tsx
+++ b/packages/components/src/Scrollable/Scrollable.stories.tsx
@@ -58,8 +58,8 @@ export const Basic = meta.story({
 
 export const Horizontal = meta.story({
   render: args => (
-    <Scrollable {...args}>
-      <div className="flex gap-2">
+    <Scrollable width="1/2" {...args}>
+      <div className="inline-flex gap-2">
         <Card>
           <Card.Content>
             <div className="h-[100px] w-[200px] border border-[#ced4da] bg-[#e9ecef]" />

--- a/themes/theme-rui/src/components/Calendar.styles.ts
+++ b/themes/theme-rui/src/components/Calendar.styles.ts
@@ -27,7 +27,7 @@ export const Calendar: ThemeComponent<'Calendar'> = {
     ],
   }),
   calendarContainer: cva({ base: 'flex flex-col gap-4 sm:flex-row' }),
-  calendarMonth: cva({ base: 'min-w-[250px] sm:flex-1' }),
+  calendarMonth: cva({ base: 'min-w-0 sm:min-w-[250px] sm:flex-1' }),
   calendarCell: cva({
     base: [
       'size-9 rounded-lg',


### PR DESCRIPTION
# Description

Two overflow findings from VRT build 148, one real fix and one story correction.

**RangeCalendar (real fix).** In "Two Months Mobile" (320px viewport, wrapped by the Panel decorator), the calendar overflowed its Panel. Each month carried a hard `min-w-[250px]` with no breakpoint guard, so below `sm` — where the months stack — the calendar could not shrink to fit a narrow Panel. Gating the floor to `sm`+ (`min-w-0 sm:min-w-[250px]`) lets RangeCalendar's flexible-cell grid shrink to fit, while the desktop two-across layout is unchanged. Base `Calendar` already fit at 320px, so it is unaffected.

**Scrollable (story only, not a component bug).** The `Scrollable` component is a correct `overflow-auto` container. The "Horizontal" story passed no `width` and used a block `flex` row, so it filled the canvas and read as "cut off." It now uses a bounded `width="1/2"` and an `inline-flex` content row (matching the docs demo), so it renders as a clean, contained horizontal scroll.

Verified in the browser: RangeCalendar fits its Panel at 320px (and is unchanged at desktop), and the Scrollable Horizontal story is a 489px box with 1384px of full-size content scrolling horizontally.

Closes DST-1631

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. `pnpm sb` → **Components/RangeCalendar → Two Months Mobile** at a 320px viewport: the calendar stays within the Panel (no horizontal overflow). At desktop width the two months still sit side by side.
2. **Components/Scrollable → Horizontal**: a bounded box whose cards scroll horizontally (no compression or clipping of the full-canvas kind).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)