### PR TITLE
fix(DST-1636): simplify Accordion icon slot to match Panel collapsibleIcon

### DIFF
--- a/.changeset/dst-1636-accordion-icon-slot-cleanup.md
+++ b/.changeset/dst-1636-accordion-icon-slot-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1636): simplify the Accordion `icon` slot to `pointer-events-none text-secondary`, matching Panel's `collapsibleIcon`. Drops the redundant `shrink-0` (already baked into `MorphCaret`) and the obsolete `transition-transform duration-250` (the caret morphs its path `d` rather than rotating). No visual change.

--- a/themes/theme-rui/src/components/Accordion.styles.ts
+++ b/themes/theme-rui/src/components/Accordion.styles.ts
@@ -77,9 +77,7 @@ export const Accordion: ThemeComponent<'Accordion'> = {
       variant: 'default',
     },
   }),
-  icon: cva({
-    base: 'pointer-events-none shrink-0 text-secondary transition-transform duration-250',
-  }),
+  icon: cva({ base: 'pointer-events-none text-secondary' }),
   actions: cva({
     base: 'shrink-0',
     variants: {


### PR DESCRIPTION
# Description

Follow-up cleanup surfaced during review of #5648 (DST-1630). Now that the Accordion chevron is rendered by the shared `MorphCaret`, two classes on the `theme-rui` Accordion `icon` slot are dead weight:

- **`shrink-0`** — redundant. `MorphCaret` already bakes it in via `cn('shrink-0', className)`.
- **`transition-transform duration-250`** — obsolete. `MorphCaret` animates open/closed by morphing the SVG path `d` (`transition: d 250ms`), not by rotating with a `transform`. Nothing transforms, so the transition is a no-op.

The slot now reads `pointer-events-none text-secondary`, byte-for-byte identical to Panel's `collapsibleIcon` slot. No visual change.

```diff
- icon: cva({
-   base: 'pointer-events-none shrink-0 text-secondary transition-transform duration-250',
- }),
+ icon: cva({ base: 'pointer-events-none text-secondary' }),
```

Closes DST-1636

## Screenshots / Preview

No visual change — the removed classes were provably inert on `beta-release` (the caret morph lives inside `MorphCaret`, and `shrink-0` is baked into it).

## Test Instructions

1. Open any **Components/Accordion** story and expand/collapse a header — the caret still morphs between the up/down states exactly as before.
2. `pnpm test:unit --run packages/components/src/Accordion` — 13/13 pass.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated <!-- no new tests; existing Accordion tests still pass (13/13) -->
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) <!-- no visual change -->
- [x] Changeset added (`pnpm changeset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
