### PR TITLE
fix(DST-1632): center section Loader, order Page actions primary-first, space Table drag handle

### DIFF
--- a/.changeset/dst-1632-alignment-spacing-polish.md
+++ b/.changeset/dst-1632-alignment-spacing-polish.md
@@ -1,0 +1,8 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1632): center the section `Loader` together with its label and give the `Table` drag handle edge spacing.
+
+The section `Loader` sized its container to a fixed square, so a labelled loader overflowed the box and the section wrapper centered the box instead of the spinner-and-label group. The spinner now carries the fixed size and the container is content-sized, so the whole group centers as one. The `Table` drag cell had no padding, leaving the grip flush against the row edge. It now uses the shared cell edge padding and its column matches the checkbox column width, so the grip lines up with its header and the first cell.

--- a/packages/components/src/Loader/Loader.test.tsx
+++ b/packages/components/src/Loader/Loader.test.tsx
@@ -20,8 +20,9 @@ test('renders loader with different size', () => {
   // eslint-disable-next-line testing-library/no-node-access
   const icon = loader.querySelector('svg');
 
-  expect(loader).toHaveClass('size-36');
-  expect(icon).toHaveClass('size-full');
+  // The spinner carries the size; the container wraps it content-sized.
+  expect(loader).toHaveClass('size-fit');
+  expect(icon).toHaveClass('size-36');
 });
 
 test('render custom label', () => {
@@ -52,7 +53,7 @@ test('inline uses "inverted" variant', () => {
   const loader = screen.getByRole('progressbar');
 
   expect(loader).toHaveClass(
-    'grid place-items-center text-primary-foreground size-20'
+    'grid place-items-center gap-2 text-primary-foreground size-fit'
   );
 });
 

--- a/packages/components/src/Page/Page.stories.tsx
+++ b/packages/components/src/Page/Page.stories.tsx
@@ -139,8 +139,8 @@ export const Actions = meta.story({
           <Title>Primary and secondary</Title>
           <Description>Group multiple buttons in a ButtonGroup.</Description>
           <ButtonGroup aria-label="Plan actions">
-            <Button variant="secondary">Compare plans</Button>
             <Button variant="primary">Upgrade plan</Button>
+            <Button variant="secondary">Compare plans</Button>
           </ButtonGroup>
         </Page.Header>
       </Page>

--- a/packages/components/src/Table/TableHeader.tsx
+++ b/packages/components/src/Table/TableHeader.tsx
@@ -41,7 +41,7 @@ const TableHeader = <T extends object>({
       {...props}
     >
       {allowsDragging && (
-        <Column className={classNames.column} minWidth={24} width={24} />
+        <Column className={classNames.column} minWidth={36} width={36} />
       )}
       {selectionBehavior === 'toggle' && (
         <Column minWidth={36} width={36} className={classNames.column}>

--- a/packages/components/src/Table/TableRow.tsx
+++ b/packages/components/src/Table/TableRow.tsx
@@ -36,7 +36,7 @@ const TableRow = <T extends object>({
   return (
     <Row id={id} className={cn('group/row', classNames.row)} {...otherProps}>
       {allowsDragging && (
-        <Cell>
+        <Cell className={classNames.cell}>
           <Button
             slot="drag"
             className={cn(

--- a/themes/theme-rui/src/components/Loader.styles.ts
+++ b/themes/theme-rui/src/components/Loader.styles.ts
@@ -2,15 +2,16 @@ import { ThemeComponent, cva } from '@marigold/system';
 
 export const Loader: ThemeComponent<'Loader'> = {
   container: cva({
-    base: 'grid place-items-center text-primary',
+    // Content-sized so the box wraps the spinner and its label for centering.
+    base: 'grid place-items-center gap-2 text-primary',
     variants: {
       variant: {
         default: '',
         inverted: 'text-primary-foreground',
       },
       size: {
-        default: 'size-20',
-        large: 'size-36',
+        default: 'size-fit',
+        large: 'size-fit',
         fit: 'size-full',
       },
     },
@@ -20,16 +21,15 @@ export const Loader: ThemeComponent<'Loader'> = {
     },
   }),
   loader: cva({
-    base: 'size-full',
     variants: {
       variant: {
         default: '',
         inverted: '',
       },
       size: {
-        default: '',
-        large: '',
-        fit: '',
+        default: 'size-20',
+        large: 'size-36',
+        fit: 'size-full',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
# Description

Three small alignment/spacing fixes surfaced by VRT build 148 (under DST-1584). Each root cause was pinned by live browser measurement.

- **Loader / Section (theme).** The container was a fixed square, so a labelled section loader overflowed the box and the wrapper centered the box rather than the spinner-and-label group. The spinner now carries the fixed size (`size-20`/`size-36`) and the container is content-sized (`size-fit`) with a `gap-2`, so the whole group centers as one. Spinner sizes are preserved (xloader and circle stay 80px/144px; `fit` mode unchanged).
- **Page / Actions (story).** The "Primary and secondary" example ordered the `ButtonGroup` secondary → primary. On a full-size page, actions read left → right as primary → secondary → ghost (Button docs "Placement and order"), so the buttons are swapped to lead with the primary. Story-only, consistent with the sibling "Primary action with overflow" example.
- **Table / Drag And Drop.** The drag `<Cell>` had no padding, so the grip sat flush against the row edge. It now uses the shared cell edge padding and its `<Column>` widened 24 → 36px to match the checkbox column, so the grip has breathing room and lines up with its header and the first cell.

Closes DST-1632

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |
<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Storybook → **Components/Loader** → `Section` and `CircleLoader`: the spinner (and its label) centers as a group in the section box; `Basic`, `large`, and `fit` are unaffected.
2. **Components/Page** → `Actions`: the "Primary and secondary" example reads primary (left) → secondary (right), matching "Primary action with overflow".
3. **Components/Table** → `DragAndDrop`: the drag grip has edge spacing (no longer flush) and aligns with the checkbox column and its header.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A for `beta-release`; diffs accepted under DST-1584
- [x] Changeset added (`pnpm changeset`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)