### PR TITLE
docs(DST-1637): extend bulk actions pattern with pagination guidance

### DIFF
--- a/docs/content/components/navigation/pagination/index.mdx
+++ b/docs/content/components/navigation/pagination/index.mdx
@@ -35,6 +35,8 @@ Pagination is used to divide large datasets into discrete pages, making them man
 
 Use pagination when the amount of dataset results would be too overwhelming for one page, either for the user or the system performance.
 
+Prefer pagination over infinite scrolling when users work on the data rather than browse it. A page is a stable, bounded view: users can reason about "these rows", return to them, and select them for an action. Infinite scrolling suits passive consumption, but it makes any "select all" ambiguous between what is visible, what has loaded so far, and what matches the query, which is why task-oriented tables in Marigold paginate.
+
 Pagination is not a replacement for search, filter or sort functionality, but rather a complementary feature.
 
 <ComponentDemo name="pagination-full" />
@@ -161,6 +163,35 @@ The default text string for the label is "**Results per page**". Only change the
   </Dont>
 </GuidelineTiles>
 
+### Changing the page
+
+A page change replaces the visible rows, and everything on the screen that was derived from those rows must be re-derived or visibly reset. Row selection is the most common case: a selection made on one page must not silently survive onto another, where the checked rows are no longer visible. The [Bulk Actions](/patterns/user-input/bulk-actions#pagination) pattern covers how selection and pagination interact in detail.
+
+The dataset can also change underneath the current page. When records are deleted, the current page can end up past the last page, stranding the user on an empty view. Clamp the page index after the data changes, so the user lands on the new last page instead:
+
+```tsx
+const lastPage = Math.max(1, Math.ceil(totalItems / pageSize));
+if (page > lastPage) {
+  setPage(lastPage);
+}
+```
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Reset or re-derive any state that was based on the visible rows when the
+      page changes, and step back to the last page when the current page
+      empties.
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't leave the user on a page that no longer exists or carry hidden
+      row-based state across a page change.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
 ### Summary: What decisions can product teams make?
 
 - The default amount of visible results per page
@@ -247,6 +278,28 @@ The `<Pagination>` component already meets all known relevant WCAG 2.2 AA standa
             strokeLinejoin="round"
             d="M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18M5.25 6h.008v.008H5.25V6ZM7.5 6h.008v.008H7.5V6Zm2.25 0h.008v.008H9.75V6Z"
           />
+        </svg>
+      ),
+    },
+    {
+      title: 'Bulk Actions',
+      href: '/patterns/user-input/bulk-actions',
+      caption:
+        'How row selection and pagination interact when users act on many records at once.',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="size-6"
+        >
+          <rect x="3" y="9" width="18" height="7" rx="2" />
+          <path d="M7 12.5h.01" />
+          <path d="M11 12.5h6" />
         </svg>
       ),
     },

--- a/docs/content/components/navigation/pagination/index.mdx
+++ b/docs/content/components/navigation/pagination/index.mdx
@@ -35,7 +35,7 @@ Pagination is used to divide large datasets into discrete pages, making them man
 
 Use pagination when the amount of dataset results would be too overwhelming for one page, either for the user or the system performance.
 
-Prefer pagination over infinite scrolling when users work on the data rather than browse it. A page is a stable, bounded view: users can reason about "these rows", return to them, and select them for an action. Infinite scrolling suits passive consumption, but it makes any "select all" ambiguous between what is visible, what has loaded so far, and what matches the query, which is why task-oriented tables in Marigold paginate.
+Prefer pagination over infinite scrolling when users work on the data rather than browse it. A page is a stable, bounded view. Users can reason about "these rows", return to them, and select them for an action. Infinite scrolling suits passive browsing. For tables where users select rows and act on them it creates ambiguity, because "select all" could mean what is visible, what has loaded so far, or everything that matches the query. This is why task-oriented tables in Marigold paginate.
 
 Pagination is not a replacement for search, filter or sort functionality, but rather a complementary feature.
 

--- a/docs/content/patterns/user-input/bulk-actions/bulk-actions-pagination.demo.tsx
+++ b/docs/content/patterns/user-input/bulk-actions/bulk-actions-pagination.demo.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import type { Selection } from '@marigold/components';
+import {
+  ActionBar,
+  Badge,
+  Button,
+  Pagination,
+  Stack,
+  Table,
+} from '@marigold/components';
+import { Archive, Tag } from '@marigold/icons';
+
+const pageSize = 4;
+
+const events = [
+  { id: '1', name: 'Jazz Night', date: 'Aug 12, 2026', status: 'On sale' },
+  { id: '2', name: 'Open Air Kino', date: 'Aug 15, 2026', status: 'On sale' },
+  { id: '3', name: 'Poetry Slam', date: 'Aug 21, 2026', status: 'Draft' },
+  { id: '4', name: 'Herbstmarkt', date: 'Sep 5, 2026', status: 'Draft' },
+  { id: '5', name: 'Wine Tasting', date: 'Sep 12, 2026', status: 'On sale' },
+  { id: '6', name: 'Krimi Dinner', date: 'Sep 19, 2026', status: 'On sale' },
+  { id: '7', name: 'Comedy Club', date: 'Sep 26, 2026', status: 'Draft' },
+  { id: '8', name: 'Filmkonzert', date: 'Oct 3, 2026', status: 'On sale' },
+  { id: '9', name: 'Lesung am See', date: 'Oct 10, 2026', status: 'Draft' },
+];
+
+export default () => {
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<Selection>(new Set());
+
+  const visible = events.slice((page - 1) * pageSize, page * pageSize);
+
+  // A page change is a scope change: clearing here keeps the selection from
+  // silently including rows that are no longer on screen.
+  const changePage = (nextPage: number) => {
+    setSelected(new Set()); // [!code highlight]
+    setPage(nextPage);
+  };
+
+  return (
+    <Stack space={4}>
+      <Table
+        aria-label="Events"
+        selectionMode="multiple"
+        selectedKeys={selected}
+        onSelectionChange={setSelected}
+        actionBar={() => (
+          <ActionBar>
+            <Button onPress={() => alert('Assign category')}>
+              <Tag />
+              Assign category
+            </Button>
+            <Button onPress={() => alert('Archive')}>
+              <Archive />
+              Archive
+            </Button>
+          </ActionBar>
+        )}
+      >
+        <Table.Header>
+          <Table.Column rowHeader>Event</Table.Column>
+          <Table.Column>Date</Table.Column>
+          <Table.Column>Status</Table.Column>
+        </Table.Header>
+        <Table.Body>
+          {visible.map(event => (
+            <Table.Row key={event.id} id={event.id}>
+              <Table.Cell>{event.name}</Table.Cell>
+              <Table.Cell>{event.date}</Table.Cell>
+              <Table.Cell>
+                <Badge
+                  variant={event.status === 'On sale' ? 'success' : 'info'}
+                >
+                  {event.status}
+                </Badge>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+      <Pagination
+        page={page}
+        totalItems={events.length}
+        pageSize={pageSize}
+        onChange={changePage}
+      />
+    </Stack>
+  );
+};

--- a/docs/content/patterns/user-input/bulk-actions/index.mdx
+++ b/docs/content/patterns/user-input/bulk-actions/index.mdx
@@ -85,12 +85,46 @@ This is a deliberately conservative choice. Cross-page selection invites a well-
 
 <ComponentDemo name="bulk-actions-scope" />
 
+### Pagination
+
+Pagination puts the scope rule under the most pressure, because the select-all checkbox becomes ambiguous: does it select the rows on screen, or every row the query matched? Users guess wrong in both directions, and either wrong guess is expensive. In this pattern the answer is fixed: **the header checkbox selects the current page, nothing more.** A single click must never grow the selection beyond the rows the user can see, and no click selects records on pages the user never opened.
+
+Moving to another page is a scope change like filtering, so it clears the selection, and the clearing must be perceivable: the action bar with its count disappears, which tells the user their selection is gone before they can act on a stale one. Changing the page size or the sort order swaps which rows are visible in the same way and clears the selection too. What must never happen is the silent middle ground, where rows checked on page one invisibly remain selected while the user looks at page two. The interface would show an unchecked page while the next press still reaches the hidden rows.
+
+The demo pairs the table with the [`<Pagination>`](/components/navigation/pagination) component. The clearing wrapper around the page setter is the same one the scope demo uses for filters:
+
+<ComponentDemo name="bulk-actions-pagination" />
+
+<GuidelineTiles>
+  <Do>
+    <DoDescription>
+      Bound select-all to the visible page and clear the selection visibly when
+      the page, page size, or sort order changes.
+    </DoDescription>
+  </Do>
+  <Dont>
+    <DontDescription>
+      Don't carry an invisible selection across pages or let a single click
+      select records on pages the user never opened.
+    </DontDescription>
+  </Dont>
+</GuidelineTiles>
+
 <Callout title="Working with very large sets" type="info">
   When users regularly need to act on more records than fit on a page, do not
   reach for cross-page selection. Give them a filter that narrows the set to
   exactly the records in question, then let them select all visible results. The
   [Filter](/patterns/user-input/filter) pattern keeps the acted-on set
   reviewable, which a hidden selection never is.
+
+If a product decision nevertheless requires acting on every matching record,
+the only safe shape is a two-step disclosure: the checkbox selects the page as
+usual, and a separate, explicitly worded control ("Select all 3,200 results
+matching this filter") extends the scope. That control states the exact count,
+the operation carries a stated upper limit instead of a silent truncation, and
+the confirmation restates the full count before anything runs. The header
+checkbox itself must never jump to the full result set.
+
 </Callout>
 
 ## Direct actions
@@ -166,6 +200,8 @@ Partial failure is the case that separates a robust implementation from a fragil
 
 The succeeded records leave the selection, the failed ones stay. The selection itself becomes the retry list, which is more durable than a toast that disappears.
 
+Staleness is a failure like any other. A record that a colleague edited or removed between selection and execution is skipped by the server, not silently substituted, and the report names it the same way: "2 events were changed by someone else and were skipped." What the user selected and what the operation touched must never quietly diverge.
+
 <ComponentDemo name="bulk-actions-partial-failure" />
 
 ## Accessibility
@@ -190,11 +226,11 @@ const keys = selected === 'all' ? events.map(event => event.id) : [...selected];
 const affected = events.filter(event => keys.includes(event.id));
 ```
 
-Every message the user sees derives from `affected.length`, never from a separately tracked counter that can drift.
+Every message the user sees derives from `affected.length`, never from a separately tracked counter that can drift. Two properties of this resolution carry safety weight. The selection is a set of record ids, never row positions, so a table that re-sorts or refreshes between selection and press cannot shift the selection onto different rows. And the server receives this explicit id list, never an instruction to re-run the current filter: a re-run query silently sweeps in records that started matching after the user made their selection.
 
 ### Clear selection when the scope changes
 
-Pagination, filters, and search all change which rows are visible, and the selection must never outlive the view it was made in. Wrap the state setters so the reset cannot be forgotten at individual call sites:
+Pagination, page size, sorting, filters, and search all change which rows are visible, and the selection must never outlive the view it was made in. Wrap the state setters so the reset cannot be forgotten at individual call sites:
 
 ```tsx
 const changeFilter = (next: string) => {
@@ -210,6 +246,17 @@ After a partial failure, rebuild the selection from the failures. The selection 
 ```tsx
 if (failed.length > 0) {
   setSelected(new Set(failed.map(event => event.id)));
+}
+```
+
+### Step back when a page empties
+
+A destructive bulk action can remove every row of the current page, and only a bulk action can: single-record deletes empty a page one row at a time, a bulk delete does it in one press. When that happens the page index points past the end of the data and a naive implementation strands the user on an empty page, sometimes without pagination controls to escape it. Clamp the page after the records are gone:
+
+```tsx
+const lastPage = Math.max(1, Math.ceil(remaining.length / pageSize));
+if (page > lastPage) {
+  setPage(lastPage);
 }
 ```
 

--- a/docs/content/patterns/user-input/bulk-actions/index.mdx
+++ b/docs/content/patterns/user-input/bulk-actions/index.mdx
@@ -118,12 +118,13 @@ The demo pairs the table with the [`<Pagination>`](/components/navigation/pagina
   reviewable, which a hidden selection never is.
 
 If a product decision nevertheless requires acting on every matching record,
-the only safe shape is a two-step disclosure: the checkbox selects the page as
-usual, and a separate, explicitly worded control ("Select all 3,200 results
-matching this filter") extends the scope. That control states the exact count,
-the operation carries a stated upper limit instead of a silent truncation, and
-the confirmation restates the full count before anything runs. The header
-checkbox itself must never jump to the full result set.
+the only safe shape is a disclosure in two steps. The checkbox selects the page
+as usual, and a separate, explicitly worded control ("Select all 3,200 results
+matching this filter") extends the scope. That control states the exact count.
+The operation has a clear upper limit that the interface shows instead of
+silently cutting records off, and the confirmation repeats the full count
+before anything runs. The header checkbox itself must never jump to the full
+result set.
 
 </Callout>
 
@@ -176,7 +177,7 @@ The hard problem in a bulk-edit form is that the selected records rarely agree. 
 
 <ComponentDemo name="bulk-actions-edit-drawer" />
 
-A destructive operation configured in a drawer still needs its confirm dialog after the submit, count and impact included. The drawer collects the input; it does not replace the confirmation.
+A destructive operation configured in a drawer still needs its confirm dialog after the submit, count and impact included. The drawer collects the input but does not replace the confirmation.
 
 ## Showing progress
 
@@ -184,7 +185,7 @@ Bulk operations in Reservix products run synchronously: the user starts the oper
 
 - **Under about two seconds**, feedback on the pressed control is enough: set the [`<Button>`](/components/actions/button) `loading` prop.
 - **Between two and ten seconds**, show progress with a running count where the actions were, "Sending 4 of 12", so the user sees the operation moving through the selection. Keep the bar visible and the selection intact while it runs.
-- **Beyond ten seconds**, users lose attention and need a way to interrupt. No current Reservix bulk operation crosses this line; if yours does, the operation needs product-level rework rather than a bigger spinner.
+- **Beyond ten seconds**, users lose attention and need a way to interrupt. No current Reservix bulk operation crosses this line. If yours does, the operation needs product-level rework rather than a bigger spinner.
 
 Disable the other actions in the bar while an operation runs, so two bulk operations cannot race on the same selection. For the general feedback vocabulary of spinners and skeletons, see the [Loading States](/patterns/feedback/loading-states) pattern.
 
@@ -200,7 +201,7 @@ Partial failure is the case that separates a robust implementation from a fragil
 
 The succeeded records leave the selection, the failed ones stay. The selection itself becomes the retry list, which is more durable than a toast that disappears.
 
-Staleness is a failure like any other. A record that a colleague edited or removed between selection and execution is skipped by the server, not silently substituted, and the report names it the same way: "2 events were changed by someone else and were skipped." What the user selected and what the operation touched must never quietly diverge.
+Staleness is a failure like any other. When a colleague edits or removes a record between selection and execution, the server skips it and the report names it like any other failure: "2 events were changed by someone else and were skipped." What the user selected and what the operation touched must never quietly drift apart.
 
 <ComponentDemo name="bulk-actions-partial-failure" />
 
@@ -226,7 +227,7 @@ const keys = selected === 'all' ? events.map(event => event.id) : [...selected];
 const affected = events.filter(event => keys.includes(event.id));
 ```
 
-Every message the user sees derives from `affected.length`, never from a separately tracked counter that can drift. Two properties of this resolution carry safety weight. The selection is a set of record ids, never row positions, so a table that re-sorts or refreshes between selection and press cannot shift the selection onto different rows. And the server receives this explicit id list, never an instruction to re-run the current filter: a re-run query silently sweeps in records that started matching after the user made their selection.
+Every message the user sees derives from `affected.length`, never from a separately tracked counter that can drift. Resolving this way also protects against two subtle mistakes. The selection is a set of record ids, not row positions, so a table that re-sorts or refreshes between selecting and pressing cannot shift the selection onto different rows. The server also receives this exact list of ids, never an instruction to run the current filter again. A query that runs again would quietly include records that only started matching after the user made their selection.
 
 ### Clear selection when the scope changes
 
@@ -251,7 +252,7 @@ if (failed.length > 0) {
 
 ### Step back when a page empties
 
-A destructive bulk action can remove every row of the current page, and only a bulk action can: single-record deletes empty a page one row at a time, a bulk delete does it in one press. When that happens the page index points past the end of the data and a naive implementation strands the user on an empty page, sometimes without pagination controls to escape it. Clamp the page after the records are gone:
+A destructive bulk action can remove every row of the current page in a single press. When that happens the page index points past the end of the data, and a naive implementation strands the user on an empty page, sometimes without pagination controls to escape it. Clamp the page after the records are gone:
 
 ```tsx
 const lastPage = Math.max(1, Math.ceil(remaining.length / pageSize));


### PR DESCRIPTION
# Description

The CAT team implemented bulk editing based on the Bulk Actions pattern and fed back that the interaction between selection and pagination is underspecified. This PR adds the missing guidance to both affected pages.

- **Bulk Actions pattern:** new "Pagination" subsection (select-all means the current page, page/page-size/sort changes clear the selection visibly) with an interactive paginated demo and Do/Don't tiles. The "very large sets" callout now documents the guarded escape hatch for acting on all matching records (disclosure in two steps, exact count, stated upper limit). New implementation notes cover id-keyed selection, executing against an explicit id list, and stepping back when a bulk delete empties the current page. Result feedback now covers concurrently changed records.
- **Pagination component:** new "Changing the page" behavior section (re-derive row-based state, clamp the page when it empties), guidance on pagination vs. infinite scrolling for task-oriented tables, and cross-links to the Bulk Actions pattern.

No component or API changes. VRT: N/A, docs content only.

Closes DST-1637

## Test Instructions

1. Run `pnpm start` and open [localhost:3000](http://localhost:3000)
2. Navigate to Patterns → User Input → Bulk Actions: check the new "Pagination" section, its demo (select rows, change page, selection clears), and the extended callout
3. Navigate to Components → Navigation → Pagination: check the new "Changing the page" section and the Bulk Actions teaser under Related

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)