### PR TITLE
feat(DST-1633): reveal a Dialog header seam when the body scrolls

### DIFF
--- a/.changeset/dialog-header-scroll-seam.md
+++ b/.changeset/dialog-header-scroll-seam.md
@@ -1,0 +1,21 @@
+---
+'@marigold/theme-rui': minor
+---
+
+feat(DST-1633): `Dialog` reveals a header seam once its body scrolls.
+
+**What changed:**
+
+- The `Dialog` header is borderless at rest and fades in a bottom hairline once the body scrolls beneath it, matching the `Sidebar`'s scroll-revealed seam. A short (non-scrolling) dialog stays seamless.
+- The scroll-seam mechanism is promoted from a private `Sidebar` utility to a reusable `ui-scroll-seam-*` primitive. It is the companion to `ui-scroll-edge` for the case where the header is a grid _sibling_ of the scrolling body rather than its ancestor. The seam color is a `--seam-color` custom property that defaults to `--color-border`.
+- The `Sidebar` is migrated onto the shared primitive with its color pinned to `--color-surface-border`, so it renders exactly as before.
+
+**Why:**
+
+A long dialog gave no cue that its body scrolled under the header. The `Sidebar` already had this affordance, and the `Dialog` is the second occurrence of the same header-over-scrolling-body structure, so the mechanism becomes a shared primitive instead of a copy.
+
+**Impact:**
+
+- `Dialog` gains the affordance automatically with no API change, covering both `<Dialog.Header>` and bare `<Title>` dialogs.
+- `Sidebar` is unchanged visually.
+- Browsers without CSS scroll-driven animations (for example Firefox) fall back to an always-on hairline, so every engine still shows a divider.

--- a/themes/theme-rui/src/components/Dialog.styles.ts
+++ b/themes/theme-rui/src/components/Dialog.styles.ts
@@ -10,6 +10,8 @@ export const Dialog: ThemeComponent<'Dialog'> = {
       // surface; the dialog drops its own border + elevation to avoid a double
       // frame. As a modal (no popover ancestor) it keeps them.
       'group-data-trigger/popover:ring-0 group-data-trigger/popover:shadow-none',
+      // Hoists the body's scroll timeline into scope for the sibling header's seam.
+      'ui-scroll-seam-scope',
     ],
     variants: {
       variant: {},
@@ -22,12 +24,16 @@ export const Dialog: ThemeComponent<'Dialog'> = {
       },
     },
   }),
+  // Borderless at rest, grows a bottom seam as the body scrolls under it
+  // (scroll-driven, see `ui-scroll-seam-*` in ui.css). On `header` so it also
+  // covers the bare `<Title>` chrome, which reuses these classNames.
   header: cva({
-    base: 'flex flex-col text-center sm:text-left px-6 pt-6',
+    base: 'flex flex-col text-center sm:text-left px-6 pt-6 ui-scroll-seam-header',
   }),
   title: cva({ base: 'text-lg font-semibold mb-1' }),
   description: cva({ base: 'text-sm text-secondary' }),
-  content: cva({ base: 'ui-panel-content text-sm' }),
+  // Declares the named scroll timeline the header seam animates against.
+  content: cva({ base: 'ui-panel-content text-sm ui-scroll-seam-timeline' }),
   actions: cva({
     base: 'ui-panel-actions flex-col-reverse sm:flex-row',
   }),

--- a/themes/theme-rui/src/components/Sidebar.styles.ts
+++ b/themes/theme-rui/src/components/Sidebar.styles.ts
@@ -43,14 +43,17 @@ export const Sidebar: ThemeComponent<'Sidebar'> = {
   closeButton: cva({ base: ['absolute top-3.5 right-3', 'size-7'] }),
   // Hoists the nav's scroll timeline (see `nav`) into scope so the header and
   // footer — the header a *preceding* sibling — can drive their seams off it.
-  content: cva({ base: 'sm:w-64 ui-sidebar-seam-scope' }),
+  // --seam-color tints the seam with the faint surface rim, not the opaque default.
+  content: cva({
+    base: 'sm:w-64 ui-scroll-seam-scope [--seam-color:var(--color-surface-border)]',
+  }),
   // border-b-0: regions separate on whitespace, not the border ui-panel-* adds
   // for Panel. min-w-0: stop the grid column growing to its widest item and
   // overflowing the fixed w-64 aside, where overflow-hidden clips rows and the
   // pill. Seam: hidden at rest, fades in as content scrolls under the header;
   // inactive on a short (non-scrolling) nav.
   header: cva({
-    base: 'ui-panel-header h-14 min-w-0 border-b-0 ui-sidebar-seam-header',
+    base: 'ui-panel-header h-14 min-w-0 border-b-0 ui-scroll-seam-header',
   }),
   nav: cva({
     base: [
@@ -58,7 +61,7 @@ export const Sidebar: ThemeComponent<'Sidebar'> = {
       // edge; min-w-0 lets the row column collapse to the aside width.
       'flex flex-col min-w-0 py-1 overflow-y-auto outline-none',
       // Declares the named timeline the header/footer seams animate against.
-      'ui-scrollbar ui-sidebar-seam-timeline',
+      'ui-scrollbar ui-scroll-seam-timeline',
     ],
   }),
   // Ambient escape hatches, a step quieter than nav rows so they never compete
@@ -69,7 +72,7 @@ export const Sidebar: ThemeComponent<'Sidebar'> = {
   // header's, fading out as the list bottoms out.
   footer: cva({
     base: [
-      'flex flex-col gap-1 min-w-0 px-4 py-2 ui-sidebar-seam-footer',
+      'flex flex-col gap-1 min-w-0 px-4 py-2 ui-scroll-seam-footer',
       '[&_a]:-mx-2 [&_a]:h-7.5 [&_a]:px-2 [&_a]:rounded-surface [&_a]:text-sm',
       '[&_a]:text-secondary [&_a]:font-normal',
       '[&_a:hover]:bg-hover [&_a:hover]:text-foreground',

--- a/themes/theme-rui/src/ui.css
+++ b/themes/theme-rui/src/ui.css
@@ -455,6 +455,10 @@
  * animation support the bar simply stays borderless — the sticky bar's opaque
  * background still separates it from passing content. Scroll-linked, so not
  * gated by `prefers-reduced-motion`.
+ *
+ * Only works when the bar is a *descendant* of the scroller (its own ancestor
+ * scrolls). For the sibling case — a header/footer flanking a scrolling body
+ * that is a grid sibling, not an ancestor — use `ui-scroll-seam-*` below.
  */
 @utility ui-scroll-edge {
   @supports (animation-timeline: scroll()) {
@@ -465,62 +469,63 @@
 }
 
 /*
- * ⚠️ NOT REUSABLE — Sidebar-specific. Coupled to the Sidebar's header/nav/footer
- * grid and its private `--sidebar-nav` timeline. (The general-purpose version is
- * `ui-scroll-edge` above.)
- *
- * Scroll-revealed seams for the sticky header and footer flanking the scrolling
- * nav. The nav is a grid *sibling*, not the seam's ancestor, so a plain
- * `scroll()` timeline can't reach it: the nav declares a NAMED timeline
- * (`--sidebar-nav` via `ui-sidebar-seam-timeline`), hoisted with `timeline-scope`
- * on the grid wrapper (`ui-sidebar-seam-scope`) so the preceding-sibling header
- * can see it too.
+ * Scroll-revealed seams for a sticky header/footer that flank a scrolling body
+ * which is a grid *sibling* (not an ancestor) of them, so an anonymous
+ * `scroll()` timeline (as `ui-scroll-edge` uses) can't reach it. The scroller
+ * declares a NAMED timeline (`--scroll-seam` via `ui-scroll-seam-timeline`),
+ * hoisted with `timeline-scope` on the common grid wrapper
+ * (`ui-scroll-seam-scope`) so a preceding-sibling header can reference it too.
  *
  *   - Header: seamless at rest; bottom hairline fades in over the first 12px.
- *   - Footer: top hairline shows until the list bottoms out, fading over the
+ *   - Footer: top hairline shows until the body bottoms out, fading over the
  *     last 12px.
  *
- * A `box-shadow` hairline, so it never affects layout. Without scroll-driven
- * animation the fallback pins both seams on as an always-on divider.
+ * Consumers: Dialog (header only), Sidebar (header + footer). The hairline
+ * color is `--seam-color` (default `--color-border`). The Sidebar overrides it
+ * to `--color-surface-border` on its grid wrapper. A `box-shadow` hairline, so
+ * it never affects layout. Sharing one timeline name across components is safe:
+ * each `timeline-scope` confines resolution to its own subtree, and Dialogs
+ * render in an overlay portal (never nested in the Sidebar's scope). Without
+ * scroll-driven animation the fallback pins the seam on as an always-on divider.
  */
-@keyframes sidebar-seam-header {
+@keyframes scroll-seam-header {
   to {
-    box-shadow: 0 1px 0 0 var(--color-surface-border);
+    box-shadow: 0 1px 0 0 var(--seam-color, var(--color-border));
   }
 }
-@keyframes sidebar-seam-footer {
+@keyframes scroll-seam-footer {
   from {
-    box-shadow: 0 -1px 0 0 var(--color-surface-border);
+    box-shadow: 0 -1px 0 0 var(--seam-color, var(--color-border));
   }
   to {
     box-shadow: 0 -1px 0 0 transparent;
   }
 }
 
-@utility ui-sidebar-seam-scope {
-  timeline-scope: --sidebar-nav;
+@utility ui-scroll-seam-scope {
+  timeline-scope: --scroll-seam;
 }
-@utility ui-sidebar-seam-timeline {
-  scroll-timeline: --sidebar-nav block;
+@utility ui-scroll-seam-timeline {
+  scroll-timeline: --scroll-seam block;
 }
 
-@utility ui-sidebar-seam-header {
+@utility ui-scroll-seam-header {
   @supports (animation-timeline: scroll()) {
-    animation: sidebar-seam-header linear both;
-    animation-timeline: --sidebar-nav;
+    animation: scroll-seam-header linear both;
+    animation-timeline: --scroll-seam;
     animation-range: 0 12px;
   }
   @supports not (animation-timeline: scroll()) {
-    box-shadow: 0 1px 0 0 var(--color-surface-border);
+    box-shadow: 0 1px 0 0 var(--seam-color, var(--color-border));
   }
 }
-@utility ui-sidebar-seam-footer {
+@utility ui-scroll-seam-footer {
   @supports (animation-timeline: scroll()) {
-    animation: sidebar-seam-footer linear both;
-    animation-timeline: --sidebar-nav;
+    animation: scroll-seam-footer linear both;
+    animation-timeline: --scroll-seam;
     animation-range: calc(100% - 12px) 100%;
   }
   @supports not (animation-timeline: scroll()) {
-    box-shadow: 0 -1px 0 0 var(--color-surface-border);
+    box-shadow: 0 -1px 0 0 var(--seam-color, var(--color-border));
   }
 }


### PR DESCRIPTION
# Description

The Dialog header is borderless at rest and fades in a bottom hairline once its
body scrolls beneath it, matching the Sidebar's scroll-revealed seam. A short
(non-scrolling) dialog stays seamless. This was raised during Chromatic review of
VRT build 148, where a scrolled "Shows very long content" dialog gave no cue that
content continued under the header.

The scroll-seam mechanism is promoted from the Sidebar's private `ui-sidebar-seam-*`
utility into a reusable `ui-scroll-seam-*` primitive (the companion to
`ui-scroll-edge` for the case where the header is a grid sibling of the scrolling
body rather than its ancestor). Seam color is a `--seam-color` custom property that
defaults to `--color-border`. The Sidebar migrates onto the primitive with its
color pinned to `--color-surface-border`, so it renders exactly as before.

Pure CSS via scroll-driven animations. Browsers without support (for example
Firefox) fall back to an always-on hairline, so every engine still shows a divider.

Closes DST-1633

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. `pnpm build:themes` (docs/Storybook read the built theme CSS).
2. `pnpm sb` -> Components/Dialog -> `VeryLongContent`: the header is borderless at
   rest, and scrolling the body fades in a bottom hairline within the first ~12px. A
   short dialog (`Default`) stays borderless. Confirm both a `<Dialog.Header>` dialog
   and a bare `<Title>` dialog get the seam.
3. `pnpm sb` -> AppShell -> `ScrollingSidebar`: the header/footer seams behave exactly
   as before (the migration is a visual no-op).
4. `pnpm test:sb` for Dialog and Sidebar/AppShell passes (existing `VeryLongContent`
   coverage exercises the scrolled state).

## Breaking Changes

No. `ui-scroll-seam-*` replaces the internal `ui-sidebar-seam-*` theme utility (not
public API), and the Sidebar is visually unchanged.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with \`component-test\` tag where applicable) — existing \`VeryLongContent\` covers it
- [ ] Unit tests added/updated — existing story tests cover it
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components) — decorative box-shadow, no a11y surface
- [ ] Visual regression tests updated (for UI changes) — not a gate for \`beta-release\` targets
- [x] Changeset added (\`pnpm changeset\`)