### PR TITLE
fix(Autocomplete): correct onSubmit argument order to match documented signature

### DIFF
--- a/.changeset/autocomplete-onsubmit-argument-order.md
+++ b/.changeset/autocomplete-onsubmit-argument-order.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+Fix `Autocomplete`'s `onSubmit` argument order to match the documented `(value, key)` signature.

--- a/.changeset/autocomplete-onsubmit-argument-order.md
+++ b/.changeset/autocomplete-onsubmit-argument-order.md
@@ -2,4 +2,4 @@
 '@marigold/components': patch
 ---
 
-Fix `Autocomplete`'s `onSubmit` argument order to match the documented `(value, key)` signature.
+Fix `Autocomplete`'s public `onSubmit` type, which declared `(value, key)` while the implementation, JSDoc, and both docs demos all used `(key, value)`. The type now matches the actual `(key, value)` signature — no runtime behavior changes.

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -228,7 +228,7 @@ test('calls onSubmit with custom value on Enter when no option is focused', asyn
   const input = screen.getByRole('combobox');
   await user.type(input, 'custom value{Enter}');
 
-  expect(onSubmit).toHaveBeenCalledWith('custom value', null);
+  expect(onSubmit).toHaveBeenCalledWith(null, 'custom value');
 });
 
 test('calls onSubmit with the selected key when an option is chosen', async () => {
@@ -241,7 +241,7 @@ test('calls onSubmit with the selected key when an option is chosen', async () =
   const option = await screen.findByRole('option', { name: 'Harry Potter' });
   await user.click(option);
 
-  expect(onSubmit).toHaveBeenCalledWith(null, 'Harry Potter');
+  expect(onSubmit).toHaveBeenCalledWith('Harry Potter', null);
 });
 
 describe('mobile view', () => {

--- a/packages/components/src/Autocomplete/Autocomplete.test.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.test.tsx
@@ -228,7 +228,20 @@ test('calls onSubmit with custom value on Enter when no option is focused', asyn
   const input = screen.getByRole('combobox');
   await user.type(input, 'custom value{Enter}');
 
-  expect(onSubmit).toHaveBeenCalled();
+  expect(onSubmit).toHaveBeenCalledWith('custom value', null);
+});
+
+test('calls onSubmit with the selected key when an option is chosen', async () => {
+  const onSubmit = vi.fn();
+  renderWithOverlay(<Basic.Component label="Label" onSubmit={onSubmit} />);
+
+  const input = screen.getByRole('combobox');
+  await user.type(input, 'ha');
+
+  const option = await screen.findByRole('option', { name: 'Harry Potter' });
+  await user.click(option);
+
+  expect(onSubmit).toHaveBeenCalledWith(null, 'Harry Potter');
 });
 
 describe('mobile view', () => {

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -229,7 +229,7 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     ref
   ) => {
     const props: RAC.ComboBoxProps<object> = {
-      onSelectionChange: key => key !== null && onSubmit?.(null, key),
+      onSelectionChange: key => key !== null && onSubmit?.(key, null),
       defaultInputValue: defaultValue,
       inputValue: value,
       onInputChange: onChange,

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -29,7 +29,7 @@ interface AutocompleteInputProps {
    * A `value` will be passed if the submission is a custom value (e.g. a user types then presses enter).
    * If the input is a selected item, `value` will be `null`.
    */
-  onSubmit?: (key: Key | null, value: string | null) => void;
+  onSubmit?: (value: string | null, key: Key | null) => void;
 
   /**
    * Called when the clear button is pressed.
@@ -77,7 +77,7 @@ const AutocompleteInput = ({
         }
         if (e.key === 'Enter') {
           if (state?.selectionManager.focusedKey === null) {
-            onSubmit?.(null, state?.inputValue);
+            onSubmit?.(state?.inputValue, null);
           }
         }
       }}
@@ -229,7 +229,7 @@ const _Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     ref
   ) => {
     const props: RAC.ComboBoxProps<object> = {
-      onSelectionChange: key => key !== null && onSubmit?.(key, null),
+      onSelectionChange: key => key !== null && onSubmit?.(null, key),
       defaultInputValue: defaultValue,
       inputValue: value,
       onInputChange: onChange,

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -29,7 +29,7 @@ interface AutocompleteInputProps {
    * A `value` will be passed if the submission is a custom value (e.g. a user types then presses enter).
    * If the input is a selected item, `value` will be `null`.
    */
-  onSubmit?: (value: string | null, key: Key | null) => void;
+  onSubmit?: (key: Key | null, value: string | null) => void;
 
   /**
    * Called when the clear button is pressed.
@@ -190,7 +190,7 @@ export interface AutocompleteProps
    * A `value` will be passed if the submission is a custom value (e.g. a user
    * types then presses enter). If the input is a selected item, `value` will be `null`.
    */
-  onSubmit?: (value: string | number | null, key: Key | null) => void;
+  onSubmit?: (key: Key | null, value: string | number | null) => void;
 }
 
 interface AutocompleteComponent extends ForwardRefExoticComponent<

--- a/packages/components/src/Autocomplete/Autocomplete.tsx
+++ b/packages/components/src/Autocomplete/Autocomplete.tsx
@@ -77,7 +77,7 @@ const AutocompleteInput = ({
         }
         if (e.key === 'Enter') {
           if (state?.selectionManager.focusedKey === null) {
-            onSubmit?.(state?.inputValue, null);
+            onSubmit?.(null, state?.inputValue);
           }
         }
       }}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

Autocomplete's public `onSubmit` type is documented as `(value, key) => void`, but the implementation had it backwards: selecting an option called it with `(key, null)`, and typing a custom value called it with `(null, text)`. 
Consumers following the documented contract would treat selections as free-text searches and free text as selected keys. So, this fixes both call sites to match the documented signature. 

No UI/visual change — internal argument-order fix only.

## Screenshots / Preview

<!-- For UI changes, paste screenshots, GIFs, or link to the Storybook/docs preview.
     Delete this section if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

```bash

$ vitest --config vite.config.ts --project=unit-tests packages/components/src/Autocomplete/Autocomplete.test.tsx

 RUN  v4.1.9 /app

stderr | packages/components/src/Autocomplete/Autocomplete.test.tsx > mobile view > renders mobile trigger with placeholder

A PressResponder was rendered without a pressable child. Either call the usePress hook, or wrap your DOM node with <Pressable> component.               

stderr | packages/components/src/Autocomplete/Autocomplete.test.tsx > mobile view > opens tray and shows empty state

A PressResponder was rendered without a pressable child. Either call the usePress hook, or wrap your DOM node with <Pressable> component.               

 ✓  unit-tests (firefox)  packages/components/src/Autocomplete/Autocomplete.test.tsx (23 tests) 1590ms

 Test Files  1 passed (1)

      Tests  23 passed (23)

   Start at  11:23:36

   Duration  30.63s (transform 0ms, setup 100ms, import 24.79s, tests 1.59s, environment 0ms)

```

## Test Instructions

Run `pnpm test:unit packages/components/src/Autocomplete/Autocomplete.test.tsx` — updated assertions verify `onSubmit` receives `(value, key)` in the correct order for both selection and free-text submission.

## Breaking Changes

<!-- Yes / No. If yes, describe the impact and migration path. -->

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
