### PR TITLE
feat(DST-1643): add a fullscreen size to Dialog

### DIFF
--- a/.changeset/dst-1643-fullscreen-dialog-size.md
+++ b/.changeset/dst-1643-fullscreen-dialog-size.md
@@ -1,0 +1,8 @@
+---
+'@marigold/components': minor
+'@marigold/theme-rui': minor
+---
+
+feat(DST-1643): add a `fullscreen` size to `Dialog`
+
+`<Dialog size="fullscreen">` fills the viewport (minus a small margin) at every breakpoint, giving content-heavy picks room for search, filters, and a long scrollable list while the title and actions stay fixed. The existing `xsmall`/`small`/`medium`/`large` sizes are unchanged.

--- a/docs/content/components/overlay/dialog/index.mdx
+++ b/docs/content/components/overlay/dialog/index.mdx
@@ -79,6 +79,12 @@ It's also best to avoid multi-step processes or requiring users to navigate with
 
 Lastly, avoid asking users to make decisions that require information not accessible in the dialog, such as needing to check a different page or document to proceed, since this can frustrate users and disrupt their workflow.
 
+### Sizes
+
+The `size` prop controls how much space a dialog takes. Most dialogs use one of the default sizes (`xsmall` to `large`, defaulting to `small`), which cap the width and let the dialog hug its content.
+
+Use `fullscreen` for content-heavy tasks, such as multi-column pickers or dense tables, where a boxed dialog would cramp the content. It fills the viewport minus a small margin at every breakpoint and keeps the title and actions pinned while only the content scrolls. Prefer a smaller size for focused, single-task dialogs like confirmations or short forms.
+
 ### Dismissal
 
 When a dialog is open, users cannot interact with the rest of the page until the dialog is closed. To accommodate both mouse and keyboard users, the `<Dialog>` provides multiple ways to close it:

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -397,6 +397,7 @@ const FullscreenPick = ({ size, ...args }: FullscreenPickProps) => {
               </Tag.Group>
             )}
 
+            {/* Plain scroll container with no accessible role, so tests assert its scroll via this testid rather than getByRole. */}
             <div
               className="min-h-0 flex-1 overflow-auto"
               data-testid="venue-list"

--- a/packages/components/src/Dialog/Dialog.stories.tsx
+++ b/packages/components/src/Dialog/Dialog.stories.tsx
@@ -1,11 +1,19 @@
+import { useMemo, useState } from 'react';
 import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
+import type { Key, Selection } from '@react-types/shared';
 import { Copy, Download, Pencil, Trash2 } from '@marigold/icons';
 import { Button } from '../Button/Button';
 import { ButtonGroup } from '../ButtonGroup/ButtonGroup';
 import { Description } from '../Description/Description';
+import { EmptyState } from '../EmptyState/EmptyState';
 import { Form } from '../Form/Form';
+import { Inline } from '../Inline/Inline';
 import { ActionMenu } from '../Menu/ActionMenu';
+import { SearchField } from '../SearchField/SearchField';
+import { Select } from '../Select/Select';
+import { Table } from '../Table/Table';
+import { Tag } from '../TagGroup/Tag';
 import { Text } from '../Text/Text';
 import { TextField } from '../TextField/TextField';
 import { Title } from '../Title/Title';
@@ -28,7 +36,7 @@ const meta = preview.meta({
         type: 'radio',
       },
       description: 'Size of the dialog',
-      options: ['default', 'xsmall', 'small', 'medium', 'large'],
+      options: ['default', 'xsmall', 'small', 'medium', 'large', 'fullscreen'],
       table: {
         type: { summary: 'string' },
       },
@@ -123,6 +131,370 @@ export const WithFormValidation = meta.story({
     </Dialog.Trigger>
   ),
 });
+
+const fullscreenVenues = [
+  {
+    id: 'astra',
+    name: 'Astra Kulturhaus',
+    city: 'Berlin',
+    capacity: '1,500',
+    type: 'Club',
+  },
+  {
+    id: 'gruenspan',
+    name: 'Grünspan',
+    city: 'Hamburg',
+    capacity: '1,200',
+    type: 'Club',
+  },
+  {
+    id: 'backstage',
+    name: 'Backstage',
+    city: 'Munich',
+    capacity: '900',
+    type: 'Club',
+  },
+  {
+    id: 'zakk',
+    name: 'zakk',
+    city: 'Dusseldorf',
+    capacity: '1,000',
+    type: 'Club',
+  },
+  {
+    id: 'batschkapp',
+    name: 'Batschkapp',
+    city: 'Frankfurt',
+    capacity: '1,500',
+    type: 'Club',
+  },
+  {
+    id: 'conne-island',
+    name: 'Conne Island',
+    city: 'Leipzig',
+    capacity: '1,100',
+    type: 'Club',
+  },
+  {
+    id: 'palladium',
+    name: 'Palladium',
+    city: 'Cologne',
+    capacity: '4,000',
+    type: 'Concert Hall',
+  },
+  {
+    id: 'capitol',
+    name: 'Capitol',
+    city: 'Hanover',
+    capacity: '1,350',
+    type: 'Concert Hall',
+  },
+  {
+    id: 'longhorn',
+    name: 'LKA Longhorn',
+    city: 'Stuttgart',
+    capacity: '1,100',
+    type: 'Concert Hall',
+  },
+  {
+    id: 'alte-oper',
+    name: 'Alte Oper',
+    city: 'Frankfurt',
+    capacity: '2,500',
+    type: 'Concert Hall',
+  },
+  {
+    id: 'laeiszhalle',
+    name: 'Laeiszhalle',
+    city: 'Hamburg',
+    capacity: '2,000',
+    type: 'Concert Hall',
+  },
+  {
+    id: 'waldbuehne',
+    name: 'Waldbühne',
+    city: 'Berlin',
+    capacity: '22,000',
+    type: 'Open Air',
+  },
+  {
+    id: 'loreley',
+    name: 'Loreley',
+    city: 'St. Goarshausen',
+    capacity: '15,000',
+    type: 'Open Air',
+  },
+  {
+    id: 'zitadelle',
+    name: 'Zitadelle',
+    city: 'Berlin',
+    capacity: '8,000',
+    type: 'Open Air',
+  },
+  {
+    id: 'kesselhaus',
+    name: 'Kesselhaus Open Air',
+    city: 'Augsburg',
+    capacity: '3,500',
+    type: 'Open Air',
+  },
+  {
+    id: 'schauspielhaus',
+    name: 'Schauspielhaus',
+    city: 'Bochum',
+    capacity: '800',
+    type: 'Theatre',
+  },
+  {
+    id: 'deutsches-theater',
+    name: 'Deutsches Theater',
+    city: 'Berlin',
+    capacity: '600',
+    type: 'Theatre',
+  },
+  {
+    id: 'thalia',
+    name: 'Thalia Theater',
+    city: 'Hamburg',
+    capacity: '1,000',
+    type: 'Theatre',
+  },
+  {
+    id: 'residenz',
+    name: 'Residenztheater',
+    city: 'Munich',
+    capacity: '900',
+    type: 'Theatre',
+  },
+  {
+    id: 'lanxess',
+    name: 'Lanxess Arena',
+    city: 'Cologne',
+    capacity: '18,000',
+    type: 'Arena',
+  },
+  {
+    id: 'barclays',
+    name: 'Barclays Arena',
+    city: 'Hamburg',
+    capacity: '16,000',
+    type: 'Arena',
+  },
+  {
+    id: 'olympiahalle',
+    name: 'Olympiahalle',
+    city: 'Munich',
+    capacity: '15,500',
+    type: 'Arena',
+  },
+  {
+    id: 'festhalle',
+    name: 'Festhalle',
+    city: 'Frankfurt',
+    capacity: '13,000',
+    type: 'Arena',
+  },
+  {
+    id: 'sap-garden',
+    name: 'SAP Garden',
+    city: 'Munich',
+    capacity: '11,500',
+    type: 'Arena',
+  },
+];
+
+const fullscreenVenueTypes = [
+  'Club',
+  'Concert Hall',
+  'Open Air',
+  'Theatre',
+  'Arena',
+];
+
+interface FullscreenPickProps {
+  size?: string;
+  dismissable?: boolean;
+  keyboardDismissable?: boolean;
+}
+
+// A content-heavy pick, the case the `fullscreen` size exists for.
+const FullscreenPick = ({ size, ...args }: FullscreenPickProps) => {
+  const [search, setSearch] = useState('');
+  const [type, setType] = useState<Key | null>('all');
+  const [selected, setSelected] = useState<Set<Key>>(() => new Set());
+
+  const results = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return fullscreenVenues.filter(venue => {
+      const matchesSearch =
+        !query || `${venue.name} ${venue.city}`.toLowerCase().includes(query);
+      const matchesType = type == null || type === 'all' || venue.type === type;
+      return matchesSearch && matchesType;
+    });
+  }, [search, type]);
+
+  // Keep venues staged even while a search or filter hides them from view.
+  const onSelectionChange = (keys: Selection) => {
+    const visibleIds = new Set(results.map(venue => venue.id));
+    setSelected(prev => {
+      const offView = [...prev].filter(key => !visibleIds.has(String(key)));
+      const visible = keys === 'all' ? [...visibleIds] : [...keys];
+      return new Set<Key>([...offView, ...visible]);
+    });
+  };
+
+  const unstage = (keys: Set<Key>) => {
+    setSelected(prev => {
+      const next = new Set<Key>(prev);
+      keys.forEach(key => next.delete(key));
+      return next;
+    });
+  };
+
+  const staged = fullscreenVenues.filter(venue => selected.has(venue.id));
+
+  return (
+    <Dialog.Trigger {...args}>
+      <Button variant="primary">Select venues</Button>
+      <Dialog size={size} closeButton>
+        <Dialog.Title>Select venues</Dialog.Title>
+        <Dialog.Content>
+          <div className="flex h-full min-h-0 flex-col gap-4">
+            <Inline space={2} alignY="input">
+              <SearchField
+                aria-label="Search venues"
+                placeholder="Search by name or city"
+                value={search}
+                onChange={setSearch}
+                width={64}
+              />
+              <Select
+                aria-label="Filter by type"
+                value={type}
+                onChange={setType}
+                width={40}
+              >
+                <Select.Option id="all">All types</Select.Option>
+                {fullscreenVenueTypes.map(t => (
+                  <Select.Option key={t} id={t}>
+                    {t}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Inline>
+
+            {staged.length > 0 && (
+              <Tag.Group
+                label={`Staged (${staged.length})`}
+                selectionMode="none"
+                onRemove={unstage}
+              >
+                {staged.map(venue => (
+                  <Tag key={venue.id} id={venue.id}>
+                    {venue.name}
+                  </Tag>
+                ))}
+              </Tag.Group>
+            )}
+
+            <div
+              className="min-h-0 flex-1 overflow-auto"
+              data-testid="venue-list"
+            >
+              <Table
+                aria-label="Venues"
+                selectionMode="multiple"
+                selectedKeys={selected}
+                onSelectionChange={onSelectionChange}
+              >
+                <Table.Header sticky>
+                  <Table.Column rowHeader>Venue</Table.Column>
+                  <Table.Column>City</Table.Column>
+                  <Table.Column>Type</Table.Column>
+                  <Table.Column>Capacity</Table.Column>
+                </Table.Header>
+                <Table.Body
+                  items={results}
+                  emptyState={() => (
+                    <EmptyState
+                      title="No venues match"
+                      description="Try a different search or type. Anything you already staged stays listed above."
+                    />
+                  )}
+                >
+                  {venue => (
+                    <Table.Row id={venue.id}>
+                      <Table.Cell>{venue.name}</Table.Cell>
+                      <Table.Cell>{venue.city}</Table.Cell>
+                      <Table.Cell>{venue.type}</Table.Cell>
+                      <Table.Cell>{venue.capacity}</Table.Cell>
+                    </Table.Row>
+                  )}
+                </Table.Body>
+              </Table>
+            </div>
+          </div>
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" slot="close">
+            Cancel
+          </Button>
+          <Button variant="primary" slot="close">
+            Add {staged.length} {staged.length === 1 ? 'venue' : 'venues'}
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Dialog.Trigger>
+  );
+};
+
+export const Fullscreen = meta.story({
+  tags: ['component-test'],
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: { size: 'fullscreen' },
+  render: args => <FullscreenPick {...args} />,
+});
+
+// The one snapshot for the fullscreen size: the open dialog filling the viewport.
+Fullscreen.test(
+  'fills the viewport',
+  {
+    parameters: { chromatic: { disableSnapshot: false } },
+  },
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Select venues' })
+    );
+
+    await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
+
+    const rect = canvas.getByRole('dialog').getBoundingClientRect();
+    expect(rect.width).toBeGreaterThan(window.innerWidth * 0.8);
+    expect(rect.height).toBeGreaterThan(window.innerHeight * 0.8);
+  }
+);
+
+Fullscreen.test(
+  'scrolls the table region, not the header area or the dialog',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Select venues' })
+    );
+
+    await waitFor(() => expect(canvas.getByRole('dialog')).toBeInTheDocument());
+
+    const dialog = canvas.getByRole('dialog');
+    const content = canvas.getByTestId('dialog-content');
+    const list = canvas.getByTestId('venue-list');
+
+    // Only the table region scrolls (the long venue list overflows it)...
+    expect(list.scrollHeight).toBeGreaterThan(list.clientHeight);
+    // ...the search/filter/tags area fits without scrolling...
+    expect(content.scrollHeight).toBeLessThanOrEqual(content.clientHeight + 1);
+    // ...and the dialog surface itself is clipped, so it can never scroll.
+    expect(getComputedStyle(dialog).overflowY).toBe('hidden');
+  }
+);
 
 export const VeryLongContent = meta.story({
   tags: ['component-test'],

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -97,9 +97,10 @@ const InnerDialog = ({
           : 'max-h-[80vh] max-w-[90vw]',
         "grid [grid-template-areas:'title'_'content'_'actions']",
         classNames.container,
-        // Grid with pinned rows and a clipped surface, so only the inner content scrolls, not the dialog.
+        // Clip the surface and pin the rows so only the content row scrolls, not the dialog.
+        // The trailing `grid` is load-bearing. It beats the container's `flex` via twMerge last-wins.
         isFullscreen &&
-          'grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-x-hidden overflow-y-hidden'
+          'grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden'
       )}
     >
       {closeButton && (

--- a/packages/components/src/Dialog/Dialog.tsx
+++ b/packages/components/src/Dialog/Dialog.tsx
@@ -47,6 +47,7 @@ const InnerDialog = ({
     size,
   });
   const [titleSlotRef, hasTitle] = useSlot(!ariaLabel);
+  const isFullscreen = size === 'fullscreen';
 
   if (
     process.env.NODE_ENV !== 'production' &&
@@ -89,9 +90,16 @@ const InnerDialog = ({
         !ariaLabel && hasTitle ? titleId : props['aria-labelledby']
       }
       className={cn(
-        'relative mx-auto max-h-[80vh] max-w-[90vw] outline-hidden',
+        'relative mx-auto outline-hidden',
+        // Fullscreen fills the Modal box, other sizes hug their content.
+        isFullscreen
+          ? 'size-full max-h-full max-w-full'
+          : 'max-h-[80vh] max-w-[90vw]',
         "grid [grid-template-areas:'title'_'content'_'actions']",
-        classNames.container
+        classNames.container,
+        // Grid with pinned rows and a clipped surface, so only the inner content scrolls, not the dialog.
+        isFullscreen &&
+          'grid grid-rows-[auto_minmax(0,1fr)_auto] overflow-x-hidden overflow-y-hidden'
       )}
     >
       {closeButton && (
@@ -121,7 +129,7 @@ export interface DialogProps
     Omit<RAC.DialogProps, 'className' | 'style' | 'render'>,
     Pick<ModalProps, 'open' | 'onOpenChange'> {
   variant?: string;
-  size?: 'xsmall' | 'small' | 'medium' | 'large' | (string & {});
+  size?: 'xsmall' | 'small' | 'medium' | 'large' | 'fullscreen' | (string & {});
   /**
    * Show the close button.
    */

--- a/themes/theme-rui/src/components/Dialog.styles.ts
+++ b/themes/theme-rui/src/components/Dialog.styles.ts
@@ -21,6 +21,7 @@ export const Dialog: ThemeComponent<'Dialog'> = {
         small: '',
         medium: '',
         large: '',
+        fullscreen: '',
       },
     },
   }),

--- a/themes/theme-rui/src/components/Modal.styles.ts
+++ b/themes/theme-rui/src/components/Modal.styles.ts
@@ -2,8 +2,10 @@ import { ThemeComponent, cva } from '@marigold/system';
 
 export const Modal: ThemeComponent<'Modal'> = cva({
   base: [
-    'sm:max-h-[min(640px,80vh)]',
-    '[--dialog-spacing-x:1rem]', // Minimal padding to the horizontal edges
+    // Var so `fullscreen` can raise the cap past 80vh.
+    'sm:max-h-[var(--dialog-max-h,min(640px,80vh))]',
+    '[--dialog-spacing-x:1rem]', // Minimal margin to the horizontal viewport edges
+    '[--dialog-spacing-y:1rem]', // Minimal margin to the vertical viewport edges
     'w-[min(calc(100%_-_var(--dialog-spacing-x)),calc(var(--dialog-width)_-_var(--dialog-spacing-x)))]',
   ],
   variants: {
@@ -12,6 +14,12 @@ export const Modal: ThemeComponent<'Modal'> = cva({
       small: '[--dialog-width:640px]', // sm breakpoint
       medium: '[--dialog-width:768px]', // md breakpoint
       large: '[--dialog-width:1024px]', // lg breakpoint
+      // Fills the viewport minus a small margin at every breakpoint.
+      fullscreen: [
+        '[--dialog-width:100vw]',
+        '[--dialog-max-h:calc(100dvh_-_var(--dialog-spacing-y))]',
+        'h-[calc(100dvh_-_var(--dialog-spacing-y))]',
+      ],
     },
   },
   defaultVariants: {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>
-->

# Description

Adds a `fullscreen` size to `<Dialog>`. `<Dialog size="fullscreen">` fills the viewport minus a small margin at every breakpoint, giving content-heavy picks room for search, filters, and a long scrollable list while the title and actions stay fixed. The existing `xsmall`/`small`/`medium`/`large` sizes are unchanged.

Implementation: the Modal theme gains a `fullscreen` size (parametrized `--dialog-max-h` + a dedicated `--dialog-spacing-y` so it can exceed the 80vh cap), and the Dialog surface becomes a clipped grid for fullscreen so only the content region scrolls, never the dialog itself.

Discovered while implementing the Pick pattern (DST-1532). Targets `beta-release`; Chromatic/VRT is not enforced on beta PRs. One Chromatic snapshot captures the open fullscreen dialog (the `fills the viewport` test); the other interaction test stays snapshot-disabled. Dialog docs + the Pick "Sizing a heavy pick" callout are a follow-up.

Closes DST-1643

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. Open Storybook → `Components/Dialog/Fullscreen`.
2. Click "Select venues" — the dialog fills the viewport with a small margin.
3. Scroll the table: only the list scrolls; the title, search/filter, staged tags, and footer stay fixed, and the dialog surface itself does not scroll.
4. Toggle the `size` control to `small`/`medium`/`large` and confirm those still cap and hug their content as before.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)