### PR TITLE
fix(DST-1645): align preset quick-selection rows with the tray nav row

### DIFF
--- a/.changeset/dst-1645-preset-tray-alignment.md
+++ b/.changeset/dst-1645-preset-tray-alignment.md
@@ -1,0 +1,5 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1645): align preset quick-selection rows with the tray nav row on small screens. The preset listbox rows reuse the shared `ListBox` `p-1` focus-ring gutter, which insets them narrower than the full-width nav row. On small screens the list now negates that gutter (`-mx-1`) so rows span the tray edge-to-edge and line up with the nav row, while the gutter still keeps each row's focus outline from being clipped by the list's overflow.

--- a/packages/components/src/Calendar/CalendarPresets.tsx
+++ b/packages/components/src/Calendar/CalendarPresets.tsx
@@ -169,7 +169,11 @@ const PresetListBox = <T,>({
         disabledKeys={disabledKeys}
         onSelectionChange={handleSelectionChange}
         autoFocus={autoFocus}
-        className={listBoxClassNames.list}
+        // Small screens: negate the list's `p-1` (`-mx-1`) so rows span the tray
+        // edge-to-edge and align with the full-width nav row; the gutter stays,
+        // still keeping each row's focus outline from clipping. Desktop rail keeps
+        // the inset.
+        className={cn(listBoxClassNames.list, isSmallScreen && '-mx-1 w-auto')}
       >
         {items.map(item => (
           <AriaListBoxItem


### PR DESCRIPTION
# Description

The Calendar / DatePicker / DateRangePicker **"Quick selection" preset tray** reused the shared `ListBox` list style, whose `p-1` focus-ring gutter insets each row by 4px per side. The nav row ("Back" / "Quick selection") sits *outside* the listbox at full width, so on small screens the preset rows (and the selected-row fill) rendered narrower than the nav row and didn't line up with it or the tray edges.

This negates the gutter on small screens with `-mx-1` (plus `w-auto`, so the list widens instead of staying pinned to `w-full`): rows now span the tray edge-to-edge and align with the nav row, while the `p-1` gutter stays in place so each row's focus outline still isn't clipped by the list's `overflow-y-auto`. Same cancel trick as Accordion's `panel` (`px-1 -mx-1`). The desktop rail keeps its inset, and the shared `ListBox` style is untouched (Select / ComboBox / Autocomplete / Menu unaffected).

Found during the Chromatic VRT review of `beta-release` (build 151, under DST-1584).

Closes DST-1645

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm sb` and pick the **Extra Small Screen (320px)** viewport (or resize below the `sm` breakpoint).
2. Open a `DatePicker` (or `DateRangePicker`) story that has presets, open the picker, and tap **"Quick selection"** to switch the tray to the preset view.
3. Confirm the preset rows — and the selected-row fill — align with the full-width **"Back"** nav row and the tray edges (no 4px inset mismatch).
4. Tab through the preset rows and confirm each focus outline renders fully, unclipped.
5. On desktop (≥ `sm`), confirm the presets rail is unchanged (rows keep their inset inside the `bg-muted` rail).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (\`pnpm changeset\`)