### PR TITLE
fix(DST-1649): run CLI main() when invoked via a symlinked bin

### DIFF
--- a/.changeset/cli-symlink-entrypoint.md
+++ b/.changeset/cli-symlink-entrypoint.md
@@ -1,0 +1,5 @@
+---
+'@marigold/cli': patch
+---
+
+fix: run the CLI when invoked via a symlinked bin. The entry-point guard compared `import.meta.url` (always the realpath) against `path.resolve(process.argv[1])`, so symlinked global bins (`npm install -g`, manual links) exited silently with code 0. `argv[1]` is now resolved through `realpathSync`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,9 +26,9 @@ deployment:
 # 1. Build the CLI
 pnpm --filter @marigold/cli build
 
-# 2. Link it globally so `marigold ...` resolves to the local build
-cd packages/cli
-pnpm link --global
+# 2. Symlink the built entry point into your global bin so `marigold ...`
+#    resolves to the local build (pnpm ≥10 removed `pnpm link --global`)
+ln -sf "$(pwd)/packages/cli/dist/bin/marigold.mjs" "$(pnpm bin -g)/marigold"
 
 # 3. Point at a docs origin (preview or local). Create
 #    packages/cli/.env.local with:
@@ -41,7 +41,7 @@ marigold docs Button
 marigold list --category form
 
 # To remove the link:
-pnpm uninstall -g @marigold/cli
+rm "$(pnpm bin -g)/marigold"
 ```
 
 Without the global link, you can also run the built entry point directly:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,31 +25,50 @@ deployment:
 ```sh
 # 1. Build the CLI
 pnpm --filter @marigold/cli build
+```
 
-# 2. Link it globally so `marigold ...` resolves to the local build.
-#
-#    pnpm ≥ 10 (this repo pins pnpm 11): `pnpm link --global` no longer
-#    exists; symlink the built entry point into your global bin instead:
+Then link it globally so `marigold ...` resolves to the local build, using the
+guide matching your pnpm version:
+
+### pnpm ≥ 10 (this repo pins pnpm 11)
+
+`pnpm link --global` no longer exists; symlink the built entry point into your
+global bin instead:
+
+```sh
+# Install (link)
 ln -sf "$(pwd)/packages/cli/dist/bin/marigold.mjs" "$(pnpm bin -g)/marigold"
 
-#    pnpm ≤ 9: the classic global link still works (note: inside this repo,
-#    corepack picks the pinned pnpm 11 from `packageManager`, so this only
-#    applies when your pnpm really is ≤ 9):
+# Uninstall (remove the link)
+rm "$(pnpm bin -g)/marigold"
+```
+
+### pnpm ≤ 9
+
+The classic global link still works. Note: inside this repo, corepack picks the
+pinned pnpm 11 from `packageManager`, so this only applies when your pnpm
+really is ≤ 9.
+
+```sh
+# Install (link)
 cd packages/cli && pnpm link --global
 
-# 3. Point at a docs origin (preview or local). Create
-#    packages/cli/.env.local with:
-#      MARIGOLD_DOCS_URL="https://marigold-docs-git-<branch>-marigold.vercel.app"
-#    or for a local docs dev server:
-#      MARIGOLD_DOCS_URL="http://localhost:3000"
+# Uninstall
+pnpm uninstall -g @marigold/cli
+```
+
+### Usage
+
+```sh
+# Point at a docs origin (preview or local). Create
+# packages/cli/.env.local with:
+#   MARIGOLD_DOCS_URL="https://marigold-docs-git-<branch>-marigold.vercel.app"
+# or for a local docs dev server:
+#   MARIGOLD_DOCS_URL="http://localhost:3000"
 
 # Now invoke as usual:
 marigold docs Button
 marigold list --category form
-
-# To remove the link:
-rm "$(pnpm bin -g)/marigold"       # pnpm ≥ 10 (symlink)
-pnpm uninstall -g @marigold/cli    # pnpm ≤ 9 (global link)
 ```
 
 Without the global link, you can also run the built entry point directly:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,9 +26,16 @@ deployment:
 # 1. Build the CLI
 pnpm --filter @marigold/cli build
 
-# 2. Symlink the built entry point into your global bin so `marigold ...`
-#    resolves to the local build (pnpm ≥10 removed `pnpm link --global`)
+# 2. Link it globally so `marigold ...` resolves to the local build.
+#
+#    pnpm ≥ 10 (this repo pins pnpm 11): `pnpm link --global` no longer
+#    exists; symlink the built entry point into your global bin instead:
 ln -sf "$(pwd)/packages/cli/dist/bin/marigold.mjs" "$(pnpm bin -g)/marigold"
+
+#    pnpm ≤ 9: the classic global link still works (note: inside this repo,
+#    corepack picks the pinned pnpm 11 from `packageManager`, so this only
+#    applies when your pnpm really is ≤ 9):
+cd packages/cli && pnpm link --global
 
 # 3. Point at a docs origin (preview or local). Create
 #    packages/cli/.env.local with:
@@ -41,7 +48,8 @@ marigold docs Button
 marigold list --category form
 
 # To remove the link:
-rm "$(pnpm bin -g)/marigold"
+rm "$(pnpm bin -g)/marigold"       # pnpm ≥ 10 (symlink)
+pnpm uninstall -g @marigold/cli    # pnpm ≤ 9 (global link)
 ```
 
 Without the global link, you can also run the built entry point directly:

--- a/packages/cli/src/bin/entrypoint.test.ts
+++ b/packages/cli/src/bin/entrypoint.test.ts
@@ -1,0 +1,55 @@
+import { execFile } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+// Regression tests for DST-1649: `marigold` invoked through a symlinked bin
+// (npm -g installs, manual links) exited silently with code 0 because the
+// entry-point guard compared the realpath (import.meta.url) against the
+// unresolved symlink path (argv[1]). These run the built CLI as a subprocess —
+// the guard at the module bottom is unreachable from in-process imports.
+
+const run = promisify(execFile);
+
+const distEntry = path.resolve(__dirname, '../../dist/bin/marigold.mjs');
+const version = (
+  JSON.parse(
+    readFileSync(path.resolve(__dirname, '../../package.json'), 'utf8')
+  ) as { version: string }
+).version;
+
+// dist/ is produced by the root postinstall, so it exists in any normal
+// checkout; skip instead of failing on source-only environments.
+describe.skipIf(!existsSync(distEntry))('bin entry point', () => {
+  let tempDir: string;
+  let symlink: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'marigold-cli-'));
+    symlink = path.join(tempDir, 'marigold');
+    symlinkSync(distEntry, symlink);
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('runs main() when invoked via a symlink', async () => {
+    const { stdout } = await run(process.execPath, [symlink, '--version']);
+
+    expect(stdout).toBe(version + '\n');
+  });
+
+  test('runs main() when invoked via the real path', async () => {
+    const { stdout } = await run(process.execPath, [distEntry, '--version']);
+
+    expect(stdout).toBe(version + '\n');
+  });
+});

--- a/packages/cli/src/bin/marigold.ts
+++ b/packages/cli/src/bin/marigold.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import pc from 'picocolors';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -464,8 +464,17 @@ export const main = async (
 
 // Only auto-invoke when this module is the entry point (i.e. the user ran
 // `marigold ...`). When imported from tests, `main()` is awaited explicitly.
+// argv[1] is resolved through symlinks because global bins (npm -g, manual
+// links) are symlinks, while import.meta.url is always the realpath.
+const resolveEntry = (p: string): string => {
+  try {
+    return realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+};
 const isEntryPoint = process.argv[1]
-  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  ? fileURLToPath(import.meta.url) === resolveEntry(process.argv[1])
   : false;
 if (isEntryPoint) {
   main().then(


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`marigold <command>` invoked through a symlinked bin exited silently with code 0. The entry-point guard compared `fileURLToPath(import.meta.url)` (always the realpath) with `path.resolve(process.argv[1])` (the symlink path), so `main()` never ran. Since global bins are symlinks, this affects published `npm install -g @marigold/cli` installs, not just local dev links. `argv[1]` is now resolved through `realpathSync` (with a `path.resolve` fallback), so the CLI behaves identically via its real path, a symlink, or `node dist/bin/marigold.mjs`.

Also rewrites the README local-development instructions: `pnpm link --global` was removed in pnpm 10 — on pnpm 11 it instead mutates `package.json`/the lockfile and drops a stray `pnpm-workspace.yaml`. The docs now symlink the built entry point into `$(pnpm bin -g)`.

**Versions:**

- **Affected:** every published `@marigold/cli` release up to and including `0.4.0`; the changeset ships this fix as the next patch.
- **pnpm:** the new README link instructions target pnpm ≥ 10 (this repo pins `pnpm@11`); `pnpm link --global` still works on pnpm 9 and earlier.
- **Node:** unchanged, ≥ 22 per the package `engines` field.

No UI changes — stories, screenshots, and VRT are N/A.

Closes DST-1649

## Test Instructions

1. `pnpm --filter @marigold/cli build`
2. `ln -sf "$(pwd)/packages/cli/dist/bin/marigold.mjs" "$(pnpm bin -g)/marigold"`
3. `marigold --version` — prints the version. Before this fix: no output, exit code 0.
4. `pnpm --filter @marigold/cli test` — all 280 tests pass (includes a new subprocess regression test that runs the built CLI through a temp symlink).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)
