### PR TITLE
fix(Radio): apply width via CSS variable instead of raw class name

### DIFF
--- a/.changeset/fix-radio-width-css-variable.md
+++ b/.changeset/fix-radio-width-css-variable.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': patch
+---
+
+fix(Radio): apply width via CSS variable instead of raw class name
+
+`Radio` built its `width` class name from the raw token directly (e.g. `cn(width || groupWidth || 'w-full')`, where `width` could be a literal `"1/2"`), which Tailwind can't statically detect at build time, so no CSS was ever generated — setting `width` had no visible effect.
+
+`Radio` now follows the same pattern already used by `FieldBase`/`TextField`/`NumberField`: a static `w-(--field-width)` class with the actual value injected via `createWidthVar`. Individual `Radio` items inside a sized `Radio.Group` now inherit the group's already-computed width instead of recomputing it, which previously caused a double-shrink (e.g. `width="1/2"` rendering at 1/4 instead of 1/2).

--- a/packages/components/src/Radio/Context.ts
+++ b/packages/components/src/Radio/Context.ts
@@ -1,10 +1,8 @@
 import { createContext, use } from 'react';
-import { WidthProp } from '@marigold/system';
 
 export interface RadioGroupContextProps {
   variant?: string;
   size?: string;
-  width?: WidthProp['width'];
 }
 
 export const RadioGroupContext = createContext<RadioGroupContextProps>({});

--- a/packages/components/src/Radio/Radio.stories.tsx
+++ b/packages/components/src/Radio/Radio.stories.tsx
@@ -88,6 +88,17 @@ export const Basic = meta.story({
   ),
 });
 
+export const WithOwnWidth = meta.story({
+  render: () => (
+    <Radio.Group label="Label">
+      <Radio value="1" width="1/2">
+        Option 1
+      </Radio>
+      <Radio value="2">Option 2</Radio>
+    </Radio.Group>
+  ),
+});
+
 export const Error = meta.story({
   render: args => (
     <Radio.Group errorMessage="Das ist ein Error" error {...args}>

--- a/packages/components/src/Radio/Radio.stories.tsx
+++ b/packages/components/src/Radio/Radio.stories.tsx
@@ -89,13 +89,27 @@ export const Basic = meta.story({
 });
 
 export const WithOwnWidth = meta.story({
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An individual `Radio` can set its own `width`. The tinted boxes mark ' +
+          'each radio field: the first spans half the group, the second the full width.',
+      },
+    },
+  },
   render: () => (
-    <Radio.Group label="Label">
-      <Radio value="1" width="1/2">
-        Option 1
-      </Radio>
-      <Radio value="2">Option 2</Radio>
-    </Radio.Group>
+    // The tint marks the radio field — the element `width` actually sizes.
+    // Without it the demo looks unchanged, since a radio dot and its label
+    // never fill their container on their own.
+    <div className="w-96 [&_[data-rac]:has(>label)]:bg-slate-200">
+      <Radio.Group label="Label">
+        <Radio value="1" width="1/2">
+          Option 1
+        </Radio>
+        <Radio value="2">Option 2</Radio>
+      </Radio.Group>
+    </div>
   ),
 });
 

--- a/packages/components/src/Radio/Radio.stories.tsx
+++ b/packages/components/src/Radio/Radio.stories.tsx
@@ -98,12 +98,12 @@ export const WithOwnWidth = meta.story({
       },
     },
   },
-  render: () => (
+  render: args => (
     // The tint marks the radio field — the element `width` actually sizes.
     // Without it the demo looks unchanged, since a radio dot and its label
     // never fill their container on their own.
     <div className="w-96 [&_[data-rac]:has(>label)]:bg-slate-200">
-      <Radio.Group label="Label">
+      <Radio.Group {...args}>
         <Radio value="1" width="1/2">
           Option 1
         </Radio>

--- a/packages/components/src/Radio/Radio.test.tsx
+++ b/packages/components/src/Radio/Radio.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Basic, Error } from './Radio.stories';
+import { Basic, Error, WithOwnWidth } from './Radio.stories';
 
 // Tests
 // ---------------
@@ -51,4 +51,26 @@ test('radio group can be horizontal', () => {
 
   const group = screen.getByTestId('group');
   expect(group).toHaveClass('flex-row');
+});
+
+test('applies width variable when set directly on an individual radio', () => {
+  render(<WithOwnWidth.Component />);
+
+  const radio = screen.getByRole('radio', { name: 'Option 1' });
+  // eslint-disable-next-line testing-library/no-node-access
+  const field = radio.closest('div[data-rac]') as HTMLElement;
+  expect(field).toHaveClass('w-(--field-width)');
+  expect(field.style.getPropertyValue('--field-width')).toBe(
+    'calc((1 / 2) * 100%)'
+  );
+});
+
+test('does not re-apply width on individual radios inside a sized group', () => {
+  render(<Basic.Component width="1/2" />);
+
+  const radio = screen.getByRole('radio', { name: 'Option 1' });
+  // eslint-disable-next-line testing-library/no-node-access
+  const field = radio.closest('div[data-rac]');
+  expect(field).toHaveClass('w-full');
+  expect(field).not.toHaveClass('w-(--field-width)');
 });

--- a/packages/components/src/Radio/Radio.test.tsx
+++ b/packages/components/src/Radio/Radio.test.tsx
@@ -59,6 +59,7 @@ test('applies width variable when set directly on an individual radio', () => {
   const radio = screen.getByRole('radio', { name: 'Option 1' });
   // eslint-disable-next-line testing-library/no-node-access
   const field = radio.closest('div[data-rac]') as HTMLElement;
+
   expect(field).toHaveClass('w-(--field-width)');
   expect(field.style.getPropertyValue('--field-width')).toBe(
     'calc((1 / 2) * 100%)'
@@ -71,6 +72,7 @@ test('does not re-apply width on individual radios inside a sized group', () => 
   const radio = screen.getByRole('radio', { name: 'Option 1' });
   // eslint-disable-next-line testing-library/no-node-access
   const field = radio.closest('div[data-rac]');
+
   expect(field).toHaveClass('w-full');
   expect(field).not.toHaveClass('w-(--field-width)');
 });

--- a/packages/components/src/Radio/Radio.tsx
+++ b/packages/components/src/Radio/Radio.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Ref } from 'react';
 import type RAC from 'react-aria-components';
 import { RadioButton, RadioField } from 'react-aria-components/RadioGroup';
-import { cn, useClassNames } from '@marigold/system';
+import { cn, createWidthVar, useClassNames } from '@marigold/system';
 import { useRadioGroupContext } from './Context';
 import { RadioGroup } from './RadioGroup';
 
@@ -55,7 +55,7 @@ const _Radio = ({
   ref,
   ...props
 }: RadioProps) => {
-  const { variant, size, width: groupWidth } = useRadioGroupContext();
+  const { variant, size } = useRadioGroupContext();
 
   const classNames = useClassNames({
     component: 'Radio',
@@ -63,9 +63,14 @@ const _Radio = ({
     size: size || sizeProp,
   });
 
+  // `groupWidth` is already applied to the group's FieldBase container, so an
+  // individual Radio only needs to compute its own CSS variable when it has
+  // its own `width` (i.e. used standalone, outside a Radio.Group). Reusing
+  // `groupWidth` here would resize against an already-resized container.
   return (
     <RadioField
-      className={cn(width || groupWidth || 'w-full')}
+      className={cn(width ? 'w-(--field-width) max-w-full min-w-0' : 'w-full')}
+      style={width ? createWidthVar('field-width', `${width}`) : undefined}
       value={value}
       isDisabled={disabled}
       {...props}

--- a/packages/components/src/Radio/RadioGroup.tsx
+++ b/packages/components/src/Radio/RadioGroup.tsx
@@ -182,7 +182,7 @@ const _RadioGroup = ({
           orientation === 'vertical' ? 'flex-col' : 'flex-row'
         )}
       >
-        <RadioGroupContext value={{ width, variant, size }}>
+        <RadioGroupContext value={{ variant, size }}>
           {visibleChildren}
           <CollapsibleGroup>{collapsedChildren}</CollapsibleGroup>
         </RadioGroupContext>


### PR DESCRIPTION
# Description

> **Supersedes #5659** (by @zigzagdev). That PR targeted `main`; this one carries the same fix forward onto `beta-release`, where `Radio` has been refactored (React 19 ref-as-prop + deep subpath imports), so the change had to be hand-applied rather than cherry-picked. Full credit to @zigzagdev for the original fix and review iteration — this PR preserves their work. #5659 is being closed in favor of this one.

Forward-port of #5659 to `beta-release`.

`Radio` built its `width` class name from the raw token directly (`cn(width || groupWidth || 'w-full')`, where `width` could be a literal `"1/2"`), which Tailwind can't statically detect at build time — so no CSS was ever generated and setting `width` had no visible effect. `Radio` now follows the same pattern already used by `FieldBase`/`TextField`/`NumberField`: a static `w-(--field-width)` class with the actual value injected via `createWidthVar`. Individual `Radio` items inside a sized `Radio.Group` now inherit the group's already-computed width instead of recomputing it, which previously caused a double-shrink (e.g. `width="1/2"` rendering at 1/4).

### Why a hand-port rather than a cherry-pick

`beta-release` diverged from `main` on `Radio.tsx` (DST-1432 deep subpath imports + the React 19 ref-as-prop refactor), so #5659's commits don't apply cleanly. The **logical** change is identical to what was reviewed on #5659; only the surrounding component structure differs.

### Verified still needed on `beta-release`

Reproduced the bug against pristine `beta-release`: `<Radio width="1/2">` renders the field with a literal `1/2` class (which Tailwind never generates), no `w-(--field-width)`, and an empty `--field-width` var. No safelist rescues the raw token. So the fix is genuinely required here.

## Test Instructions

1. Storybook → `Components/Radio` → `WithOwnWidth`: an individual radio with `width="1/2"` renders at half width.
2. Storybook → `Components/Radio` → `Basic`: set the group `width` control — the whole group resizes without individual items double-shrinking.
3. `pnpm test:unit packages/components/src/Radio/Radio.test.tsx` — **8 passed** locally (6 existing + 2 new width assertions).

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)