### PR TITLE
test(DST-1590): cover ghost Button disabled/loading on every ground

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.stories.tsx
+++ b/packages/components/src/ActionBar/ActionBar.stories.tsx
@@ -110,6 +110,65 @@ export const WithoutClearButton = meta.story({
   ),
 });
 
+/**
+ * Inactive states on the ActionBar's dark `ui-contrast` ground.
+ *
+ * The bar cascades `variant="ghost"` onto its plain `<Button>` children, and a
+ * ghost Button takes its disabled/pending fill from `ui-state-disabled` — which
+ * paints the opaque, white-calibrated `--color-disabled-surface`. On this ground
+ * that reads as a light block rather than a receding one. Kept as a snapshot so
+ * the regression is visible in VRT; see DST-1590.
+ */
+export const DisabledAndLoading = meta.story({
+  tags: ['component-test'],
+  args: {
+    selectedItemCount: 2,
+  },
+  render: args => (
+    <ActionBar {...args}>
+      <Button onPress={fn()}>
+        <Pencil />
+        Edit
+      </Button>
+      <Button disabled>
+        <Copy />
+        Copy
+      </Button>
+      <Button loading>
+        <Trash2 />
+        Delete
+      </Button>
+    </ActionBar>
+  ),
+  play: async ({ canvas, step }) => {
+    await step('the enabled action stays operable', async () => {
+      await expect(canvas.getByRole('button', { name: 'Edit' })).toBeEnabled();
+    });
+
+    await step('the disabled action is not operable', async () => {
+      await expect(canvas.getByRole('button', { name: 'Copy' })).toBeDisabled();
+    });
+
+    await step(
+      'the loading action is marked pending, not disabled',
+      async () => {
+        // Queried by state rather than by name: `loading` swaps the label for a
+        // `visibility: hidden` copy, so a pending Button currently has *no*
+        // accessible name (WCAG 4.1.2). That is a Button-level defect, tracked
+        // separately — asserting the name here would lock the bug in.
+        const pending = canvas
+          .getAllByRole('button')
+          .find(button => button.hasAttribute('data-pending'))!;
+
+        // `loading` maps to RAC's `isPending`, which keeps the button focusable
+        // and marks it `aria-disabled` rather than removing it from the tree.
+        await expect(pending).toHaveAttribute('aria-disabled', 'true');
+        await expect(pending).toHaveAttribute('tabindex', '0');
+      }
+    );
+  },
+});
+
 const users = [
   {
     name: 'Hans Müller',

--- a/packages/components/src/ActionBar/ActionBar.stories.tsx
+++ b/packages/components/src/ActionBar/ActionBar.stories.tsx
@@ -140,33 +140,6 @@ export const DisabledAndLoading = meta.story({
       </Button>
     </ActionBar>
   ),
-  play: async ({ canvas, step }) => {
-    await step('the enabled action stays operable', async () => {
-      await expect(canvas.getByRole('button', { name: 'Edit' })).toBeEnabled();
-    });
-
-    await step('the disabled action is not operable', async () => {
-      await expect(canvas.getByRole('button', { name: 'Copy' })).toBeDisabled();
-    });
-
-    await step(
-      'the loading action is marked pending, not disabled',
-      async () => {
-        // Queried by state rather than by name: `loading` swaps the label for a
-        // `visibility: hidden` copy, so a pending Button currently has *no*
-        // accessible name (WCAG 4.1.2). That is a Button-level defect, tracked
-        // separately — asserting the name here would lock the bug in.
-        const pending = canvas
-          .getAllByRole('button')
-          .find(button => button.hasAttribute('data-pending'))!;
-
-        // `loading` maps to RAC's `isPending`, which keeps the button focusable
-        // and marks it `aria-disabled` rather than removing it from the tree.
-        await expect(pending).toHaveAttribute('aria-disabled', 'true');
-        await expect(pending).toHaveAttribute('tabindex', '0');
-      }
-    );
-  },
 });
 
 const users = [

--- a/packages/components/src/ActionBar/ActionBar.test.tsx
+++ b/packages/components/src/ActionBar/ActionBar.test.tsx
@@ -9,6 +9,7 @@ import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 import {
   Basic,
+  DisabledAndLoading,
   IntegratedWithTable,
   NoSelection,
   WithoutClearButton,
@@ -87,6 +88,35 @@ test('keeps aria-label on icon-only action buttons', () => {
   expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+});
+
+test('keeps an enabled action operable next to inactive ones', () => {
+  render(<DisabledAndLoading.Component />);
+
+  expect(screen.getByRole('button', { name: 'Edit' })).toBeEnabled();
+});
+
+test('renders a disabled action as not operable', () => {
+  render(<DisabledAndLoading.Component />);
+
+  expect(screen.getByRole('button', { name: 'Copy' })).toBeDisabled();
+});
+
+test('marks a loading action as pending rather than disabled', () => {
+  render(<DisabledAndLoading.Component />);
+
+  // Queried by state rather than by name: `loading` swaps the label for a
+  // `visibility: hidden` copy, so a pending Button currently has *no*
+  // accessible name (WCAG 4.1.2). That is a Button-level defect, tracked
+  // separately — asserting the name here would lock the bug in.
+  const pending = screen
+    .getAllByRole('button')
+    .find(button => button.hasAttribute('data-pending'))!;
+
+  // `loading` maps to RAC's `isPending`, which keeps the button focusable and
+  // marks it `aria-disabled` rather than removing it from the tree.
+  expect(pending).toHaveAttribute('aria-disabled', 'true');
+  expect(pending).toHaveAttribute('tabindex', '0');
 });
 
 test('calls onClearSelection when Escape is pressed', async () => {

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -155,6 +155,50 @@ export const GhostOnBackground = meta.story({
   ),
 });
 
+/**
+ * A ghost Button in every state, on each ground it actually lands on.
+ *
+ * `GhostOnBackground` above covers the resting state; the inactive ones behave
+ * differently, because `ui-state-disabled` paints the opaque
+ * `--color-disabled-surface`. That fill is calibrated for a white surface, so on
+ * `bg-background` it matches the page exactly and on `bg-primary` it reads as a
+ * light block. Snapshotted so both stay visible in VRT; see DST-1590.
+ */
+export const GhostStatesOnBackground = meta.story({
+  parameters: {
+    controls: { exclude: ['variant', 'loading', 'disabled', 'children'] },
+  },
+  render: args => {
+    const states = (
+      <>
+        <Button {...args} variant="ghost">
+          Rest
+        </Button>
+        <Button {...args} variant="ghost" disabled>
+          Disabled
+        </Button>
+        <Button {...args} variant="ghost" loading>
+          Loading
+        </Button>
+      </>
+    );
+
+    return (
+      <Stack space={4}>
+        <div className="bg-surface flex items-center gap-3 rounded border p-6">
+          {states}
+        </div>
+        <div className="bg-background text-foreground flex items-center gap-3 rounded border p-6">
+          {states}
+        </div>
+        <div className="bg-primary text-primary-foreground flex items-center gap-3 rounded p-6">
+          {states}
+        </div>
+      </Stack>
+    );
+  },
+});
+
 export const FullWidth = meta.story({
   args: {
     fullWidth: true,


### PR DESCRIPTION
# Description

`ui-state-disabled` paints the opaque, white-calibrated `--color-disabled-surface`. `ActionBar` cascades `variant="ghost"` onto its plain `<Button>` children, so a loading or disabled bulk action renders as a **near-white pill on the dark bar**, with a dark spinner on top. On the charcoal-100 page the same fill matches the ground exactly, so the button disappears entirely. `text-disabled` on that fill measures **2.08:1**.

Neither state had a story, so VRT has never seen it. **This PR adds the coverage only** — no behavior, token or style changes. The fix itself is DST-1590.

- `Components/ActionBar → DisabledAndLoading` — rest / disabled / loading on the bar's dark `ui-contrast` ground
- `Components/Button → GhostStatesOnBackground` — the same three states across surface / page / contrast

Added as a *new* Button story rather than extending the baselined `GhostOnBackground`, so existing Chromatic snapshots stay put. Both stories carry doc comments explaining the cause and pointing at DST-1590, so the snapshots don't get "fixed" by accident.

Related: DST-1590 (this PR does not close it — it is the regression coverage landing ahead of the token work)

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. `pnpm sb`, open `Components/ActionBar → DisabledAndLoading`. The "Copy" (disabled) and loading actions render as light blocks on the dark bar; the disabled label sits at ~2:1 against its own fill.
2. Open `Components/Button → GhostStatesOnBackground`. Top row (white surface) is correct. Middle row (page) — the disabled and loading buttons have **no visible pill at all**, just a floating spinner. Bottom row (contrast) — white blocks.
3. `pnpm vitest run --config vite.config.ts --project=storybook-tests ActionBar Button`

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated — N/A, no source changes
- [ ] Component documentation added/updated (if it exists) — N/A
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — adds two new snapshots; not triggered
- [ ] Changeset added (`pnpm changeset`) — N/A, `*.stories.tsx` only, no published behavior change

---

**Note for the reviewer:** while writing the ActionBar play function I found a separate defect — a pending `<Button>` has **no accessible name**. `loading` swaps the label for a `visibility: hidden` copy (`Button.tsx:93-99`), which removes it from the accessibility tree. Confirmed in both testing-library's and Chromium's name computation. The play function therefore queries the pending button by `data-pending` rather than by name, so the test doesn't lock the bug in. Unrelated to the colour work; needs its own ticket.