### PR TITLE
fix(DST-1660): keep a loading Button's accessible name

### DIFF
--- a/.changeset/loading-button-accessible-name.md
+++ b/.changeset/loading-button-accessible-name.md
@@ -1,0 +1,11 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1660): keep a loading `Button`'s accessible name
+
+A `<Button loading>` previously had **no accessible name at all**. The label is kept mounted so the button doesn't change width when the spinner is overlaid, but it was hidden with `invisible` (`visibility: hidden`), which removes a subtree from the accessibility tree — not just from the screen. The spinner's own `aria-label` did not substitute, because that is a child widget's name rather than text content the button can take its name from.
+
+The effect: a screen reader announced "Delete, button" before the press and roughly "dimmed, button" the moment the action started, so the user lost the identity of the operation they were waiting on. That is a WCAG 2.1 §4.1.2 (Name, Role, Value) failure at Level A, and it was worse than a plain `disabled` button, which keeps its name.
+
+The label is now hidden with `opacity-0`. It reserves the exact same layout box, so nothing moves — verified by comparing `getBoundingClientRect()` for every button across all three surface grounds, with `display: none` as a control to confirm the measurement detects real shifts. Rendering is unchanged; this is purely a fix to what assistive technology reports.

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -167,6 +167,10 @@ export const Loading = meta.story({
   tags: ['component-test'],
   parameters: {
     controls: { exclude: ['loading'] },
+    // The idle state is a plain primary button — already covered by `Basic` and
+    // `ButtonVariants`. The pending state is the one worth a baseline, so the
+    // snapshot lives on the test below that actually reaches it.
+    chromatic: { disableSnapshot: true },
   },
   render: ({ children, ...args }) => {
     const [loading, setLoading] = useState<boolean | undefined>(false);
@@ -196,7 +200,9 @@ Loading.test(
   'Shows a spinner while loading',
   {
     parameters: {
-      chromatic: { disableSnapshot: true },
+      // The one place the pending state gets a visual baseline: spinner
+      // overlaid, label held at `opacity-0` so the width doesn't change.
+      chromatic: { disableSnapshot: false },
     },
   },
   async ({ canvas }) => {

--- a/packages/components/src/Button/Button.stories.tsx
+++ b/packages/components/src/Button/Button.stories.tsx
@@ -162,6 +162,9 @@ export const FullWidth = meta.story({
 });
 
 export const Loading = meta.story({
+  // Required for the `Loading.test(...)` blocks below to be picked up by the
+  // test runner — without it they are silently never executed.
+  tags: ['component-test'],
   parameters: {
     controls: { exclude: ['loading'] },
   },
@@ -203,5 +206,28 @@ Loading.test(
 
     await expect(await canvas.findByRole('progressbar')).toBeInTheDocument();
     await expect(button).toHaveAttribute('data-pending', 'true');
+  }
+);
+
+Loading.test(
+  'Keeps its accessible name while loading',
+  {
+    parameters: {
+      chromatic: { disableSnapshot: true },
+    },
+  },
+  async ({ canvas }) => {
+    // The label is hidden with `opacity-0` rather than `invisible` precisely so
+    // it survives here: `visibility: hidden` would drop it from the
+    // accessibility tree and leave a pending button anonymous (WCAG 4.1.2).
+    // Querying *by name* is the assertion — don't relax it to a state query.
+    const button = canvas.getByRole('button', { name: 'Submit' });
+
+    await userEvent.click(button);
+
+    await expect(await canvas.findByRole('progressbar')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Submit' })
+    ).toHaveAttribute('data-pending', 'true');
   }
 );

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -95,7 +95,14 @@ const _Button = ({ ref: refProp, ...inputProps }: ButtonProps) => {
           <span className="absolute">
             <ProgressCircle />
           </span>
-          <span className="invisible flex gap-[inherit]">{children}</span>
+          {/* The label stays mounted so the button keeps its width while the
+              spinner is overlaid. It must be hidden with `opacity-0`, not
+              `invisible`: `visibility: hidden` drops the subtree from the
+              accessibility tree, leaving the button with no accessible name
+              while pending (WCAG 4.1.2) — the spinner's own `aria-label` is a
+              child widget's name and does not substitute. `opacity: 0` reserves
+              the exact same layout box but keeps the name. See DST-1660. */}
+          <span className="flex gap-[inherit] opacity-0">{children}</span>
         </>
       ) : (
         children


### PR DESCRIPTION
# Description

A `<Button loading>` had **no accessible name at all**. The label is kept mounted so the button doesn't resize when the spinner is overlaid, but it was hidden with `invisible` (`visibility: hidden`) — which removes a subtree from the **accessibility tree**, not just from the screen. The spinner's own `aria-label` did not substitute: that is a child widget's name, not text content the button can take its name from.

A screen reader announced "Delete, button" before the press and roughly *"dimmed, button"* the moment the action started, so the user lost the identity of the operation they were waiting on. WCAG 2.1 §4.1.2 (Name, Role, Value), **Level A** — and worse than a plain `disabled` button, which keeps its name.

**Fix:** hide the label with `opacity-0` instead. Rendering is pixel-identical; only what assistive technology reports changes.

```diff
- <span className="invisible flex gap-[inherit]">{children}</span>
+ <span className="flex gap-[inherit] opacity-0">{children}</span>
```

Closes DST-1660

### Two things worth a reviewer's attention

**1. No layout shift — measured, not assumed.** `visibility: hidden` already reserves the layout box (that is why the button doesn't resize today); `opacity: 0` reserves the identical box. Verified on the real component by toggling the class in the live DOM and comparing `getBoundingClientRect()` for *every* button across all three surface grounds, so a width change would also surface as an x-shift on siblings:

| | every rect identical to as-shipped? |
| --- | --- |
| `invisible` (before) | — baseline |
| `opacity-0` (this PR) | **yes — byte-identical** |
| `display: none` (control) | **no** — 85.734px → 32px |

The `display: none` control is included to prove the probe detects real shifts. Full numbers are on DST-1660.

**2. The `Loading` story's tests had never run.** It was missing `tags: ['component-test']`, so the runner skipped its `.test()` blocks entirely — including the pre-existing "Shows a spinner while loading", which has never executed. Added the tag, so both now run.

The new "Keeps its accessible name while loading" test was confirmed to **fail** against the old `invisible` markup and **pass** with the fix, so it genuinely guards the regression.

## Screenshots / Preview

No visual change — `opacity: 0` and `visibility: hidden` paint identically. Chromatic should show no diff.

## Test Instructions

1. `pnpm vitest run --config vite.config.ts --project=storybook-tests packages/components/src/Button/Button.stories.tsx` — 6 tests, including the two `Loading` tests that previously never ran.
2. To confirm the test guards the fix: revert `opacity-0` back to `invisible` in `Button.tsx` and re-run — "Keeps its accessible name while loading" fails.
3. `pnpm sb` → `Components/Button/Loading`, press the button, and inspect the pending button in the a11y panel: it now reports the name "Submit" instead of an empty name.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated — story test added; pre-existing unit tests unchanged
- [ ] Component documentation added/updated (if it exists) — N/A, no API change
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components) — this PR *is* the a11y fix; name computation verified against both `dom-accessibility-api` and Chromium's accname
- [ ] Visual regression tests updated (for UI changes) — no visual change expected; not triggered
- [x] Changeset added (`pnpm changeset`) — patch

---

**Scope note:** `Menu`'s trigger uses `RACButton` directly and exposes no `loading` prop, so it does not have this defect — checked as part of DST-1660. `Button.tsx` was the only place in the component layer hiding an accessible name with `invisible`; the other uses (measurement clones in `HiddenBreadcrumbs`, selection checkmarks whose state is carried by ARIA, `DateSegment` placeholders) are correct as-is.

**Related:** #5679 adds `ActionBar → DisabledAndLoading`, whose play function currently queries the pending button by `data-pending` with a comment explaining this bug. Once both land, that query can be simplified to a name lookup — happy to push that as a follow-up commit to whichever merges second.