### PR TITLE
feat(DST-1590): add the alpha wash ramp and a tri-ground Storybook playground

### DIFF
--- a/.changeset/alpha-wash-ramp.md
+++ b/.changeset/alpha-wash-ramp.md
@@ -1,0 +1,9 @@
+---
+'@marigold/theme-rui': minor
+---
+
+Add the two-polarity alpha wash ramp (`--color-charcoal-a-*` / `--color-charcoal-b-*`) and the `--color-fill-*` indirection layer they feed.
+
+An alpha fill only adapts within one polarity — a dark-base wash rides light grounds and vanishes on dark ones, and a light-base wash does the reverse — so there are two ramps rather than one, with alphas solved per polarity to a shared contrast target instead of shared as numbers.
+
+Purely additive: `muted`, `focus-highlight`, `hover` and `selected` still point at the opaque charcoal rungs, so nothing changes visually. Repointing them is the next step of DST-1590.

--- a/packages/components/src/AlphaPalette.stories.tsx
+++ b/packages/components/src/AlphaPalette.stories.tsx
@@ -1,0 +1,712 @@
+import {
+  type PropsWithChildren,
+  type ReactNode,
+  useLayoutEffect,
+  useRef,
+} from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import preview from '.storybook/preview';
+import { cn } from '@marigold/system';
+import { Button } from './Button/Button';
+import { Headline } from './Headline/Headline';
+import { Inline } from './Inline/Inline';
+import { SegmentedControl } from './SegmentedControl/SegmentedControl';
+import { Stack } from './Stack/Stack';
+
+const meta = preview.meta({
+  title: 'Styles/Alpha',
+  parameters: { surface: false },
+});
+
+/* ------------------------------------------------------------------ *
+ * Grounds
+ * ------------------------------------------------------------------ */
+
+/**
+ * The three grounds Marigold ships onto. Every specimen below renders on all
+ * three, because a wash that is only ever reviewed on white is a wash whose
+ * behaviour on the other two is a guess.
+ *
+ * `solid` is the flat colour a ground reduces to for measurement: `ui-contrast`
+ * paints a gradient and a glow over `--color-primary`, so ratios quoted against
+ * it are measured against that base rather than against the rendered gradient.
+ * The gradient varies by a couple of hundredths across the surface, which is
+ * well inside the tolerance we care about — but it is an approximation and the
+ * numbers should be read as such.
+ */
+const GROUNDS = [
+  {
+    id: 'surface',
+    label: 'surface',
+    note: 'white',
+    className: 'bg-surface text-foreground',
+    solid: '--color-surface',
+    polarity: 'A (dark base)',
+  },
+  {
+    id: 'page',
+    label: 'page',
+    note: 'charcoal-100',
+    className: 'bg-background text-foreground',
+    solid: '--color-background',
+    polarity: 'A (dark base)',
+  },
+  {
+    id: 'contrast',
+    label: 'contrast',
+    note: 'charcoal-900',
+    className: 'ui-contrast',
+    solid: '--color-primary',
+    polarity: 'B (light base)',
+  },
+] as const;
+
+type Ground = (typeof GROUNDS)[number];
+
+/**
+ * Renders `children` once per ground.
+ *
+ * The panels use the real surface utilities rather than hand-rolled
+ * backgrounds, and that matters more than it looks: `ui-contrast` also applies
+ * `text-primary-foreground`. Polarity derivation keys off `currentColor`, so a
+ * harness that set the background without the text colour would render the
+ * adaptive specimens as if they worked while testing nothing at all.
+ */
+const Grounds = ({ children }: { children: (ground: Ground) => ReactNode }) => (
+  <div className="grid gap-4 lg:grid-cols-3">
+    {GROUNDS.map(ground => (
+      <div
+        key={ground.id}
+        data-ground={ground.id}
+        data-ground-solid={ground.solid}
+        className={cn(
+          'rounded-surface flex flex-col gap-3 p-4',
+          ground.className
+        )}
+      >
+        <span className="text-xs tracking-wide uppercase opacity-60">
+          {ground.label} · {ground.note}
+        </span>
+        {children(ground)}
+      </div>
+    ))}
+  </div>
+);
+
+const Note = ({ children }: PropsWithChildren) => (
+  <p className="text-secondary max-w-prose text-sm">{children}</p>
+);
+
+/* ------------------------------------------------------------------ *
+ * Measurement
+ * ------------------------------------------------------------------ */
+
+/**
+ * Composite `fill` over `ground` the way the browser would, and return the
+ * resulting 8-bit RGB.
+ *
+ * Painting both onto a 1x1 canvas hands the colour parsing, the colour-space
+ * conversion and the source-over blend to the engine rather than
+ * reimplementing any of the three here — which matters for `oklch()`, where a
+ * hand-rolled conversion is exactly the kind of thing that looks right and is
+ * quietly wrong.
+ */
+const composite = (ground: string, fill: string) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+  ctx.fillStyle = ground;
+  ctx.fillRect(0, 0, 1, 1);
+  ctx.fillStyle = fill;
+  ctx.fillRect(0, 0, 1, 1);
+
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  return [r!, g!, b!] as const;
+};
+
+type Rgb = readonly [number, number, number];
+
+/** WCAG 2.1 relative luminance. */
+const luminance = ([r, g, b]: Rgb) => {
+  const [rl, gl, bl] = [r, g, b].map(channel => {
+    const c = channel / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rl! + 0.7152 * gl! + 0.0722 * bl!;
+};
+
+/** WCAG 2.1 contrast ratio between two composited colours. */
+const contrastRatio = (a: Rgb, b: Rgb) => {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi! + 0.05) / (lo! + 0.05);
+};
+
+const readToken = (token: string) =>
+  getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+
+/**
+ * Measures every `[data-swatch]` inside `children` against the ground it sits
+ * on, once, after layout — writing the result to `data-ratio` and into the
+ * swatch's readout node.
+ *
+ * One pass over the tree rather than a hook per swatch: the ratio is a property
+ * of painted pixels, it is read exactly once, and it never changes afterwards,
+ * so routing it through component state would buy a second render per swatch
+ * and nothing else.
+ *
+ * The fill is read back off the element rather than resolved from its token, so
+ * what gets measured is what the browser actually painted — relative colour
+ * syntax already flattened, alpha included.
+ */
+const Measured = ({ children }: PropsWithChildren) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const root = ref.current;
+    if (!root) return;
+
+    for (const swatch of root.querySelectorAll<HTMLElement>('[data-swatch]')) {
+      const groundToken =
+        swatch.closest<HTMLElement>('[data-ground]')?.dataset.groundSolid;
+      if (!groundToken) continue;
+
+      const ground = readToken(groundToken);
+      const ratio = contrastRatio(
+        composite(ground, getComputedStyle(swatch).backgroundColor),
+        composite(ground, 'transparent')
+      );
+
+      swatch.dataset.ratio = ratio.toFixed(3);
+      const readout = swatch.querySelector<HTMLElement>('[data-ratio-out]');
+      if (readout) readout.textContent = `${ratio.toFixed(2)}:1`;
+    }
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+};
+
+/* ------------------------------------------------------------------ *
+ * The ramp
+ * ------------------------------------------------------------------ */
+
+/**
+ * Class names are spelled out rather than built from `step`, because Tailwind
+ * finds utilities by scanning source text — a template literal would compile to
+ * nothing and the swatches would render bare.
+ */
+const RAMP = [
+  {
+    step: '50',
+    job: 'muted',
+    a: { class: 'bg-charcoal-a-50', alpha: 0.02 },
+    b: { class: 'bg-charcoal-b-50', alpha: 0.02 },
+    target: 1.04,
+  },
+  {
+    step: '100',
+    job: 'focus-highlight',
+    a: { class: 'bg-charcoal-a-100', alpha: 0.05 },
+    b: { class: 'bg-charcoal-b-100', alpha: 0.045 },
+    target: 1.11,
+  },
+  {
+    step: '200',
+    job: 'hover',
+    a: { class: 'bg-charcoal-a-200', alpha: 0.11 },
+    b: { class: 'bg-charcoal-b-200', alpha: 0.085 },
+    target: 1.27,
+  },
+  {
+    step: '300',
+    job: 'selected',
+    a: { class: 'bg-charcoal-a-300', alpha: 0.19 },
+    b: { class: 'bg-charcoal-b-300', alpha: 0.14 },
+    target: 1.52,
+  },
+] as const;
+
+const Swatch = ({
+  fillClass,
+  alpha,
+  label,
+  target,
+}: {
+  fillClass: string;
+  alpha: number;
+  label: string;
+  target: number;
+}) => (
+  <div
+    data-swatch={label}
+    className={cn(
+      'flex items-baseline justify-between rounded px-3 py-2 text-xs',
+      fillClass
+    )}
+  >
+    <span>
+      {label} <span className="opacity-60">/ {alpha}</span>
+    </span>
+    <span className="tabular-nums opacity-80">
+      {/* Filled in by `Measured` after layout. */}
+      <span data-ratio-out>—</span>
+      <span className="opacity-60"> (t {target})</span>
+    </span>
+  </div>
+);
+
+/**
+ * Both ramps on all three grounds, each swatch measured live against its
+ * ground. Reading down a column shows the ramp separating into four legible
+ * steps; reading across a row shows whether a step holds its weight when the
+ * ground changes.
+ *
+ * The point of the story is the two rows that *fail*: ramp A on the contrast
+ * ground and ramp B on the two light ones. That is the polarity rule made
+ * visible — an alpha wash adapts within a polarity and simply disappears
+ * across one.
+ */
+export const Ramp = meta.story({
+  tags: ['component-test'],
+  render: () => (
+    <Stack space="group">
+      <Headline level="3">Alpha ramp</Headline>
+      <Note>
+        Four steps, two polarities. Ramp A is a dark base and darkens what it
+        sits on, so it rides light grounds; ramp B is a light base and does the
+        reverse. Neither crosses over — which is why there are two ramps and not
+        one, and why alphas are solved per polarity to a shared contrast target
+        rather than shared as numbers.
+      </Note>
+      <Measured>
+        <Grounds>
+          {ground => (
+            <Stack space="related">
+              <span className="text-xs opacity-60">
+                native polarity: {ground.polarity}
+              </span>
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-medium opacity-70">
+                  ramp A · dark base
+                </span>
+                {RAMP.map(rung => (
+                  <Swatch
+                    key={rung.step}
+                    fillClass={rung.a.class}
+                    alpha={rung.a.alpha}
+                    label={`a-${rung.step}`}
+                    target={rung.target}
+                  />
+                ))}
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-medium opacity-70">
+                  ramp B · light base
+                </span>
+                {RAMP.map(rung => (
+                  <Swatch
+                    key={rung.step}
+                    fillClass={rung.b.class}
+                    alpha={rung.b.alpha}
+                    label={`b-${rung.step}`}
+                    target={rung.target}
+                  />
+                ))}
+              </div>
+            </Stack>
+          )}
+        </Grounds>
+      </Measured>
+    </Stack>
+  ),
+});
+
+const readRatio = (scope: HTMLElement, swatch: string) => {
+  const value = scope
+    .querySelector(`[data-swatch="${swatch}"]`)
+    ?.getAttribute('data-ratio');
+
+  return value ? Number(value) : null;
+};
+
+Ramp.test(
+  'each ramp hits its contrast target on its own polarity',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvasElement }) => {
+    for (const ground of GROUNDS) {
+      const panel = canvasElement.querySelector<HTMLElement>(
+        `[data-ground="${ground.id}"]`
+      )!;
+      // The ramp native to this ground is the one under test; the other is the
+      // counter-example the story exists to show, and is asserted below.
+      const native = ground.id === 'contrast' ? 'b' : 'a';
+
+      for (const rung of RAMP) {
+        const measured = readRatio(panel, `${native}-${rung.step}`);
+
+        // A null here means the canvas readback failed to parse a colour, not
+        // that the ramp is fine — fail loudly rather than skipping.
+        await expect(
+          measured,
+          `${native}-${rung.step} on ${ground.id} was not measured`
+        ).not.toBeNull();
+        await expect(
+          Math.abs(measured! - rung.target),
+          `${native}-${rung.step} on ${ground.id}: ${measured} vs target ${rung.target}`
+        ).toBeLessThanOrEqual(0.02);
+      }
+    }
+  }
+);
+
+Ramp.test(
+  'the wrong polarity is invisible, which is why there are two ramps',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvasElement }) => {
+    const contrast = canvasElement.querySelector<HTMLElement>(
+      '[data-ground="contrast"]'
+    )!;
+
+    // Ramp A is a dark wash on an already-dark ground: the whole ramp collapses
+    // into the ground. If this ever starts passing as a *visible* ramp, the
+    // polarity rule has been broken somewhere upstream.
+    for (const rung of RAMP) {
+      await expect(readRatio(contrast, `a-${rung.step}`)).toBeLessThan(1.06);
+    }
+  }
+);
+
+/* ------------------------------------------------------------------ *
+ * Derived polarity
+ * ------------------------------------------------------------------ */
+
+/**
+ * Why polarity is derived rather than chosen.
+ *
+ * The left specimen is `bg-current/10` — the shipped `ui-state-hover-ghost`.
+ * It tints toward whatever `currentColor` already is, so it flips polarity by
+ * itself and needs no per-ground branch. The right specimen pins ramp A
+ * regardless of ground, which is what picking a polarity by hand looks like
+ * when the component later turns up somewhere its author did not anticipate.
+ */
+export const Adaptive = meta.story({
+  render: () => (
+    <Stack space="group">
+      <Headline level="3">Derived vs. chosen polarity</Headline>
+      <Note>
+        <code>bg-current/10</code> derives its polarity from the ink, so one
+        declaration covers every ground. A pinned ramp cannot: it is correct on
+        the grounds its author had in mind and invisible on the others.
+      </Note>
+      <Grounds>
+        {() => (
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div className="rounded bg-current/10 px-3 py-4 text-center">
+              derived
+              <div className="opacity-60">bg-current/10</div>
+            </div>
+            <div className="bg-charcoal-a-200 rounded px-3 py-4 text-center">
+              pinned
+              <div className="opacity-60">a-200</div>
+            </div>
+          </div>
+        )}
+      </Grounds>
+    </Stack>
+  ),
+});
+
+/* ------------------------------------------------------------------ *
+ * Component states
+ * ------------------------------------------------------------------ */
+
+const WASHES = [
+  { label: 'muted', className: 'bg-muted' },
+  { label: 'focus-highlight', className: 'bg-focus-highlight' },
+  { label: 'hover', className: 'bg-hover' },
+  { label: 'selected', className: 'bg-selected' },
+] as const;
+
+/**
+ * The regression grid: the real components that consume a wash, in the states
+ * that consume it, on all three grounds.
+ *
+ * Two layers of evidence here, and they are not equally strong.
+ *
+ * The *visual* layer is what Chromatic snapshots. `disabled` and `loading` are
+ * real props, but hover cannot be forced from a class on a real component and
+ * there is no pseudo-states addon installed — so the hover specimens apply the
+ * state utility to a wrapper. That is the same shortcut `Styles/RUI` takes with
+ * `ListSurface`, and it carries the same caveat: a forced specimen shows what
+ * the utility paints, not that the component actually reaches for it.
+ *
+ * The *behavioural* layer closes that gap. The play function below hovers the
+ * real button and asserts the computed fill matches the forced specimen beside
+ * it, so the shortcut cannot quietly drift away from the truth.
+ */
+export const ComponentStates = meta.story({
+  tags: ['component-test'],
+  render: () => (
+    <Stack space="group">
+      <Headline level="3">Component states per ground</Headline>
+      <Note>
+        Every component that reaches for a wash, in every state that reaches for
+        one. The ghost Button is the case DST-1590 was filed for: its disabled
+        and loading states hard-set an opaque, white-calibrated fill, which is
+        why they read as near-white pills on the contrast ground.
+      </Note>
+
+      <Headline level="4">Ghost Button</Headline>
+      <Grounds>
+        {() => (
+          <Inline space="related" alignY="center">
+            <Button variant="ghost">Rest</Button>
+            {/* Forced: `hover:` cannot be triggered from a class, so the wash
+                is applied directly. The play function proves it matches. */}
+            <div className="[&>button]:ui-state-hover-ghost">
+              <Button variant="ghost">Forced hover</Button>
+            </div>
+            <Button variant="ghost" disabled>
+              Disabled
+            </Button>
+            <Button variant="ghost" loading>
+              Loading
+            </Button>
+          </Inline>
+        )}
+      </Grounds>
+
+      <Headline level="4">Wash fills</Headline>
+      <Note>
+        The four semantic washes painted <em>directly on the ground</em> rather
+        than inside a nested <code>ui-surface</code>. That is deliberate: a
+        nested surface would impose its own white fill and answer a different
+        question (&ldquo;what does a white card look like here?&rdquo;) while
+        looking like it answered this one.
+      </Note>
+      <Grounds>
+        {() => (
+          <div className="border-border flex flex-col overflow-hidden rounded border text-sm">
+            <div className="border-border border-b px-3 py-2">resting</div>
+            {WASHES.map(wash => (
+              <div
+                key={wash.label}
+                data-wash={wash.label}
+                className={cn(
+                  'border-border px-3 py-2 not-last:border-b',
+                  wash.className
+                )}
+              >
+                {wash.label}
+              </div>
+            ))}
+          </div>
+        )}
+      </Grounds>
+
+      <Headline level="4">SegmentedControl</Headline>
+      <Grounds>
+        {() => (
+          <Stack space="related">
+            <SegmentedControl
+              aria-label="Default"
+              variant="default"
+              defaultValue="upcoming"
+            >
+              <SegmentedControl.Option value="upcoming">
+                Upcoming
+              </SegmentedControl.Option>
+              <SegmentedControl.Option value="past">
+                Past
+              </SegmentedControl.Option>
+            </SegmentedControl>
+            <SegmentedControl
+              aria-label="Ghost"
+              variant="ghost"
+              defaultValue="upcoming"
+            >
+              <SegmentedControl.Option value="upcoming">
+                Upcoming
+              </SegmentedControl.Option>
+              <SegmentedControl.Option value="past">
+                Past
+              </SegmentedControl.Option>
+            </SegmentedControl>
+          </Stack>
+        )}
+      </Grounds>
+
+      <Note>
+        The ActionBar is the production case for the contrast column above: it
+        is a contrast surface wherever it appears, and{' '}
+        <code>ActionBar.tsx</code> cascades{' '}
+        <code>variant=&quot;ghost&quot;</code> onto its children — which is how
+        the ghost Button&apos;s disabled and loading fills end up on a dark bar.
+        It is not rendered here on purpose: the bar is{' '}
+        <code>position: fixed</code>, so it would float over this story rather
+        than sit in it. See{' '}
+        <code>Components/ActionBar → DisabledAndLoading</code>.
+      </Note>
+    </Stack>
+  ),
+});
+
+ComponentStates.test(
+  'a real hover resolves to the wash the forced specimen paints',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvasElement }) => {
+    for (const ground of GROUNDS) {
+      const panel = within(
+        canvasElement.querySelector<HTMLElement>(
+          `[data-ground="${ground.id}"]`
+        )!
+      );
+
+      const rest = panel.getByRole('button', { name: 'Rest' });
+      const forced = panel.getByRole('button', { name: 'Forced hover' });
+
+      await userEvent.hover(rest);
+
+      // The assertion that keeps the forced specimens honest: if the ghost
+      // hover ever stops resolving to `bg-current/10`, the visual grid above
+      // would still look plausible while showing something the component no
+      // longer does.
+      await waitFor(async () => {
+        await expect(
+          getComputedStyle(rest).backgroundColor,
+          `real vs forced hover diverged on ${ground.id}`
+        ).toBe(getComputedStyle(forced).backgroundColor);
+      });
+
+      await userEvent.unhover(rest);
+    }
+  }
+);
+
+ComponentStates.test(
+  'a loading ghost Button reaches the pending state on every ground',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvasElement }) => {
+    for (const ground of GROUNDS) {
+      const panel = canvasElement.querySelector<HTMLElement>(
+        `[data-ground="${ground.id}"]`
+      )!;
+
+      // Queried by state rather than by name: on `beta-release` a pending
+      // Button still hides its label with `visibility: hidden`, which drops it
+      // from the accessibility tree, so `{ name: 'Loading' }` finds nothing.
+      // That is DST-1660, fixed in its own PR — asserting the name here would
+      // couple this branch to that one. Swap this for a name lookup once the
+      // fix lands.
+      const pending = panel.querySelector('[data-pending="true"]');
+
+      await expect(
+        pending,
+        `no pending Button rendered on ${ground.id}`
+      ).not.toBeNull();
+    }
+  }
+);
+
+/* ------------------------------------------------------------------ *
+ * Stacking
+ * ------------------------------------------------------------------ */
+
+/**
+ * R4, made visible: one alpha per element, never two.
+ *
+ * Stacking is easy to do by accident because it does not require nesting —
+ * two overlapping siblings are enough. `SegmentedControl.styles.ts` has exactly
+ * that today: the selection indicator (`z-0`) and the option (`z-10`) are
+ * siblings that both carry `ui-state-hover-ghost` in the ghost variant, so a
+ * hovered selected option pays the wash twice.
+ */
+export const Stacking = meta.story({
+  render: () => (
+    <Stack space="group">
+      <Headline level="3">Stacking</Headline>
+      <Note>
+        Two washes on one element composite to a third value that belongs to no
+        step of the ramp. Co-occurring states need an explicit combined token,
+        not two fills — and the trap is overlapping siblings, not just nesting.
+      </Note>
+      <Grounds>
+        {() => (
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div className="bg-charcoal-a-200 rounded px-3 py-4 text-center">
+              single
+              <div className="opacity-60">a-200</div>
+            </div>
+            <div className="bg-charcoal-a-200 rounded text-center">
+              <div className="bg-charcoal-a-200 rounded px-3 py-4">
+                stacked
+                <div className="opacity-60">a-200 × 2</div>
+              </div>
+            </div>
+          </div>
+        )}
+      </Grounds>
+    </Stack>
+  ),
+});
+
+/* ------------------------------------------------------------------ *
+ * The open decision
+ * ------------------------------------------------------------------ */
+
+/**
+ * The one question in DST-1590 that measurement cannot settle, rendered both
+ * ways so it can be decided by looking.
+ *
+ * `ui-state-disabled` currently *resets* the background to a flat neutral —
+ * "this control is out of play". An alpha veil instead *preserves* whatever is
+ * underneath at reduced strength. The veil is plainly right for a ghost button
+ * on the ActionBar. It is much less obviously right for a disabled destructive
+ * control, where a 5% veil leaves the alarm red at nearly full strength.
+ *
+ * The likely resolution is that these are two different tokens rather than one
+ * contested one, but that is a design call.
+ */
+export const DisabledVeilVsReset = meta.story({
+  render: () => (
+    <Stack space="group">
+      <Headline level="3">Disabled: veil or reset?</Headline>
+      <Note>
+        Reset flattens the control to a neutral fill; veil keeps its identity
+        and drops its strength. Neither is universally right, which is the
+        argument for splitting the token rather than picking a winner.
+      </Note>
+      <Grounds>
+        {() => (
+          <Stack space="related">
+            <div className="grid grid-cols-2 gap-2 text-center text-xs">
+              <div className="ui-surface ui-state-disabled px-3 py-4">
+                reset
+                <div className="opacity-60">today</div>
+              </div>
+              <div className="ui-surface text-disabled cursor-not-allowed px-3 py-4">
+                <div className="bg-charcoal-a-100 rounded">
+                  veil
+                  <div className="opacity-60">a-100</div>
+                </div>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-center text-xs">
+              <div className="ui-contrast-destructive ui-state-disabled px-3 py-4">
+                reset
+                <div className="opacity-60">destructive</div>
+              </div>
+              <div className="ui-contrast-destructive cursor-not-allowed px-3 py-4">
+                <div className="bg-charcoal-a-100 rounded">
+                  veil
+                  <div className="opacity-60">destructive</div>
+                </div>
+              </div>
+            </div>
+          </Stack>
+        )}
+      </Grounds>
+    </Stack>
+  ),
+});

--- a/themes/theme-rui/src/tokens.css
+++ b/themes/theme-rui/src/tokens.css
@@ -46,6 +46,44 @@
   --color-charcoal-900: oklch(0.22 0.008 54);
   --color-charcoal-950: oklch(0.15 0.008 54);
 
+  /* charcoal alpha ramps (state & hierarchy washes)
+
+     An alpha fill only adapts *within* one polarity: a dark-base wash darkens
+     whatever it sits on, so it rides light grounds and vanishes on dark ones; a
+     light-base wash does the reverse. Neither crosses over. Hence two ramps,
+     not one -- ramp A is the default (white surface, charcoal-100 page), ramp B
+     takes over on the charcoal-900 contrast surface.
+
+     The two ramps are NOT the same alphas. They are solved so each step lands
+     on the same fill-vs-ground contrast on its own grounds, because a wash over
+     a dark ground needs less alpha to read at the same strength:
+
+       step   ramp A    ramp B    fill-vs-ground
+       a-50   0.02      0.02      1.04:1
+       a-100  0.05      0.045     1.11:1
+       a-200  0.11      0.085     1.27:1
+       a-300  0.19      0.14      1.52:1
+
+     Four steps, not five: there are exactly four wash jobs in the system
+     (muted, focus-highlight, hover, selected). Add a rung when a fifth job
+     turns up, not before.
+
+     These deliberately sit under 3:1 -- a wash is reinforcement, never the sole
+     signal for a state (R7). The opaque "bold" tokens (selected-bold, control,
+     soft, primary) are the markers and stay opaque. */
+
+  /* Ramp A -- dark base. Rides light grounds. */
+  --color-charcoal-a-50: oklch(from var(--color-charcoal-950) l c h / 0.02);
+  --color-charcoal-a-100: oklch(from var(--color-charcoal-950) l c h / 0.05);
+  --color-charcoal-a-200: oklch(from var(--color-charcoal-950) l c h / 0.11);
+  --color-charcoal-a-300: oklch(from var(--color-charcoal-950) l c h / 0.19);
+
+  /* Ramp B -- light base. Rides dark grounds. */
+  --color-charcoal-b-50: oklch(from var(--color-white) l c h / 0.02);
+  --color-charcoal-b-100: oklch(from var(--color-white) l c h / 0.045);
+  --color-charcoal-b-200: oklch(from var(--color-white) l c h / 0.085);
+  --color-charcoal-b-300: oklch(from var(--color-white) l c h / 0.14);
+
   /* ====================== */
   /*    SEMANTIC COLORS     */
   /* ====================== */
@@ -79,7 +117,26 @@
   --color-primary: var(--color-charcoal-900);
   --color-primary-foreground: var(--color-charcoal-50);
 
+  /* --- Wash Fills (per-ground indirection) --- */
+  /* The seam between "which ramp" and "which job". Defaults to ramp A; a dark
+     ground repoints these four to ramp B once and every wash beneath it flips
+     polarity with no component-level change.
+
+     These must INHERIT -- that is the whole mechanism. Do not register them
+     with `@property { inherits: false }` the way --ui-background-color and its
+     siblings are: those are deliberately non-inheriting so a themed parent
+     surface cannot bleed into nested surfaces, which is the exact opposite of
+     what a per-ground flip needs. */
+  --color-fill-50: var(--color-charcoal-a-50);
+  --color-fill-100: var(--color-charcoal-a-100);
+  --color-fill-200: var(--color-charcoal-a-200);
+  --color-fill-300: var(--color-charcoal-a-300);
+
   /* --- Neutral Backgrounds & States --- */
+  /* NOTE: still the opaque charcoal rungs. Repointing these onto --color-fill-*
+     is the next step of DST-1590 and is where all the visual risk lives; the
+     ramp above ships first, additively, so `Styles/Alpha` can baseline against
+     today's colours. */
   --color-muted: var(--color-charcoal-50);
   --color-control: var(--color-charcoal-300);
   --color-hover: var(--color-charcoal-200);


### PR DESCRIPTION
# Description

Phase 1 of DST-1590: the two-polarity alpha ramp, plus the Storybook playground that makes it reviewable.

**Deliberately additive.** `muted`, `focus-highlight`, `hover` and `selected` still point at the opaque charcoal rungs, so nothing changes visually. Repointing them onto the ramp is the next step — and the reason for shipping in this order is that `Styles/Alpha` gets baselined in Chromatic while it still renders today's colours. The diff on that one story then *is* the review artifact for the change that follows, instead of hunting it across 190 component stories.

Relates to DST-1590 (does not close it).

## Tokens

Two ramps rather than one, because an alpha fill only adapts *within* a polarity: a dark-base wash rides light grounds and vanishes on dark ones, and a light-base wash does the reverse. The alphas are solved per polarity to a shared fill-vs-ground contrast target rather than shared as numbers.

| step | job | ramp A | ramp B | target |
| --- | --- | --- | --- | --- |
| `50` | `muted` | 0.02 | 0.02 | 1.04:1 |
| `100` | `focus-highlight` | 0.05 | 0.045 | 1.11:1 |
| `200` | `hover` | 0.11 | 0.085 | 1.27:1 |
| `300` | `selected` | 0.19 | 0.14 | 1.52:1 |

Four steps, not the "5 or so" the ticket guessed at — there are exactly four wash jobs in the system, and a fifth rung would be inventing a role.

`--color-fill-*` is the seam between "which ramp" and "which job": a dark ground repoints those four once and every wash beneath it flips polarity with no component-level change. **They must inherit**, which is the opposite of the `--ui-*` vars' deliberate `inherits: false` — called out in a comment where someone would otherwise pattern-match it wrong.

## Playground

`Styles/Alpha`, a sibling of `Styles/RUI`. Five stories, each rendered on all three production grounds:

| Story | Shows |
| --- | --- |
| `Ramp` | both ramps, each swatch measured live against its ground |
| `Adaptive` | derived (`bg-current/10`) vs. pinned polarity |
| `ComponentStates` | the regression grid |
| `Stacking` | R4 — one wash per element, never two |
| `DisabledVeilVsReset` | the open design decision, rendered both ways |

The grounds harness uses the real surface utilities rather than hand-rolled backgrounds. That matters more than it looks: `ui-contrast` also sets `text-primary-foreground`, and polarity derivation keys off `currentColor` — a harness that set only the background would render the adaptive specimens as if they worked while testing nothing at all.

`DisabledVeilVsReset` exists to settle the one question in DST-1590 that measurement cannot: whether a disabled control should reset to a flat neutral or keep its identity under a veil. Both are on screen on all three grounds, so it can be decided by looking.

## Screenshots / Preview

`Ramp` is the whole thesis in one image — ramp A on white measures 1.04 / 1.11 / 1.27 / 1.52 (dead on target) while ramp B there measures 1.00:1, and the relationship inverts on the contrast ground.

`ComponentStates` shows the actual defect: on the contrast ground the ghost Button's disabled and loading states render as near-white pills, and `muted` / `focus-highlight` / `hover` / `selected` paint near-white blocks with white text on them.

| Before | After |
| ------ | ----- |
|        |       |

<!-- Screenshots to be attached — see `Styles/Alpha` in the Storybook preview. -->

## Test Instructions

1. `pnpm sb`, then open **Styles → Alpha**.
2. On `Ramp`, check the measured ratios: the ramp native to each ground hits its target; the other collapses to ~1.0:1.
3. On `ComponentStates`, compare the three grounds — the contrast column is the defect DST-1590 was filed for.
4. `pnpm test:sb` — 6 tests in `AlphaPalette.stories.tsx`.

## Breaking Changes

No. Purely additive; no existing token changes value.

## Notes for the reviewer

**The regression coverage is two layers and they are not equally strong.** `disabled` and `loading` are real props, but hover cannot be forced from a class on a real component and there is no pseudo-states addon installed — so the hover specimens apply the state utility to a wrapper. That is the same shortcut `Styles/RUI` already takes with `ListSurface`, and it carries the same caveat: a forced specimen shows what the utility paints, not that the component reaches for it. The play function closes that gap by hovering the real button and asserting the computed fill matches the forced specimen beside it.

**The measurement tests are verified to guard.** Ratios come from 1x1 canvas readback plus WCAG relative luminance, so a future token tweak that breaks a target fails CI rather than shipping. Confirmed by perturbing `a-200` from 0.11 to 0.14 and watching it fail with `a-200 on surface: 1.369 vs target 1.27`.

**Two things I deliberately left out.** The ActionBar is not rendered in `ComponentStates` — it is `position: fixed`, so it floats over the story rather than sitting in it, and it already has coverage in `ActionBar → DisabledAndLoading` (#5679). And the pending-Button assertion is a `data-pending` query rather than a name lookup, because the DST-1660 fix is still unmerged in #5680; there is a comment saying to swap it once that lands.

**Ratios on the contrast ground are measured against `--color-primary`**, not the rendered `ui-contrast` gradient. The gradient varies by a couple of hundredths across the surface — inside the tolerance, but it is an approximation and the code says so.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)