### PR TITLE
fix(DST-1661): give menu items and the file drop zone a real focus ring

### DIFF
--- a/.changeset/menu-focus-ring.md
+++ b/.changeset/menu-focus-ring.md
@@ -1,0 +1,11 @@
+---
+'@marigold/theme-rui': patch
+---
+
+Give Menu items and the FileField drop zone a real keyboard focus indicator.
+
+Both signalled focus with a background wash alone — 1.11:1 for a menu item, ~1.05:1 for the drop zone — well under the 3:1 WCAG 1.4.11 asks of a state indicator. In a menu the wash is doubly unreliable, since focus follows the mouse there and the same wash fires on hover.
+
+Adds `ui-state-focus-item`, the missing counterpart to `ui-state-focus`. `ui-state-focus` is a two-part indicator: the border flips to full-opacity `--color-ring` and the outline is a soft halo around it. On an element with no border to flip it degrades to the halo alone, which measures 2.08:1. `ui-state-focus-item` is for those borderless rows — a full-opacity inset ring (4.97:1 over the focus wash, 3.14:1 on the contrast ground), inset so overflow-hidden overlays like Popover cannot clip it.
+
+Only keyboard focus changes. Hover, selection and pointer interaction are untouched.

--- a/docs/content/foundations/token-overview/index.mdx
+++ b/docs/content/foundations/token-overview/index.mdx
@@ -403,13 +403,14 @@ Selection tells users which item has already been chosen. Not every selection lo
 
 Focus highlight marks the item the user is currently navigating to via keyboard. Unlike selection, which shows a confirmed choice, focus indicates where the user's cursor is right now. Two intensities handle different contexts: a subtle tint for menu items and drop zones, and a bolder fill for inline segments like date fields where the focused part needs to stand out clearly.
 
+A focus highlight is not a focus indicator on its own. `focus-highlight` composites to around 1.05:1 against the surface it tints, well under the 3:1 that [WCAG 1.4.11](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html) asks of a state indicator, and in a menu the same tint fires on hover because focus follows the mouse. Pair it with a focus ring — `ui-state-focus` where there is a border to recolor, `ui-state-focus-item` on borderless rows — and let the tint track the cursor while the ring proves where keyboard focus is.
+
 <TokenTable
   tokens={[
     {
       name: 'focus-highlight',
       value: 'charcoal-100',
-      useFor:
-        'Subtle focus background for keyboard navigation (Menu, FileField)',
+      useFor: 'Subtle focus tint accompanying a focus ring (Menu, FileField)',
     },
     {
       name: 'focus-highlight-bold',
@@ -420,8 +421,8 @@ Focus highlight marks the item the user is currently navigating to via keyboard.
 />
 
 ```tsx
-// Subtle focus: menu items, file drop zones
-<div className="data-focused:bg-focus-highlight" />
+// Subtle tint plus the ring that carries the indicator: menu items, drop zones
+<div className="focus-visible:bg-focus-highlight focus-visible:ui-state-focus-item" />
 
 // Bold focus: inline segments like date fields
 <div className="data-focused:bg-focus-highlight-bold" />
@@ -435,6 +436,13 @@ Focus highlight marks the item the user is currently navigating to via keyboard.
       focused part needs stronger contrast.
     </DoDescription>
   </Do>
+  <Dont>
+    <DontDescription>
+      Don't let a focus highlight be the only focus indicator. On its own it
+      lands around 1.05:1 and, in a menu, it also fires on hover — add
+      `ui-state-focus` or `ui-state-focus-item` alongside it.
+    </DontDescription>
+  </Dont>
   <Dont>
     <DontDescription>
       Don't use `bg-selected` for focus states. Selection and focus are

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react';
 import { I18nProvider } from 'react-aria-components/I18nProvider';
-import { expect } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../Button/Button';
 import { Form } from '../Form/Form';
+import {
+  WCAG_NON_TEXT,
+  contrast,
+  flatten,
+  insetFocusRing,
+  paintedGround,
+} from '../contrast.utils';
 import { FileField } from './FileField';
 import { makeFile } from './makeFile';
 
@@ -84,6 +91,55 @@ Basic.test(
     await expect(
       canvas.queryByRole('button', { name: 'Upload' })
     ).toHaveTextContent('Upload');
+  }
+);
+
+Basic.test(
+  'Keyboard focus draws a ring that clears 3:1 against both adjacent colors',
+  // Snapshot on: this is the only baseline that shows the drop zone's focus
+  // ring, and it is the change in DST-1661 that had neither a test nor a
+  // snapshot behind it.
+  { parameters: { chromatic: { disableSnapshot: false } } },
+  async ({ canvas, userEvent }) => {
+    // One Tab reaches the drop zone. Note the element that takes DOM focus is
+    // RAC's own 0x0 proxy `<button aria-label="DropZone">` *inside* the zone --
+    // the styled div is never focused itself and carries `data-focus-visible`
+    // instead, which is what the theme's `focus-visible:` variant matches
+    // (`tailwindcss-react-aria-components` remaps it). Assert on the div.
+    await userEvent.tab();
+
+    const dropZone = await waitFor(() => {
+      const focused = canvas
+        .getByText('Drop files here')
+        .closest<HTMLElement>('[data-focus-visible]');
+      expect(focused).not.toBeNull();
+      return focused!;
+    });
+
+    const { boxShadow, ring, color: ringColor } = insetFocusRing(dropZone);
+    expect(
+      ring,
+      `no inset focus ring in box-shadow: ${boxShadow}`
+    ).toBeTruthy();
+    expect(ringColor, `no color found in shadow: ${ring}`).toBeTruthy();
+
+    // The tint alone composites to ~1.05:1 against the surface, so the ring has
+    // to carry the indicator on both sides: the tinted fill inside it and the
+    // untinted surface outside.
+    const inside = paintedGround(dropZone);
+    const outside = paintedGround(dropZone.parentElement);
+    expect(outside.length).toBeGreaterThan(0);
+
+    for (const [side, ground] of [
+      ['inside (focus tint)', inside],
+      ['outside (surface)', outside],
+    ] as const) {
+      const ratio = contrast(flatten([...ground, ringColor!]), flatten(ground));
+      expect(
+        ratio,
+        `focus ring vs ${side} is ${ratio.toFixed(2)}:1, needs ${WCAG_NON_TEXT}:1`
+      ).toBeGreaterThanOrEqual(WCAG_NON_TEXT);
+    }
   }
 );
 

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -332,6 +332,113 @@ Basic.test(
   }
 );
 
+// WCAG 1.4.11: visual information required to identify a state needs 3:1
+// against adjacent colors. A focus indicator is such a state.
+const WCAG_NON_TEXT = 3;
+
+/**
+ * Every painted background from the page down to `element`, bottom layer first.
+ * Walked rather than assumed: menu items are transparent, the Menu container is
+ * transparent, and the Popover is what actually paints the surface.
+ */
+const paintedGround = (element: HTMLElement | null) => {
+  const layers: string[] = [];
+  for (let node = element; node; node = node.parentElement) {
+    const background = getComputedStyle(node).backgroundColor;
+    if (background !== 'rgba(0, 0, 0, 0)' && background !== 'transparent') {
+      layers.unshift(background);
+    }
+  }
+  return layers;
+};
+
+/**
+ * Composite the layers onto white and read the pixel back, so alpha, oklch and
+ * color-space conversion are resolved by the browser instead of by us.
+ */
+const flatten = (layers: string[]) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext('2d', { willReadFrequently: true })!;
+  context.fillStyle = '#fff';
+  context.fillRect(0, 0, 1, 1);
+  for (const layer of layers) {
+    context.fillStyle = layer;
+    context.fillRect(0, 0, 1, 1);
+  }
+  const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
+  return [r!, g!, b!] as const;
+};
+
+const contrast = (a: readonly number[], b: readonly number[]) => {
+  const luminance = (rgb: readonly number[]) => {
+    const [r, g, b] = rgb.map(value => {
+      const channel = value! / 255;
+      return channel <= 0.03928
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
+  };
+  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (high! + 0.05) / (low! + 0.05);
+};
+
+Basic.test(
+  'Keyboard focus draws a ring that clears 3:1 against both adjacent colors',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Hogwarts Houses' })
+    );
+    await userEvent.keyboard('{ArrowDown}');
+
+    const item = await waitFor(() => {
+      const focused = canvas
+        .getByRole('menu')
+        .querySelector<HTMLElement>('[data-focus-visible]');
+      expect(focused).not.toBeNull();
+      return focused!;
+    });
+
+    // The background wash measures ~1.11:1 on its own and, because focus
+    // follows the mouse in a menu, it also fires on hover. It cannot be the
+    // indicator. Assert the ring is a separate, real layer.
+    const { boxShadow } = getComputedStyle(item);
+    const ring = boxShadow
+      .split(/,(?![^(]*\))/)
+      .map(shadow => shadow.trim())
+      .find(shadow => shadow.includes('inset'));
+    expect(
+      ring,
+      `no inset focus ring in box-shadow: ${boxShadow}`
+    ).toBeTruthy();
+
+    const ringColor = ring!.match(
+      /(?:oklch|oklab|rgba?|color)\([^)]*\)|#[0-9a-f]{3,8}/i
+    )?.[0];
+    expect(ringColor, `no color found in shadow: ${ring}`).toBeTruthy();
+
+    // WCAG's "adjacent colors": the row's own fill inside the ring, and the
+    // menu surface outside it.
+    const inside = paintedGround(item);
+    const outside = paintedGround(item.parentElement);
+    expect(inside.length).toBeGreaterThan(outside.length);
+
+    for (const [side, ground] of [
+      ['inside (row fill)', inside],
+      ['outside (menu surface)', outside],
+    ] as const) {
+      const ratio = contrast(flatten([...ground, ringColor!]), flatten(ground));
+      expect(
+        ratio,
+        `focus ring vs ${side} is ${ratio.toFixed(2)}:1, needs ${WCAG_NON_TEXT}:1`
+      ).toBeGreaterThanOrEqual(WCAG_NON_TEXT);
+    }
+  }
+);
+
 export const MultiSelection = meta.story({
   tags: ['component-test'],
   parameters: { chromatic: { disableSnapshot: true } },

--- a/packages/components/src/Menu/Menu.stories.tsx
+++ b/packages/components/src/Menu/Menu.stories.tsx
@@ -7,6 +7,13 @@ import { Description } from '../Description/Description';
 import { Divider } from '../Divider/Divider';
 import { Keyboard } from '../Keyboard/Keyboard';
 import { TextValue } from '../TextValue/TextValue';
+import {
+  WCAG_NON_TEXT,
+  contrast,
+  flatten,
+  insetFocusRing,
+  paintedGround,
+} from '../contrast.utils';
 import { ActionMenu } from './ActionMenu';
 import { Menu } from './Menu';
 
@@ -332,62 +339,14 @@ Basic.test(
   }
 );
 
-// WCAG 1.4.11: visual information required to identify a state needs 3:1
-// against adjacent colors. A focus indicator is such a state.
-const WCAG_NON_TEXT = 3;
-
-/**
- * Every painted background from the page down to `element`, bottom layer first.
- * Walked rather than assumed: menu items are transparent, the Menu container is
- * transparent, and the Popover is what actually paints the surface.
- */
-const paintedGround = (element: HTMLElement | null) => {
-  const layers: string[] = [];
-  for (let node = element; node; node = node.parentElement) {
-    const background = getComputedStyle(node).backgroundColor;
-    if (background !== 'rgba(0, 0, 0, 0)' && background !== 'transparent') {
-      layers.unshift(background);
-    }
-  }
-  return layers;
-};
-
-/**
- * Composite the layers onto white and read the pixel back, so alpha, oklch and
- * color-space conversion are resolved by the browser instead of by us.
- */
-const flatten = (layers: string[]) => {
-  const canvas = document.createElement('canvas');
-  canvas.width = 1;
-  canvas.height = 1;
-  const context = canvas.getContext('2d', { willReadFrequently: true })!;
-  context.fillStyle = '#fff';
-  context.fillRect(0, 0, 1, 1);
-  for (const layer of layers) {
-    context.fillStyle = layer;
-    context.fillRect(0, 0, 1, 1);
-  }
-  const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
-  return [r!, g!, b!] as const;
-};
-
-const contrast = (a: readonly number[], b: readonly number[]) => {
-  const luminance = (rgb: readonly number[]) => {
-    const [r, g, b] = rgb.map(value => {
-      const channel = value! / 255;
-      return channel <= 0.03928
-        ? channel / 12.92
-        : ((channel + 0.055) / 1.055) ** 2.4;
-    });
-    return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
-  };
-  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
-  return (high! + 0.05) / (low! + 0.05);
-};
-
 Basic.test(
   'Keyboard focus draws a ring that clears 3:1 against both adjacent colors',
-  { parameters: { chromatic: { disableSnapshot: true } } },
+  // Snapshot on, unlike the other Basic tests: this is the one interaction in
+  // the file that produces :focus-visible, so it is the only baseline that
+  // shows the ring. Every snapshotted test elsewhere drives the UI with
+  // `click` alone. The assertions below catch token and utility regressions;
+  // the snapshot catches the ring being clipped, doubled or misaligned.
+  { parameters: { chromatic: { disableSnapshot: false } } },
   async ({ canvas }) => {
     await userEvent.click(
       canvas.getByRole('button', { name: 'Hogwarts Houses' })
@@ -405,26 +364,26 @@ Basic.test(
     // The background wash measures ~1.11:1 on its own and, because focus
     // follows the mouse in a menu, it also fires on hover. It cannot be the
     // indicator. Assert the ring is a separate, real layer.
-    const { boxShadow } = getComputedStyle(item);
-    const ring = boxShadow
-      .split(/,(?![^(]*\))/)
-      .map(shadow => shadow.trim())
-      .find(shadow => shadow.includes('inset'));
+    const { boxShadow, ring, color: ringColor } = insetFocusRing(item);
     expect(
       ring,
       `no inset focus ring in box-shadow: ${boxShadow}`
     ).toBeTruthy();
-
-    const ringColor = ring!.match(
-      /(?:oklch|oklab|rgba?|color)\([^)]*\)|#[0-9a-f]{3,8}/i
-    )?.[0];
     expect(ringColor, `no color found in shadow: ${ring}`).toBeTruthy();
 
     // WCAG's "adjacent colors": the row's own fill inside the ring, and the
     // menu surface outside it.
     const inside = paintedGround(item);
     const outside = paintedGround(item.parentElement);
-    expect(inside.length).toBeGreaterThan(outside.length);
+
+    // Guard on `paintedGround`, not on the wash. If the walk came back empty,
+    // `flatten` would silently fall back to bare white and the ratios below
+    // would be measured against a ground that is not on screen -- passing
+    // against nothing, the DST-1590 failure mode. Asserting the walk found a
+    // real fill covers that without pinning the wash in place: the wash is the
+    // roving cursor, not the indicator, so this test stays honest if it is
+    // ever restyled or dropped.
+    expect(outside.length).toBeGreaterThan(0);
 
     for (const [side, ground] of [
       ['inside (row fill)', inside],

--- a/packages/components/src/contrast.utils.ts
+++ b/packages/components/src/contrast.utils.ts
@@ -1,0 +1,85 @@
+/**
+ * Contrast measurement for story tests that assert a *visual* state carries
+ * enough contrast to be perceivable -- focus rings, in particular.
+ *
+ * Browser-only: reads computed styles and composites through a canvas, so it
+ * belongs to the story tests (real browser via Playwright), not to the jsdom
+ * unit tests. Kept out of `index.ts`; this is internal test tooling.
+ */
+
+/**
+ * WCAG 1.4.11: visual information required to identify a state needs 3:1
+ * against adjacent colors. A focus indicator is such a state.
+ */
+export const WCAG_NON_TEXT = 3;
+
+/**
+ * Every painted background from the page down to `element`, bottom layer first.
+ * Walked rather than assumed: menu items are transparent, the Menu container is
+ * transparent, and the Popover is what actually paints the surface.
+ */
+export const paintedGround = (element: HTMLElement | null) => {
+  const layers: string[] = [];
+  for (let node = element; node; node = node.parentElement) {
+    const background = getComputedStyle(node).backgroundColor;
+    if (background !== 'rgba(0, 0, 0, 0)' && background !== 'transparent') {
+      layers.unshift(background);
+    }
+  }
+  return layers;
+};
+
+/**
+ * Composite the layers onto white and read the pixel back, so alpha, oklch and
+ * color-space conversion are resolved by the browser instead of by us.
+ */
+export const flatten = (layers: string[]) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const context = canvas.getContext('2d', { willReadFrequently: true })!;
+  context.fillStyle = '#fff';
+  context.fillRect(0, 0, 1, 1);
+  for (const layer of layers) {
+    context.fillStyle = layer;
+    context.fillRect(0, 0, 1, 1);
+  }
+  const [r, g, b] = context.getImageData(0, 0, 1, 1).data;
+  return [r!, g!, b!] as const;
+};
+
+export const contrast = (a: readonly number[], b: readonly number[]) => {
+  const luminance = (rgb: readonly number[]) => {
+    const [r, g, b] = rgb.map(value => {
+      const channel = value! / 255;
+      return channel <= 0.03928
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
+  };
+  const [high, low] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (high! + 0.05) / (low! + 0.05);
+};
+
+/**
+ * The inset `box-shadow` layer `ui-state-focus-item` paints, and the color in
+ * it. Returns `undefined` for either part that is missing so callers can assert
+ * on it with a useful message.
+ */
+export const insetFocusRing = (element: HTMLElement) => {
+  const { boxShadow } = getComputedStyle(element);
+  // Split on top-level commas only -- color functions contain their own.
+  const ring = boxShadow
+    .split(/,(?![^(]*\))/)
+    .map(shadow => shadow.trim())
+    .find(shadow => shadow.includes('inset'));
+
+  return {
+    boxShadow,
+    ring,
+    color: ring?.match(
+      /(?:oklch|oklab|rgba?|color)\([^)]*\)|#[0-9a-f]{3,8}/i
+    )?.[0],
+  };
+};

--- a/themes/theme-rui/src/components/FileField.styles.ts
+++ b/themes/theme-rui/src/components/FileField.styles.ts
@@ -6,7 +6,11 @@ export const FileField: ThemeComponent<'FileField'> = {
     base: [
       'relative overflow-hidden transition-[color,background]',
       'data-[drop-target=true]:bg-muted',
-      'focus-visible:bg-focus-highlight/50',
+      // The tint alone composites to ~1.05:1 against the surface -- it reads as
+      // a warmth, not as focus. The ring is the indicator; the tint stays as its
+      // accompaniment. The dashed border is decorative and never flips, so
+      // ui-state-focus would have nothing to recolor here.
+      'focus-visible:bg-focus-highlight/50 focus-visible:ui-state-focus-item',
     ],
     variants: {
       size: {

--- a/themes/theme-rui/src/components/Menu.styles.ts
+++ b/themes/theme-rui/src/components/Menu.styles.ts
@@ -23,6 +23,11 @@ export const Menu: ThemeComponent<'Menu'> = {
     base: [
       'group/option relative grid grid-cols-[auto_1fr_auto] items-center [&:has(>svg)]:gap-x-2 cursor-pointer rounded-[calc(var(--radius-surface)-3px)] p-2 text-sm outline-hidden select-none text-nowrap max-sm:min-h-touch-target',
       'disabled:cursor-not-allowed disabled:text-disabled',
+      // On item, not itemBase: `destructive` doesn't share itemBase, and every
+      // variant needs the ring. The variants' focus background is the roving
+      // cursor (in a menu, focus follows the mouse, so it doubles as hover);
+      // this is the part that only appears for real keyboard focus.
+      'focus-visible:ui-state-focus-item',
       '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:size-4 [&_svg]:row-span-full [&_svg]:self-center',
       // Selection visuals like ListBox: checkmark reserves col 1, row highlights on select. Don't also add a leading icon.
       '[&_.selection-indicator]:invisible [&_.selection-indicator]:text-foreground [&_.selection-indicator]:opacity-100',

--- a/themes/theme-rui/src/ui.css
+++ b/themes/theme-rui/src/ui.css
@@ -183,10 +183,37 @@
 /*
  * Applies a consistent visual style used for keyboard focus states across components.
  * Used this when the border of the component can be changed.
+ *
+ * Two-part indicator, and both parts matter: the *border* flips to full-opacity
+ * --color-ring (5.5:1 on white) and the outline is a soft halo around it. The
+ * halo alone measures 2.08:1 -- below the 3:1 a focus indicator needs -- so this
+ * utility only carries its weight on something that has a border to flip
+ * (ui-frame / ui-surface / ui-control). On a borderless row it silently
+ * degrades to the halo. Use ui-state-focus-item there instead.
  */
 @utility ui-state-focus {
   @apply outline-ring/50 outline-3 outline-offset-0 outline-solid;
   --ui-border-color: var(--color-ring);
+}
+
+/*
+ * Keyboard focus for borderless rows: menu items, list options, table rows --
+ * anything that has no --ui-border-color for ui-state-focus to recolor.
+ *
+ * Full-opacity --color-ring, because this ring *is* the whole indicator: 4.97:1
+ * over focus-highlight, 3.59:1 over selected, 3.14:1 on the contrast ground.
+ * At the /50 ui-state-focus uses it would land at 2.01:1 and fail.
+ *
+ * Inset rather than outline: rows live inside overflow-hidden, rounded overlays
+ * (Popover paints the rim, the Menu inside it is only p-1 off the edge), so an
+ * outward outline gets clipped at the corners. An inset ring cannot be, and it
+ * needs no outline reset from the caller.
+ *
+ * Pairs with, rather than replaces, a focus background -- the wash tracks the
+ * roving pointer/keyboard cursor, this proves where keyboard focus actually is.
+ */
+@utility ui-state-focus-item {
+  @apply inset-ring-ring inset-ring-2;
 }
 
 /*


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`Menu` items and the `FileField` drop zone signalled keyboard focus with a background wash and nothing else — **1.11:1** for a menu item, **~1.05:1** for the drop zone. Both are far under the 3:1 that WCAG 2.1 SC 1.4.11 asks of a state indicator. In a menu the wash is doubly unreliable: React Aria moves `focusedKey` on hover, so `data-focused` (and the wash) fires on hover too, making keyboard focus and mouse hover visually identical.

**Copying `ListBox` would not have fixed it.** `ui-state-focus` is a *two-part* indicator:

```css
@utility ui-state-focus {
  @apply outline-ring/50 outline-3 outline-offset-0 outline-solid;
  --ui-border-color: var(--color-ring);   /* the load-bearing half */
}
```

On a framed control the **border** flips to full-opacity `--color-ring` (5.50:1) and the outline is a soft halo around it. On an element with no border to flip, only the halo lands — measured at **2.08:1** on white. Confirmed on the real component, not inferred: a keyboard-focused `ListBox` row renders `outline: solid 3px oklab(… / 0.5)` and no border flip. **ListBox's own focus indicator is 2.08:1 today.**

So this adds the missing counterpart, `ui-state-focus-item`, for borderless rows:

```css
@utility ui-state-focus-item {
  @apply inset-ring-2 inset-ring-ring;
}
```

Full opacity because this ring *is* the whole indicator — 4.97:1 over `focus-highlight`, 3.59:1 over `selected`, 3.14:1 on the contrast ground. Inset rather than outline because menu items sit only 4px (`p-1`) inside an `overflow-hidden`, rounded `Popover`; I confirmed that clip boundary in the DOM (item spans 32–142.7px inside a container clipping at 28–146.7px), so an outward 3px outline would land right on it. An inset ring cannot be clipped and needs no outline reset from the caller.

The ring goes on Menu's `item` base rather than `itemBase` — `destructive` does not share `itemBase` and every variant needs it.

**Only keyboard focus changes.** Hover, selection and pointer interaction are untouched.

Closes DST-1661
Follow-up: DST-1662 — migrate `ListBox`, `SelectList`, `Table` rows and `Sidebar` off the 2.08:1 halo. Deliberately not in this PR: it is a visual change on every focusable row in the system and wants its own Chromatic review rather than riding along on a bug fix.

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Before: keyboard-focused menu item, `outline: none` / `box-shadow: none`, wash only.
     After:  same item with the 2px inset ring.
     Storybook → Components/Menu → Basic, press ArrowDown. -->

## Test Instructions

1. Storybook → `Components/Menu` → `Basic`. Open the menu with the mouse, then press <kbd>ArrowDown</kbd>. The focused item should carry a solid 2px inset ring in addition to the background wash.
2. Move the mouse over a different item. The hovered row should get the wash **but no ring** — the ring is `focus-visible` only.
3. `Components/Menu` → `Advanced`, <kbd>ArrowUp</kbd> to "Delete". The `destructive` variant should also get the ring (it does not share `itemBase`).
4. `Components/Menu` → `Mobile` (small viewport, renders in a Tray). Same behaviour, ring not clipped.
5. `Components/FileField` → `Basic`. <kbd>Tab</kbd> to the drop zone — inset ring inside the dashed border.
6. Automated: `pnpm test:sb --run packages/components/src/Menu/Menu.stories.tsx`

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

---

### Note on the test

The new assertion reads the rendered `box-shadow`, walks the ancestor chain to find what is actually painted underneath (menu items and the Menu container are both transparent — `Popover` paints the surface), and composites via canvas against both adjacent colors. It fails on a token or utility regression, not merely on a class name being present.

**Verified by perturbation** rather than assumed to work: dropping the ring to `/50` reports `focus ring vs inside (row fill) is 2.01:1, needs 3:1`; removing it reports the empty box-shadow. Both reverted.

### Known, deliberately left out

After keyboard navigation, a single synthetic mouse-move leaves the hovered row with `data-hovered` but no background — React Aria suppresses focus-follow-hover while focus-visible is active. With a real mouse the next move corrects it. Closable with a `hover:` rule on the same lines, but it is a transient I could only produce synthetically, so I did not widen scope for it.