### PR TITLE
fix(DST-1659): draw the Checkbox box from theme tokens

### DIFF
--- a/.changeset/checkbox-themed-icon-border.md
+++ b/.changeset/checkbox-themed-icon-border.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1659): draw the `Checkbox` box from theme tokens instead of raw Tailwind literals
+
+The checkbox icon painted itself with `bg-white` and `border-black`. Both now come from the token layer: `bg-surface` for the fill and `border-control-border` for the affordance edge, matching how every other control draws its boundary.
+
+`@marigold/theme-rui` already overrides both slots in `Checkbox.styles.ts`, so the rendered markup and the visual result are unchanged there. The literals only leaked in custom themes, where a consumer could not recolor the box edge or fill without fighting a hardcoded value. This was the last raw color in the component layer.

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -21,8 +21,8 @@ const Icon = ({ className, checked, indeterminate, ...props }: IconProps) => {
       className={cn(
         'flex shrink-0 grow-0 basis-4 items-center justify-center',
         'h-4 w-4 p-px',
-        'bg-white',
-        'rounded-[3px] border border-solid border-black',
+        'bg-surface',
+        'border-control-border rounded-[3px] border border-solid',
         className
       )}
       {...props}


### PR DESCRIPTION
# Description

`Checkbox`'s icon painted its box with raw Tailwind literals instead of the token layer:

```
'bg-white',
'rounded-[3px] border border-solid border-black',
```

Both now come from tokens, as specified in the ticket:

| Before | After | Why |
| --- | --- | --- |
| `border-black` | `border-control-border` | the affordance-edge token (`charcoal-950 / 0.26`), matching how every other control draws its boundary |
| `bg-white` | `bg-surface` | the surface fill token |

**No visual change.** `@marigold/theme-rui` already overrides both slots in [`Checkbox.styles.ts:10`](https://github.com/marigold-ui/marigold/blob/main/themes/theme-rui/src/components/Checkbox.styles.ts#L10), and since `cn` is `tailwind-merge`-backed, the theme classes (appended last) drop the component-level ones. The rendered `class` attribute is byte-identical.

The literals only ever leaked in **custom themes**, where a consumer could not recolor the box edge or fill without fighting a hardcoded value. This was the last raw color in the component layer, so it closes out the "no raw colors in components" invariant.

Closes DST-1659

## Screenshots / Preview

Not applicable — the rendered markup is unchanged under `theme-rui`, so there is nothing to show side by side. See the snapshot note below.

## Test Instructions

The ticket asked whether the class snapshot at `Checkbox.test.tsx:47` needs updating. **It does not** — it passes untouched, which is the strongest available proof that this is a no-op under `theme-rui`. Both the component base and the theme base are static strings, so the merged result is identical in *every* state (selected, indeterminate, disabled), not just the default.

1. `pnpm vitest run --config vite.config.ts --project=unit-tests packages/components/src/Checkbox` → 23/23 pass, snapshot unchanged
2. `pnpm vitest run --config vite.config.ts --project=storybook-tests packages/components/src/Checkbox` → 11/11 pass (real browser, Playwright)
3. `pnpm typecheck:only` → exit 0

For the custom-theme behaviour, render a `Checkbox` under a theme whose `Checkbox.checkbox` slot sets no border/background colour: previously a hard black-on-white box, now the theme's own `--color-control-border` / `--color-surface`.

## Breaking Changes

No. Behaviour under `theme-rui` is identical. Custom themes that relied on the hardcoded black/white default will now inherit their own tokens — which is the point of the fix.

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable) — n/a, no behaviour change; existing Checkbox stories cover it
- [x] Unit tests added/updated — existing snapshot verified as still correct (see above)
- [ ] Component documentation added/updated (if it exists) — n/a, no API change
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) — n/a, styling only
- [ ] Visual regression tests updated (for UI changes) — n/a, no visual change under `theme-rui`
- [x] Changeset added (`pnpm changeset`)

## Context

Last surviving scope item of DST-1414 (💄 Make `--color-border` alpha-based), which was closed as superseded by DST-1565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
