### PR TITLE
fix(DST-1666): apply DateFormat's documented tabular default

### DIFF
--- a/.changeset/dateformat-tabular-default.md
+++ b/.changeset/dateformat-tabular-default.md
@@ -1,0 +1,18 @@
+---
+'@marigold/system': patch
+---
+
+fix(DST-1666): `DateFormat` applies its documented `tabular` default.
+
+**What changed:**
+
+- `tabular` now defaults to `true`, so `<DateFormat value={date} />` renders with `tabular-nums`. Previously the prop was destructured without a default, so it was `undefined` unless passed explicitly and the class was never applied.
+- Opting out with `tabular={false}` no longer leaves an empty `class=""` attribute behind, matching `NumericFormat`.
+
+**Why:**
+
+Three places already documented the default as `true` — the `@default true` JSDoc that feeds the docs site props table, the prose in the `DateFormat` docs ("To disable it, set `tabular={false}`"), and `NumericFormat`, which has always defaulted it correctly. Only the implementation disagreed, so consumers reading the docs and relying on the default got misaligned digits in table columns with no indication why.
+
+**Impact:**
+
+This is a visible rendering change anywhere `DateFormat` is used without an explicit `tabular` prop, which in practice is everywhere — no call site in this repo passed it. Digits shift to uniform width, which is what the documentation always promised. Pass `tabular={false}` to keep proportional digits.

--- a/docs/content/components/formatters/dateformat/index.mdx
+++ b/docs/content/components/formatters/dateformat/index.mdx
@@ -42,7 +42,7 @@ For accessibility, screen readers will treat the formatted range as one continuo
 
 ### Tabular display
 
-Use the `tabular` prop to align dates in columns or tables. When enabled, each digit has the same width, keeping rows straight. This is ideal for data tables, reports, or any layout where vertical alignment helps. To disable it, set `tabular={false}`.
+Use the `tabular` prop to align dates in columns or tables. When enabled (the default), each digit has the same width, keeping rows straight. This is ideal for data tables, reports, or any layout where vertical alignment helps. To disable it, set `tabular={false}`.
 
 <ComponentDemo name="dateformat-tabular-format" />
 

--- a/packages/system/src/components/Formatters/DateFormat.test.tsx
+++ b/packages/system/src/components/Formatters/DateFormat.test.tsx
@@ -33,7 +33,7 @@ test('allows opting out of tabular digits', () => {
 
   expect(date).not.toHaveClass('tabular-nums');
   // No empty `class=""` left behind when the only class is opted out of.
-  expect(date).not.toHaveAttribute('class');
+  expect(date).not.toHaveAttribute('class', '');
 });
 
 test('formats a date range', () => {

--- a/packages/system/src/components/Formatters/DateFormat.test.tsx
+++ b/packages/system/src/components/Formatters/DateFormat.test.tsx
@@ -12,6 +12,30 @@ test('supports formatting date based on specific locale', () => {
   expect(date).toBeInTheDocument();
 });
 
+test('uses tabular digits by default', () => {
+  render(
+    <I18nProvider locale="ru-RU">
+      <DateFormat value={new Date('2021-11-07T07:45:00Z')} />
+    </I18nProvider>
+  );
+
+  expect(screen.getByText('07.11.2021')).toHaveClass('tabular-nums');
+});
+
+test('allows opting out of tabular digits', () => {
+  render(
+    <I18nProvider locale="ru-RU">
+      <DateFormat value={new Date('2021-11-07T07:45:00Z')} tabular={false} />
+    </I18nProvider>
+  );
+
+  const date = screen.getByText('07.11.2021');
+
+  expect(date).not.toHaveClass('tabular-nums');
+  // No empty `class=""` left behind when the only class is opted out of.
+  expect(date).not.toHaveAttribute('class');
+});
+
 test('formats a date range', () => {
   render(
     <I18nProvider locale="de-De">

--- a/packages/system/src/components/Formatters/DateFormat.tsx
+++ b/packages/system/src/components/Formatters/DateFormat.tsx
@@ -12,7 +12,11 @@ export interface DateFormatProps extends DateFormatterOptions {
   tabular?: boolean;
 }
 
-export const DateFormat = ({ value, tabular, ...props }: DateFormatProps) => {
+export const DateFormat = ({
+  value,
+  tabular = true,
+  ...props
+}: DateFormatProps) => {
   const formatter = useDateFormatter({
     ...props,
   });
@@ -31,7 +35,10 @@ export const DateFormat = ({ value, tabular, ...props }: DateFormatProps) => {
     // composed inside it. That child is entirely formatter output, which is
     // exactly what varies. Keep it that way — wrapping the value in another
     // element would move the real output out from under the suppression.
-    <span suppressHydrationWarning className={tabular ? 'tabular-nums' : ''}>
+    <span
+      suppressHydrationWarning
+      className={tabular ? 'tabular-nums' : undefined}
+    >
       {Array.isArray(value)
         ? formatter.formatRange(value[0], value[1])
         : formatter.format(value)}

--- a/packages/system/src/components/Formatters/NumericFormat.test.tsx
+++ b/packages/system/src/components/Formatters/NumericFormat.test.tsx
@@ -12,6 +12,34 @@ test('renders Currency', () => {
   expect(currency).toBeInTheDocument();
 });
 
+test('uses tabular digits by default', () => {
+  render(
+    <I18nProvider locale="en-US">
+      <NumericFormat style="currency" currency="USD" value={20} />
+    </I18nProvider>
+  );
+
+  expect(screen.getByText('$20.00')).toHaveClass('tabular-nums');
+});
+
+test('allows opting out of tabular digits', () => {
+  render(
+    <I18nProvider locale="en-US">
+      <NumericFormat
+        style="currency"
+        currency="USD"
+        value={20}
+        tabular={false}
+      />
+    </I18nProvider>
+  );
+
+  const currency = screen.getByText('$20.00');
+
+  expect(currency).not.toHaveClass('tabular-nums');
+  expect(currency).not.toHaveAttribute('class');
+});
+
 test('supports formatting currency in different language', () => {
   render(
     <I18nProvider locale="de-DE">

--- a/packages/system/src/components/Formatters/NumericFormat.test.tsx
+++ b/packages/system/src/components/Formatters/NumericFormat.test.tsx
@@ -37,7 +37,7 @@ test('allows opting out of tabular digits', () => {
   const currency = screen.getByText('$20.00');
 
   expect(currency).not.toHaveClass('tabular-nums');
-  expect(currency).not.toHaveAttribute('class');
+  expect(currency).not.toHaveAttribute('class', '');
 });
 
 test('supports formatting currency in different language', () => {


### PR DESCRIPTION
# Description

`DateFormat` documented `tabular` as defaulting to `true` but never applied that default. The prop was destructured without one, so it stayed `undefined` unless a consumer passed it explicitly, and `tabular-nums` was never applied.

Three places already documented the opposite:

- the `@default true` JSDoc, which is what feeds the generated props table on the docs site
- the prose docs — "To disable it, set `tabular={false}`", which only parses if the default is on
- `NumericFormat`, the sibling formatter, which has always destructured `tabular = true` and behaved correctly

So the docs site actively told consumers that dates come out with tabular digits, and they did not.

**Current vs. new behavior:** `<DateFormat value={date} />` previously rendered proportional digits; it now renders with `tabular-nums`. `tabular={false}` still opts out, and now does so without leaving an empty `class=""` attribute behind (matching `NumericFormat`'s `undefined` falsy branch).

**Why it went unnoticed:** the only place exercising the prop is `dateformat-tabular-format.demo.tsx`, which passes `tabular={tabular}` explicitly from a `useState(true)` toggle. The demo never relied on the default, so it always looked correct. Neither formatter had any test for `tabular`.

Found while reviewing the `suppressHydrationWarning` change to these same two files in #5522 (DST-1434). No behavior from that change is touched here.

Closes DST-1666

## Screenshots / Preview

Not captured locally — this is a digit-width change that only reads meaningfully in a table, and it lands wherever `DateFormat` is used. The `dateformat-tabular-format` and `numericformat-tabular-format` demos in the docs preview are the clearest place to see it: the Switch in each demo toggles `tabular` explicitly, so both states are directly comparable.

~~Chromatic is the real check here — see the note under Breaking Changes.~~ **Correction:** Chromatic does not cover this change. `.storybook/main.ts` globs stories only from `packages/components/src` and `packages/system/src`, and no story renders `<DateFormat>` — every call site is under `docs/`. The docs preview is the real check. See [this thread](https://github.com/marigold-ui/marigold/pull/5687#discussion_r3681429209) for the detail.

## Test Instructions

1. `pnpm vitest run --config vite.config.ts --project=unit-tests packages/system/src/components/Formatters` — 22 tests pass. The four new ones cover the default and the opt-out on both formatters.
2. To see the bug rather than the fix: revert `tabular = true` back to `tabular` in `DateFormat.tsx` and re-run. `uses tabular digits by default` fails with an empty received class list, and `allows opting out of tabular digits` fails with `class=""`. Both were confirmed failing before the fix was applied.
3. In the docs preview, open **Components → Formatters → DateFormat → Tabular display** and toggle "Use tabular digits". Compare against the same demo on **NumericFormat**; the two now behave identically.
4. Anywhere `<DateFormat>` renders in a `Table` column (e.g. the billing and users examples), digits should now be uniform width and line up between rows.

## Breaking Changes

No — in the semver sense. `patch` on `@marigold/system`, since this restores the documented contract rather than changing it.

Worth flagging for the reviewer anyway: this is a **visible rendering change at every `DateFormat` call site that omits the prop, which is all 38 of them in this repo** — none passed `tabular` explicitly. Consumers who want the old look pass `tabular={false}`.

~~The Chromatic diff will therefore be wide, and every date in it is expected to change.~~ It turned out not to be: all 38 call sites are in `docs/`, which Storybook does not glob, so the expected snapshot delta is zero and Chromatic [build 159](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=159) showed no change attributable to this diff. Verified on the docs preview instead. The flip side is that this change has **no VRT coverage** — nothing would catch a future regression of it.

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable) — n/a, these formatters have no stories; covered by unit tests instead
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists) — added "(the default)" to the `DateFormat` tabular section so it matches `NumericFormat`'s wording
- [ ] Accessibility reviewed against ARIA APG — n/a, no interactive or semantic change; `tabular-nums` is purely a font-feature setting
- [x] Visual regression tests updated (for UI changes) — Chromatic [build 159](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=159) run on `a31a2d916` and reviewed; the 4 pending changes are pre-existing baseline drift, unrelated to this diff. Note that no story renders `DateFormat`, so VRT does not actually cover this change — see Screenshots / Preview
- [x] Changeset added (`pnpm changeset`)

