### PR TITLE
fix(DST-1656): resolve literals in JSX expression containers

### DIFF
--- a/.changeset/migrate-static-attr-value.md
+++ b/.changeset/migrate-static-attr-value.md
@@ -1,0 +1,5 @@
+---
+'@marigold/cli': patch
+---
+
+fix(DST-1656): stop `marigold migrate` from warning on value-conditional props whose value is a literal wrapped in braces. The value check only read a bare `StringLiteral`, so `width={20}`, `width={48}` and `width={'1/2'}` all fell into the "cannot be ruled out statically" branch — a v18 run over a real app produced 16 `Select`/`ComboBox`/`Autocomplete` `width="fit"` warnings without a single site actually using `fit`. Literals inside a JSX expression container now resolve like bare ones; genuinely dynamic values such as `width={someVar}` still warn.

--- a/packages/cli/src/lib/codemod/jsx.test.ts
+++ b/packages/cli/src/lib/codemod/jsx.test.ts
@@ -327,6 +327,17 @@ export const B = () => <Select width="full" />;
     expect(warnings[0]).toContain('width="fit"');
   });
 
+  test('stays quiet for literals wrapped in an expression container', () => {
+    const source = `import { Select } from '@marigold/components';
+export const A = () => <Select width={20} />;
+export const B = () => <Select width={'1/2'} />;
+export const C = () => <Select width={'fit'} />;
+`;
+    const warnings = warningsOf(reportJsxUsage(v18).apply(source));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('width="fit"');
+  });
+
   test('warns when a conditional value cannot be verified statically', () => {
     const source = `import { Switch } from '@marigold/components';
 export const App = ({ size }: { size: string }) => <Switch size={size} />;

--- a/packages/cli/src/lib/codemod/jsx.test.ts
+++ b/packages/cli/src/lib/codemod/jsx.test.ts
@@ -327,14 +327,15 @@ export const B = () => <Select width="full" />;
     expect(warnings[0]).toContain('width="fit"');
   });
 
-  test('stays quiet for literals wrapped in an expression container', () => {
+  test('resolves literals in an expression container, warns on dynamic ones', () => {
     const source = `import { Select } from '@marigold/components';
 export const A = () => <Select width={20} />;
 export const B = () => <Select width={'1/2'} />;
 export const C = () => <Select width={'fit'} />;
+export const D = ({ w }: { w: string }) => <Select width={w} />;
 `;
     const warnings = warningsOf(reportJsxUsage(v18).apply(source));
-    expect(warnings).toHaveLength(1);
+    expect(warnings).toHaveLength(2);
     expect(warnings[0]).toContain('width="fit"');
   });
 

--- a/packages/cli/src/lib/codemod/primitives/jsx.ts
+++ b/packages/cli/src/lib/codemod/primitives/jsx.ts
@@ -31,6 +31,21 @@ const jsxAttributes = (opening: AnyNode | undefined): AnyNode[] =>
 const attrName = (attr: AnyNode): string | null =>
   (attr.name as { name?: string } | undefined)?.name ?? null;
 
+/**
+ * The statically known value of a JSX attribute, or null when it cannot be
+ * resolved. A literal wrapped in an expression container (`width={20}`,
+ * `width={'1/2'}`) is just as knowable as a bare `width="fit"`.
+ */
+const staticAttrValue = (value: AnyNode | undefined): string | null => {
+  const node =
+    value?.type === 'JSXExpressionContainer'
+      ? (value.expression as AnyNode | undefined)
+      : value;
+  return node?.type === 'StringLiteral' || node?.type === 'NumericLiteral'
+    ? String((node as { value: string | number }).value)
+    : null;
+};
+
 /** local names for the manifest's component names, only when imported */
 export const localsFor = (file: AnyNode, components: Iterable<string>) => {
   const wanted = new Set(components);
@@ -543,12 +558,10 @@ export const reportJsxUsage = (manifest: MigrationManifest): Codemod =>
           if (entry.component !== component || !entry.prop) continue;
           for (const attr of jsxAttributes(opening)) {
             if (attrName(attr) !== entry.prop) continue;
-            const value = attr.value as AnyNode | undefined;
             if (entry.value !== undefined) {
-              const literal =
-                value?.type === 'StringLiteral'
-                  ? ((value as { value?: string }).value ?? null)
-                  : null;
+              const literal = staticAttrValue(
+                attr.value as AnyNode | undefined
+              );
               // a non-literal value cannot be ruled out statically: warn too
               if (literal !== null && literal !== entry.value) continue;
             }

--- a/packages/cli/src/lib/codemod/primitives/jsx.ts
+++ b/packages/cli/src/lib/codemod/primitives/jsx.ts
@@ -42,7 +42,7 @@ const staticAttrValue = (value: AnyNode | undefined): string | null => {
       ? (value.expression as AnyNode | undefined)
       : value;
   return node?.type === 'StringLiteral' || node?.type === 'NumericLiteral'
-    ? String((node as { value: string | number }).value)
+    ? String(node.value)
     : null;
 };
 

--- a/packages/cli/src/lib/codemod/primitives/jsx.ts
+++ b/packages/cli/src/lib/codemod/primitives/jsx.ts
@@ -33,8 +33,9 @@ const attrName = (attr: AnyNode): string | null =>
 
 /**
  * The statically known value of a JSX attribute, or null when it cannot be
- * resolved. A literal wrapped in an expression container (`width={20}`,
- * `width={'1/2'}`) is just as knowable as a bare `width="fit"`.
+ * resolved. A string or number literal wrapped in an expression container
+ * (`width={20}`, `width={'1/2'}`) is just as knowable as a bare `width="fit"`.
+ * Everything else, template literals included, stays unresolved and warns.
  */
 const staticAttrValue = (value: AnyNode | undefined): string | null => {
   const node =


### PR DESCRIPTION
# Description

`reportJsxUsage` handles value-conditional warnings — entries like `Select[width]` that should only fire for one specific value. Its value check only read a bare `StringLiteral`:

```ts
const literal = value?.type === 'StringLiteral' ? value.value ?? null : null;
```

Anything wrapped in braces produced `null`, which the surrounding logic treats as "cannot be ruled out statically" and warns on deliberately. So every `width={20}` looked indistinguishable from `width={someVar}`.

Running `migrate v18` over a real consumer app surfaced how noisy that is: **16 `width="fit"` warnings across `Select`, `ComboBox` and `Autocomplete`, and not one of the sites used `fit`** — they were `width={20}`, `width={48}`, `width={96}`, `width={'1/2'}` and similar. The real `width="fit"` usages in that app were all on `NumberField`, `DatePicker`, `TextField`, `Switch` and `Scrollable`, where v18 still accepts it, and were correctly left alone.

16 false positives out of 21 total warnings is enough noise to make people stop reading the report, which defeats the point of the manual-decision warnings.

`staticAttrValue` unwraps `JSXExpressionContainer` and resolves `StringLiteral` and `NumericLiteral`, so a literal in braces is as knowable as a bare one. The deliberate warn-when-unknowable behaviour is untouched.

Relates to DST-1656 — found while migrating the core apps onto the v18 beta. The false positives have no dedicated ticket; happy to file one if you'd prefer the scope changed.

## Test Instructions

1. `pnpm vitest run src/lib/codemod/` in `packages/cli` — 72 pass.
2. New case `stays quiet for literals wrapped in an expression container` covers `width={20}`, `width={'1/2'}` (silent) and `width={'fit'}` (warns).
3. The pre-existing `warns when a conditional value cannot be verified statically` case (`<Switch size={size} />`, an `Identifier`) still passes — that is the regression guard for the warn-on-unknowable path.

## Breaking Changes

No. Report-only codemod; it can only remove spurious warnings, never suppress a real one, since a value that cannot be resolved still warns.

## Checklist

- [x] Unit tests added/updated
- [x] Changeset added (`pnpm changeset`)
- [ ] Storybook preview and Marigold docs preview are available — n/a, CLI only
- [ ] Stories added/updated — n/a, no component change
- [ ] Component documentation added/updated — n/a
- [ ] Accessibility reviewed against ARIA APG — n/a
- [ ] Visual regression tests updated — n/a, no UI change