### PR TITLE
test(DST-1671): add DateFormat stories so the tabular default has VRT coverage

### DIFF
--- a/packages/system/src/components/Formatters/DateFormat.stories.tsx
+++ b/packages/system/src/components/Formatters/DateFormat.stories.tsx
@@ -1,0 +1,98 @@
+import preview from '.storybook/preview';
+import { I18nProvider } from '@react-aria/i18n';
+import { DateFormat } from './DateFormat';
+
+// Fixed instants, formatted in UTC with a pinned locale, so the snapshot does
+// not shift with the capture environment's clock, timezone or browser language.
+const DATES = [
+  new Date('2021-11-11T12:00:00Z'),
+  new Date('2021-01-01T12:00:00Z'),
+  new Date('2088-08-28T12:00:00Z'),
+  new Date('2021-10-30T12:00:00Z'),
+];
+
+const meta = preview.meta({
+  title: 'Components/DateFormat',
+  component: DateFormat,
+  argTypes: {
+    tabular: {
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: 'true' } },
+    },
+  },
+  args: {
+    value: DATES[0],
+    timeZone: 'UTC',
+    tabular: true,
+  },
+});
+
+export const Basic = meta.story({
+  render: args => (
+    <I18nProvider locale="en-US">
+      <DateFormat {...args} />
+    </I18nProvider>
+  ),
+});
+
+/**
+ * Guards the `tabular` default against regression. The dates are pinned to
+ * `2-digit` day and month so every string is the same length — tabular figures
+ * only equalise equal-length numbers, so a format that drops leading zeros
+ * could never line up and would prove nothing. The values then mix `1`s with
+ * wide digits: with `tabular-nums` all four rows come out identical in width
+ * and the right edge is flush, without it the `1`-heavy rows are narrower and
+ * the edge goes ragged. `items-start` keeps each box hugging its text so that
+ * difference lands in the snapshot instead of being absorbed by a stretched
+ * flex child.
+ */
+export const TabularDigits = meta.story({
+  render: () => (
+    <I18nProvider locale="en-US">
+      <div className="flex gap-16">
+        <div className="flex flex-col items-start gap-1">
+          <p className="text-secondary text-xs font-medium tracking-wide uppercase">
+            tabular (the default)
+          </p>
+          {DATES.map(date => (
+            <DateFormat
+              key={date.toISOString()}
+              value={date}
+              timeZone="UTC"
+              day="2-digit"
+              month="2-digit"
+              year="numeric"
+            />
+          ))}
+        </div>
+        <div className="flex flex-col items-start gap-1">
+          <p className="text-secondary text-xs font-medium tracking-wide uppercase">
+            tabular={'{false}'}
+          </p>
+          {DATES.map(date => (
+            <DateFormat
+              key={date.toISOString()}
+              value={date}
+              timeZone="UTC"
+              day="2-digit"
+              month="2-digit"
+              year="numeric"
+              tabular={false}
+            />
+          ))}
+        </div>
+      </div>
+    </I18nProvider>
+  ),
+});
+
+export const Range = meta.story({
+  args: {
+    value: [DATES[1], DATES[0]],
+  },
+  render: args => (
+    <I18nProvider locale="en-US">
+      <DateFormat {...args} />
+    </I18nProvider>
+  ),
+});


### PR DESCRIPTION
# Description

`DateFormat` had no Storybook story, so Chromatic never snapshotted it and it had no visual regression coverage at all. This adds `Basic`, `Range` and `TabularDigits` in `packages/system/src/components/Formatters/DateFormat.stories.tsx`.

Follow-up to #5687 (DST-1666). That PR was gated on a Chromatic run, on the assumption that changing rendering at ~38 `DateFormat` call sites would produce a wide visual diff. It didn't, and finding out why is what produced this ticket:

- `.storybook/main.ts` globs stories only from `packages/components/src` and `packages/system/src`
- every `DateFormat` call site is under `docs/` — examples, demos, MDX
- no `*.stories.tsx` renders `<DateFormat>`; the five story files that mention the formatters (`Table`, `legacy/Table`, `Panel`, `ActionBar`, `Calendar`) use `NumericFormat` exclusively

So the `tabular` fix had to be verified by hand on the docs preview, and the original bug had gone unnoticed by VRT just as it had by unit tests. This closes that gap.

**`TabularDigits` is the actual guard**, and two details decide whether it guards anything:

- **day and month are pinned to `2-digit`.** Tabular figures only equalise _equal-length_ number strings. The default en-US format drops leading zeros (`1/1/2021` next to `11/11/2021`), so those rows could never line up whatever `tabular` did — a story built on it would look plausible and prove nothing. This was my first attempt, caught by measuring rather than eyeballing.
- **each box hugs its text (`items-start`).** As stretched flex children, the spans took the column width and absorbed the very difference the snapshot needed to capture.

Determinism: fixed instants, `timeZone="UTC"`, pinned `en-US` `I18nProvider`. Snapshots don't move with the runner's clock, timezone or browser language.

Closes DST-1671

## Screenshots / Preview

No before/after images — the meaningful signal here is measured, not eyeballed. Rendered widths in Firefox with both fixes applied:

| Row          | `tabular` (default) | `tabular={false}` |
| ------------ | ------------------- | ----------------- |
| `11/11/2021` | 94.35px             | 72.96px           |
| `01/01/2021` | 94.35px             | 80.23px           |
| `08/28/2088` | 94.35px             | 90.21px           |
| `10/30/2021` | 94.35px             | 83.65px           |
| **spread**   | **0px** (flush)     | **17.25px** (ragged) |

A 17px spread across four rows is a large, unmistakable diff — well clear of any threshold concern, which was the main open question about whether a story could really catch this.

Storybook preview: **Components → DateFormat → Tabular Digits**.

## Test Instructions

1. `pnpm sb`, open **Components → DateFormat → Tabular Digits**. The left column's right edge is flush; the right column's is ragged. Toggle `tabular` on **Basic** via controls to see it on a single value.
2. To confirm the story actually guards the behaviour rather than just rendering: revert `tabular = true` to `tabular` in `DateFormat.tsx` and reload. The left column goes ragged and matches the right.
3. `pnpm vitest run --config vite.config.ts --project=unit-tests packages/system/src/components/Formatters` — 22 tests pass, unchanged by this PR.
4. Typecheck, ESLint and Prettier are clean.

## Breaking Changes

No. Stories only — no source, theme or docs change. `@marigold/system` publishes `files: ["dist"]` and builds via `tsdown src/index.ts`, so stories never reach consumers. **No changeset** for that reason.

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable) — deliberately untagged; these are visual-regression stories with no interaction to drive, and the `tabular` class contract is already asserted by the unit tests added in #5687. The `storybook-tests` project filters on `tags: ['component-test']`, so they're correctly skipped by that runner.
- [ ] Unit tests added/updated — n/a, no source change; the existing 22 Formatters tests still pass
- [ ] Component documentation added/updated (if it exists) — n/a, the `DateFormat` docs already describe `tabular` and its default (updated in #5687)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) — n/a, no interactive or semantic change
- [x] Visual regression tests updated (for UI changes) — [build 160](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=160) on `f583a955d`: 398 snapshots (up 3 = these stories, recorded as new rather than changed). The `UI Tests` check passes with the 4 pre-existing changes accepted as baselines, so no acceptance step is outstanding. See the note below for the one thing still worth eyeballing
- [ ] Changeset added (`pnpm changeset`) — n/a, see Breaking Changes

## Note for the reviewer

These are new stories, so Chromatic recorded them as **new snapshots rather than changes** — there was nothing to diff against. Worth being explicit that this therefore protects against _future_ regressions and would not have caught the bug in #5687; no story existed then.

The baseline is already taken and the build has resolved as passed, so there is no accept/reject gate left. That makes one visual check worth doing anyway: on `Components/DateFormat → Tabular Digits`, the left column's right edge should be **flush** and the right column's **ragged**. If they look alike, the baseline is wrong — and since it is already recorded, that would need a code fix plus a fresh build rather than a rejection.

`NumericFormat` has the identical zero-story gap. Left alone here since it was never broken, but mirroring it is a small follow-on.
