### PR TITLE
fix(DST-1678): update image source for Bento story

### DIFF
--- a/packages/components/src/Grid/Grid.stories.tsx
+++ b/packages/components/src/Grid/Grid.stories.tsx
@@ -116,7 +116,7 @@ export const Bento = meta.story({
         <Grid.Area name="event-2">
           <Teaser
             alt="artist from back"
-            src="https://cdn.pressebox.de/f/f3ebdc8b4e5375b5/attachments/1451457.attachment"
+            src="https://www.reservix.net/app/uploads/resized/2023/12/Startseite-Portale-1-1000x667-051224-1000x750-c-center.jpg"
           />
         </Grid.Area>
         <Grid.Area name="tickets">


### PR DESCRIPTION

# Description

After merging an unrelated change in main, https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=164  chromatic shoot a snapshot about the grid story that its no longer matching the base. There is an image not properly loading, so I replaced it with a faster loading image also from reservix matching the other images in the story.  

Closes DST-1678

## Test Instructions

<!-- Numbered steps a reviewer can follow. Even "no manual testing needed" is fine. -->

1. Go to Grid stories -> Bento story
2. Check if image is loaded 

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
