### PR TITLE
fix(DST-1686): make the control track fill ground-adaptive and enlarge the SegmentedControl indicator

### DIFF
--- a/.changeset/slider-track-control-surface.md
+++ b/.changeset/slider-track-control-surface.md
@@ -1,0 +1,18 @@
+---
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+---
+
+fix: make `control` a ground-adaptive track fill, and give the `Slider` rail the same token as `Switch` and `SegmentedControl`
+
+**The Slider rail was the wrong token, painted twice.** It used `bg-border` — the token for structural lines (dividers, grid lines, table rules) — where the `Switch` groove and the `SegmentedControl` track both use `bg-control`. On top of that, `Slider` applied its `track` style to two exactly-overlapping elements (the `SliderTrack` and an inner rail `div`), so the translucent `bg-border` composited with itself and the rail rendered at ~0.26 effective alpha instead of 0.14 — measuring `#c0bfbe` on white where the token specifies `#dddddc`. The redundant inner element is gone; the `SliderTrack` itself is the rail. Geometry is unchanged (both were `h-2` at the same position) and `touch-none`, `select-none` and the disabled cursor stay on the interactive track element.
+
+**`control` is now translucent** (`charcoal-950 / 16%`, was the opaque `charcoal-300`). A track is not painted on one known background — it appears on a white Card, the gray page ground, a `muted` fill, and inside a hovered Table or ListBox row — and a fixed palette step drifts across those. charcoal-300 measured 1.53:1 on white but only 1.21:1 inside a hovered row, where the groove half-dissolved into the row it sits in. At 16% the four grounds land within 0.02 of each other (1.41–1.43:1), so a track weighs the same wherever it goes. Same rationale as `border` in DST-1672.
+
+The three tracks (`Switch`, `SegmentedControl`, `Slider`) read a touch lighter on white surfaces as a result: `#d8d8d7` rather than `#d4d0ce`. The trade-off is that the white Switch thumb and SegmentedControl indicator now vary against the track by ground (1.43:1 on white, 1.79:1 on a hovered row) where the opaque step held a flat 1.53:1 — track-vs-ground and thumb-vs-track cannot both be constant while the thumb is opaque, and ground legibility wins because it decides whether the control reads as a control at all.
+
+**The `SegmentedControl` indicator is larger.** The frame around the selected thumb went from 4px to 3px (`inset-y-[3px]` on the indicator, `p-[3px]` on the list), so the thumb is 30px tall instead of 28px. Since the thumb's own 1px rim occupies the innermost pixel of that frame, 2px of bare track is what you see.
+
+**The `SegmentedControl` thumb's focus ring is now the shared `ui-state-focus`.** It previously hand-rolled only the outline, so it missed the other half of that utility — firming `--ui-border-color` to the opaque ring colour — and read noticeably lighter than every other focused control. A focused thumb and a focused `Input` now resolve identically: 3px `outline-ring/50` at `outline-offset-0`, plus a 1px opaque `oklch(0.52 0.008 54)` rim. The ring stays outside the thumb, and 3px is the minimum frame that clears it: the list is a scroll container clipping at its padding box, so that padding is the only room an outset ring can grow into. Below 3px the first and last thumbs get a visibly shaved ring.
+
+If you use `bg-control` in your own code, note that it is now translucent: two stacked elements that both carry it composite into a darker track than the token specifies.

--- a/.changeset/slider-track-control-surface.md
+++ b/.changeset/slider-track-control-surface.md
@@ -3,7 +3,7 @@
 '@marigold/theme-rui': patch
 ---
 
-fix: make `control` a ground-adaptive track fill, and give the `Slider` rail the same token as `Switch` and `SegmentedControl`
+fix(DST-1686): make `control` a ground-adaptive track fill, and give the `Slider` rail the same token as `Switch` and `SegmentedControl`
 
 **The Slider rail was the wrong token, painted twice.** It used `bg-border` — the token for structural lines (dividers, grid lines, table rules) — where the `Switch` groove and the `SegmentedControl` track both use `bg-control`. On top of that, `Slider` applied its `track` style to two exactly-overlapping elements (the `SliderTrack` and an inner rail `div`), so the translucent `bg-border` composited with itself and the rail rendered at ~0.26 effective alpha instead of 0.14 — measuring `#c0bfbe` on white where the token specifies `#dddddc`. The redundant inner element is gone; the `SliderTrack` itself is the rail. Geometry is unchanged (both were `h-2` at the same position) and `touch-none`, `select-none` and the disabled cursor stay on the interactive track element.
 
@@ -15,4 +15,8 @@ The three tracks (`Switch`, `SegmentedControl`, `Slider`) read a touch lighter o
 
 **The `SegmentedControl` thumb's focus ring is now the shared `ui-state-focus`.** It previously hand-rolled only the outline, so it missed the other half of that utility — firming `--ui-border-color` to the opaque ring colour — and read noticeably lighter than every other focused control. A focused thumb and a focused `Input` now resolve identically: 3px `outline-ring/50` at `outline-offset-0`, plus a 1px opaque `oklch(0.52 0.008 54)` rim. The ring stays outside the thumb, and 3px is the minimum frame that clears it: the list is a scroll container clipping at its padding box, so that padding is the only room an outset ring can grow into. Below 3px the first and last thumbs get a visibly shaved ring.
 
-If you use `bg-control` in your own code, note that it is now translucent: two stacked elements that both carry it composite into a darker track than the token specifies.
+**The `SegmentedControl` track's corners are now concentric with the indicator's.** Both used the shared `rounded-surface`, but two rounded rectangles nested with a gap only look like parallel arcs when the outer radius is the inner radius plus that gap. With the thumb at 8px and 3px of frame around it, the track needs 11px; at 8px its corner read visibly tighter than the arc it frames. The track is now `calc(var(--radius-surface) + 3px)` — derived from the token, so it stays concentric if the radius is retuned. This is a deliberate exception to using `rounded-surface` everywhere.
+
+**The `SegmentedControl` indicator's resting rim is re-derived from the track.** `ui-frame` draws its rim as an *outset* ring, so the indicator's rim lands on the track and composites over `bg-control` — it reads denser than the same `control-border` token does on a field. The old compensation subtracted a flat 0.08, hand-tuned against the previous opaque `charcoal-300` track, which left the rim at an effective 0.31 against a field's 0.26. It is now derived from the track's own alpha (`--control-alpha`, newly exposed on the token), so a resting indicator rim and a resting `Input` edge render the same on every ground, and retuning the track cannot silently detune the rim.
+
+If you use `bg-control` in your own code, note that it is now translucent: two stacked elements that both carry it composite into a darker track than the token specifies, and anything that paints a translucent edge *over* a track has to account for the track underneath it.

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -123,21 +123,24 @@ jobs:
           # `untraced` list below, so the trace dies there and every affected story
           # inherited its baseline. Forcing a full run to get real snapshots of the
           # SegmentedControl/Switch changes. The trace gap itself is its own ticket.
+          # `untraced` has to be commented out with it: it is a TurboSnap-only input
+          # and the CLI rejects it outright ("Invalid --untraced") when onlyChanged
+          # is false. Restore both together.
           onlyChanged: false # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
           zip: true # Zip the Storybook build for faster uploads
           # Files whose changes should NOT trigger story re-snapshots via
           # dependency tracing. Keep this list focused on files that change
           # often but cannot affect rendered output.
-          untraced: |
-            ./.storybook/decorators.tsx
-            **/*.md
-            **/*.mdx
-            .changeset/**
-            **/*.test.{ts,tsx}
-            **/vitest.*.{ts,mjs,js}
-            **/vitest.setup.{ts,mjs,js}
-            eslint.config.*
-            **/tsconfig*.json
+          # untraced: |
+          #   ./.storybook/decorators.tsx
+          #   **/*.md
+          #   **/*.mdx
+          #   .changeset/**
+          #   **/*.test.{ts,tsx}
+          #   **/vitest.*.{ts,mjs,js}
+          #   **/vitest.setup.{ts,mjs,js}
+          #   eslint.config.*
+          #   **/tsconfig*.json
           storybookConfigDir: './.storybook'
           storybookBuildDir: './storybook-static'
           storybookBaseDir: '.'

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -117,7 +117,13 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           branchName: ${{ steps.resolve-branch.outputs.branch }}
-          onlyChanged: true # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
+          # !!! TEMPORARY — REVERT TO `true` BEFORE MERGING THIS PR (DST-1686) !!!
+          # TurboSnap gave this theme-only change zero coverage: `themes/**` reaches
+          # most stories only through `.storybook/decorators.tsx`, which is in the
+          # `untraced` list below, so the trace dies there and every affected story
+          # inherited its baseline. Forcing a full run to get real snapshots of the
+          # SegmentedControl/Switch changes. The trace gap itself is its own ticket.
+          onlyChanged: false # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
           zip: true # Zip the Storybook build for faster uploads
           # Files whose changes should NOT trigger story re-snapshots via
           # dependency tracing. Keep this list focused on files that change

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -117,30 +117,21 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           branchName: ${{ steps.resolve-branch.outputs.branch }}
-          # !!! TEMPORARY — REVERT TO `true` BEFORE MERGING THIS PR (DST-1686) !!!
-          # TurboSnap gave this theme-only change zero coverage: `themes/**` reaches
-          # most stories only through `.storybook/decorators.tsx`, which is in the
-          # `untraced` list below, so the trace dies there and every affected story
-          # inherited its baseline. Forcing a full run to get real snapshots of the
-          # SegmentedControl/Switch changes. The trace gap itself is its own ticket.
-          # `untraced` has to be commented out with it: it is a TurboSnap-only input
-          # and the CLI rejects it outright ("Invalid --untraced") when onlyChanged
-          # is false. Restore both together.
-          onlyChanged: false # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
+          onlyChanged: true # TurboSnap: https://www.chromatic.com/docs/turbosnap/setup/
           zip: true # Zip the Storybook build for faster uploads
           # Files whose changes should NOT trigger story re-snapshots via
           # dependency tracing. Keep this list focused on files that change
           # often but cannot affect rendered output.
-          # untraced: |
-          #   ./.storybook/decorators.tsx
-          #   **/*.md
-          #   **/*.mdx
-          #   .changeset/**
-          #   **/*.test.{ts,tsx}
-          #   **/vitest.*.{ts,mjs,js}
-          #   **/vitest.setup.{ts,mjs,js}
-          #   eslint.config.*
-          #   **/tsconfig*.json
+          untraced: |
+            ./.storybook/decorators.tsx
+            **/*.md
+            **/*.mdx
+            .changeset/**
+            **/*.test.{ts,tsx}
+            **/vitest.*.{ts,mjs,js}
+            **/vitest.setup.{ts,mjs,js}
+            eslint.config.*
+            **/tsconfig*.json
           storybookConfigDir: './.storybook'
           storybookBuildDir: './storybook-static'
           storybookBaseDir: '.'
@@ -148,8 +139,7 @@ jobs:
           # One-shot diagnostics so we can see WHY TurboSnap chose to
           # snapshot what it did. Inspect via the uploaded artifact below.
           diagnosticsFile: true
-          # Also TurboSnap-only — restore with `onlyChanged` / `untraced` above.
-          # traceChanged: expanded
+          traceChanged: expanded
 
       - name: Upload Chromatic diagnostics
         if: always()

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -148,7 +148,8 @@ jobs:
           # One-shot diagnostics so we can see WHY TurboSnap chose to
           # snapshot what it did. Inspect via the uploaded artifact below.
           diagnosticsFile: true
-          traceChanged: expanded
+          # Also TurboSnap-only — restore with `onlyChanged` / `untraced` above.
+          # traceChanged: expanded
 
       - name: Upload Chromatic diagnostics
         if: always()

--- a/docs/content/foundations/token-overview/index.mdx
+++ b/docs/content/foundations/token-overview/index.mdx
@@ -247,7 +247,11 @@ Controls carry two neutral tokens. Most define their shape with a border, drawn 
 
 `control-border` is the visible edge of a bordered control such as a text input or a select. It is the denser sibling of `surface-border`, kept above the contrast threshold so the boundary is always seen. The full set of edge tokens lives under [Borders](#borders).
 
-Some controls have no border to define them. The switch track is the clearest example. When OFF, the track needs to look like a solid, physical groove that the thumb can slide along. A white or transparent background would make it disappear into the surface, while `selected` or `disabled-surface` would send the wrong signal. `control` fills this gap with a medium-weight neutral background that reads as an interactive control in its resting state, and it pairs naturally with `selected-bold` for the ON state.
+Some controls have no border to define them. The switch track is the clearest example. When OFF, the track needs to look like a physical groove that the thumb can slide along. A white or transparent background would make it disappear into the surface, while `selected` or `disabled-surface` would send the wrong signal. `control` fills this gap with a neutral groove that reads as an interactive control in its resting state, and it pairs naturally with `selected-bold` for the ON state.
+
+Exactly three components use it, and all three are tracks: the Switch groove, the SegmentedControl track, and the Slider rail.
+
+`control` is **translucent**, for the same reason the edge tokens are. A track is not painted on one known background — it appears on a white Card, on the gray page ground, on a `muted` fill, and inside a hovered Table or ListBox row. A fixed palette step drifts across those: charcoal-300 measured 1.53:1 on white but only 1.21:1 inside a hovered row, where the groove half-dissolved into the row it sits in. At 16% the four grounds land within 0.02 of each other, so a track weighs the same wherever you put it.
 
 <TokenTable
   tokens={[
@@ -259,9 +263,9 @@ Some controls have no border to define them. The switch track is the clearest ex
     },
     {
       name: 'control',
-      value: 'charcoal-300',
+      value: 'charcoal-950 / 16%',
       useFor:
-        'Resting fill for controls that show their inactive state through a background instead of a border (e.g. switch track)',
+        'Resting fill of an unselected control track: the Switch groove, the SegmentedControl track, the Slider rail. Translucent, so it holds ~1.42:1 against every ground a track lands on rather than varying with the fill behind it',
     },
   ]}
 />
@@ -278,7 +282,18 @@ Some controls have no border to define them. The switch track is the clearest ex
   `control-border` token documented with the other edges under
   [Borders](#borders). Only reach for `bg-control` when a control communicates
   its state through a filled background rather than a border, like switch
-  tracks, slider tracks, and similar "trough" elements.
+  tracks, slider tracks, and similar "trough" elements. The name is broader than
+  the role: read it as "control track".
+</Callout>
+
+<Callout title="Never paint it twice">
+  Because the fill is translucent, two stacked elements that both carry
+  `bg-control` composite into a darker track than the token specifies — 16% over
+  16% renders as 29%. This is a real bug we shipped: the Slider applied its
+  track style to both the `SliderTrack` and an inner rail `div` at identical
+  geometry, so the rail rendered visibly darker than the Switch groove beside
+  it. If a component layers elements over its track, only one of them may carry
+  the fill.
 </Callout>
 
 <GuidelineTiles>
@@ -292,7 +307,8 @@ Some controls have no border to define them. The switch track is the clearest ex
     <DontDescription>
       Don't use `bg-control` for bordered form controls like text inputs,
       selects, or textareas. Those should use `bg-surface` with the `ui-control`
-      ring.
+      ring. And don't stack it on two overlapping elements — a translucent fill
+      painted twice composites darker.
     </DontDescription>
   </Dont>
 </GuidelineTiles>

--- a/docs/content/foundations/token-overview/index.mdx
+++ b/docs/content/foundations/token-overview/index.mdx
@@ -293,7 +293,11 @@ Exactly three components use it, and all three are tracks: the Switch groove, th
   track style to both the `SliderTrack` and an inner rail `div` at identical
   geometry, so the rail rendered visibly darker than the Switch groove beside
   it. If a component layers elements over its track, only one of them may carry
-  the fill.
+  the fill. The same arithmetic applies to a translucent *edge* drawn on a
+  track, because `ui-frame` rims are outset rings: they land on the track rather
+  than on the ground, so `control-border` over `control` reads denser than it
+  does on a field. The `SegmentedControl` indicator thins its rim to compensate,
+  deriving the amount from `--control-alpha` rather than hard-coding it.
 </Callout>
 
 <GuidelineTiles>

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -111,11 +111,7 @@ const _Slider = <T extends number | number[]>({
       >
         {({ state }) => (
           <>
-            {/* The `SliderTrack` above *is* the rail: it already carries
-                `classNames.track` at the same `h-2` geometry. Don't add a
-                second rail element here — it paints the track style twice, and
-                any translucency in the token then composites with itself into a
-                darker rail than the token specifies. */}
+            {/* No rail element here — the `SliderTrack` above is the rail. */}
             {/* fill */}
             <div
               className={cn(

--- a/packages/components/src/Slider/Slider.tsx
+++ b/packages/components/src/Slider/Slider.tsx
@@ -111,13 +111,11 @@ const _Slider = <T extends number | number[]>({
       >
         {({ state }) => (
           <>
-            {/* track */}
-            <div
-              className={cn(
-                'absolute top-[50%] h-2 w-full translate-y-[-50%]',
-                classNames.track
-              )}
-            />
+            {/* The `SliderTrack` above *is* the rail: it already carries
+                `classNames.track` at the same `h-2` geometry. Don't add a
+                second rail element here — it paints the track style twice, and
+                any translucency in the token then composites with itself into a
+                darker rail than the token specifies. */}
             {/* fill */}
             <div
               className={cn(

--- a/themes/theme-rui/src/components/SegmentedControl.styles.ts
+++ b/themes/theme-rui/src/components/SegmentedControl.styles.ts
@@ -3,16 +3,29 @@ import { ThemeComponent, cva } from '@marigold/system';
 export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
   // Outer track. Provides the surface (default variant). Doesn't clip: the inner
   // list is the scroll container, so option focus rings aren't cut at this edge.
+  // The radius is set per variant rather than once on `base`: twMerge doesn't
+  // recognise `rounded-surface` as a radius utility, so it won't drop it in favour
+  // of a variant's arbitrary `rounded-[…]` and emit order would decide the winner.
   group: cva({
-    base: 'group/segmented relative items-center rounded-surface',
+    base: 'group/segmented relative items-center',
     variants: {
       variant: {
         // Track matches the Switch groove and the Slider rail (`bg-control`, a
-        // translucent fill — see the token docs; never paint it twice). The 2px
-        // outer margin lives on the list (p-0.5), not here, so the list stays the
+        // translucent fill — see the token docs; never paint it twice). The 3px
+        // outer margin lives on the list (p-[3px]), not here, so the list stays the
         // one element that defines the frame around the thumbs.
-        default: 'bg-control',
-        ghost: '',
+        //   The radius is the one place this component departs from the shared
+        // `rounded-surface`, and it has to: two rounded rects nested with a gap are
+        // only concentric when the outer radius is the inner radius plus that gap
+        // (`R_outer = R_inner + d`). The thumb keeps `rounded-surface` (8px) and
+        // sits 3px in, so the track needs 11px. Sharing one radius makes the outer
+        // corner visibly tighter than the arc it frames. (The thumb's outset 1px
+        // rim doesn't change the sum: it widens the inner arc to 9px but closes the
+        // gap to 2px.) Derived from the token, so a retuned `--radius-surface`
+        // stays concentric.
+        default: 'bg-control rounded-[calc(var(--radius-surface)+3px)]',
+        // No track to frame, so no gap to compensate for.
+        ghost: 'rounded-surface',
       },
       size: {
         default: 'text-sm',
@@ -24,18 +37,13 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
     },
   }),
   // Inner scroll container: rows the options and scrolls them horizontally on
-  // overflow, with an edge fade (`ui-scroll-mask-x`). `p-[3px]` insets the segments
-  // 3px from the track edge, so 3px of frame shows to the left of the first thumb
-  // and to the right of the last — the horizontal half of the frame around the
-  // indicator (`inset-y-[3px]` below is the vertical half). Of those 3px the thumb's
-  // own 1px rim takes the innermost, so 2px of bare track is what you see.
-  // `-my-[3px]` cancels the vertical 3px so it adds no height (only `px` is a real
-  // inset; a negative `-mx` would overflow the rounded track — broke at 320px).
-  //   3px is also exactly the room the indicator's focus ring needs. A scrollport
-  //   clips at its padding box, so this padding is the only space an outset ring can
-  //   grow into, and `ui-state-focus` is `outline-3` at `outline-offset-0` — 3px.
-  //   Don't drop below 3px without moving the ring inside the thumb: at 2px the
-  //   first and last thumbs get a visibly shaved ring (verified).
+  // overflow, with an edge fade (`ui-scroll-mask-x`).
+  //   `p-[3px]` is the frame around the thumbs (`inset-y-[3px]` below is its
+  // vertical half), and 3px is the floor: a scrollport clips at its padding box,
+  // so this is the only room the thumb's outset focus ring has to grow into, and
+  // `ui-state-focus` needs 3px of it. Below that the first and last thumbs get a
+  // visibly shaved ring. `-my-[3px]` cancels the vertical padding so it adds no
+  // height; a negative `-mx` would overflow the rounded track (broke at 320px).
   //   - `motion-safe:scroll-smooth` makes the selection-reveal scroll animate for
   //     users who allow motion and jump instantly for those who don't; the
   //     component's `scrollTo` defers to it via `behavior: 'auto'` (matches Tabs).
@@ -121,11 +129,19 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
         // that utility firms `--ui-border-color` to the opaque ring colour as well
         // as drawing the 3px outline, and the outline alone (what this used to do)
         // reads noticeably lighter than every other control without it.
-        //   At rest, control-border's ground-adaptive firming over-darkens the edge
-        // against the track, so the alpha is stepped down 0.08 (token-derived);
-        // ui-state-focus overrides that on focus.
+        //   At rest the rim is thinned, because ui-frame's rim is an *outset* ring:
+        // it lands on the track, so it composites over `control` and reads denser
+        // than the same token does on a field. Two layers of one colour stack to
+        // `control-alpha + (1 - control-alpha) * a`, so solving that for
+        // `control-border`'s alpha gives the thinned value below — 0.119 at the
+        // current tokens. Derived from `--control-alpha` rather than hard-coded, so
+        // retuning the track can't silently detune the rim (it did: the old
+        // hand-tuned -0.08 was measured against the opaque charcoal-300 track and
+        // left the rim at an effective 0.31 against 0.26 on a field). Verified on
+        // rendered pixels: #c0bfbf on `surface`, matching an Input to within a
+        // rounding unit on all four grounds. ui-state-focus overrides it on focus.
         default:
-          'inset-y-[3px] left-0 w-full ui-control [--ui-border-color:oklch(from_var(--color-control-border)_l_c_h_/_calc(alpha_-_0.08))] group-has-[[data-focus-visible]]/segmented:ui-state-focus',
+          'inset-y-[3px] left-0 w-full ui-control [--ui-border-color:oklch(from_var(--color-control-border)_l_c_h_/_calc((alpha_-_var(--control-alpha))_/_(1_-_var(--control-alpha))))] group-has-[[data-focus-visible]]/segmented:ui-state-focus',
         // Resembles a ghost Button's surface.
         ghost: 'inset-y-0 left-0 w-full rounded-surface ui-state-hover-ghost',
       },

--- a/themes/theme-rui/src/components/SegmentedControl.styles.ts
+++ b/themes/theme-rui/src/components/SegmentedControl.styles.ts
@@ -7,9 +7,10 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
     base: 'group/segmented relative items-center rounded-surface',
     variants: {
       variant: {
-        // Track matches the Switch's unselected track. The 4px outer margin lives
-        // on the list (p-1), not here, so the edge thumbs' focus ring stays inside
-        // the scroll container's clip.
+        // Track matches the Switch groove and the Slider rail (`bg-control`, a
+        // translucent fill — see the token docs; never paint it twice). The 2px
+        // outer margin lives on the list (p-0.5), not here, so the list stays the
+        // one element that defines the frame around the thumbs.
         default: 'bg-control',
         ghost: '',
       },
@@ -23,18 +24,25 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
     },
   }),
   // Inner scroll container: rows the options and scrolls them horizontally on
-  // overflow, with an edge fade (`ui-scroll-mask-x`). A scrollport is the padding
-  // box, so `p-1` is room *inside* the clip: it both insets the segments 4px from
-  // the track edge and keeps the edge thumbs' focus ring from being clipped.
-  // `-my-1` cancels the vertical 4px so it adds no height (only `px` is a real
+  // overflow, with an edge fade (`ui-scroll-mask-x`). `p-[3px]` insets the segments
+  // 3px from the track edge, so 3px of frame shows to the left of the first thumb
+  // and to the right of the last — the horizontal half of the frame around the
+  // indicator (`inset-y-[3px]` below is the vertical half). Of those 3px the thumb's
+  // own 1px rim takes the innermost, so 2px of bare track is what you see.
+  // `-my-[3px]` cancels the vertical 3px so it adds no height (only `px` is a real
   // inset; a negative `-mx` would overflow the rounded track — broke at 320px).
+  //   3px is also exactly the room the indicator's focus ring needs. A scrollport
+  //   clips at its padding box, so this padding is the only space an outset ring can
+  //   grow into, and `ui-state-focus` is `outline-3` at `outline-offset-0` — 3px.
+  //   Don't drop below 3px without moving the ring inside the thumb: at 2px the
+  //   first and last thumbs get a visibly shaved ring (verified).
   //   - `motion-safe:scroll-smooth` makes the selection-reveal scroll animate for
   //     users who allow motion and jump instantly for those who don't; the
   //     component's `scrollTo` defers to it via `behavior: 'auto'` (matches Tabs).
   //   - `overscroll-x-contain` keeps horizontal overscroll from triggering the
   //     browser back/forward gesture at the track ends (matches Tabs).
   list: cva({
-    base: 'flex w-full items-center ui-scroll-mask-x p-1 -my-1 overscroll-x-contain motion-safe:scroll-smooth',
+    base: 'flex w-full items-center ui-scroll-mask-x p-[3px] -my-[3px] overscroll-x-contain motion-safe:scroll-smooth',
     variants: {
       variant: {
         default: 'gap-0',
@@ -100,17 +108,24 @@ export const SegmentedControl: ThemeComponent<'SegmentedControl'> = {
       variant: {
         // Flat control-surface thumb (ui-control): a well like the fields, not
         // a raised cap — the moving thumb and selection do the work. It fills
-        // its segment horizontally (left-0
-        // w-full) so adjacent thumbs meet with no gap; the 4px top/bottom margin is
-        // the inset-y, and the 4px end margin comes from the track's p-1 — so the
-        // between-gap (0) and the outer margin are set independently.
-        //   The keyboard focus ring is drawn here, not on the cell, so it wraps the
-        // thumb exactly (offset-1 = flush with the thumb's 1px ring). Selection
-        // follows focus, so the focused option is always the one under this thumb.
-        //   On the dark charcoal-300 track, control-border's ground-adaptive firming
-        // over-darkens the edge, so the alpha is stepped down 0.08 (token-derived).
+        // its segment horizontally (left-0 w-full) so adjacent thumbs meet with no
+        // gap; the 3px top/bottom margin is the inset-y, and the 3px end margin
+        // comes from the track's p-[3px] — so the between-gap (0) and the outer
+        // margin are set independently. 3px rather than the original 4px so the
+        // thumb carries more of the track (30px tall, was 28px), while still
+        // clearing the focus ring — see the note on `list` above.
+        //   The keyboard focus ring is drawn here, not on the cell, so it marks the
+        // thumb exactly. Selection follows focus, so the focused option is always
+        // the one under this thumb. It is the shared `ui-state-focus`, not a
+        // hand-rolled outline, so a focused thumb matches a focused Input exactly:
+        // that utility firms `--ui-border-color` to the opaque ring colour as well
+        // as drawing the 3px outline, and the outline alone (what this used to do)
+        // reads noticeably lighter than every other control without it.
+        //   At rest, control-border's ground-adaptive firming over-darkens the edge
+        // against the track, so the alpha is stepped down 0.08 (token-derived);
+        // ui-state-focus overrides that on focus.
         default:
-          'inset-y-[4px] left-0 w-full ui-control [--ui-border-color:oklch(from_var(--color-control-border)_l_c_h_/_calc(alpha_-_0.08))] group-has-[[data-focus-visible]]/segmented:outline-3 group-has-[[data-focus-visible]]/segmented:outline-solid group-has-[[data-focus-visible]]/segmented:outline-ring/50 group-has-[[data-focus-visible]]/segmented:outline-offset-1',
+          'inset-y-[3px] left-0 w-full ui-control [--ui-border-color:oklch(from_var(--color-control-border)_l_c_h_/_calc(alpha_-_0.08))] group-has-[[data-focus-visible]]/segmented:ui-state-focus',
         // Resembles a ghost Button's surface.
         ghost: 'inset-y-0 left-0 w-full rounded-surface ui-state-hover-ghost',
       },

--- a/themes/theme-rui/src/components/Slider.styles.ts
+++ b/themes/theme-rui/src/components/Slider.styles.ts
@@ -2,9 +2,14 @@ import { ThemeComponent, cva } from '@marigold/system';
 
 export const Slider: ThemeComponent<'Slider'> = {
   container: cva({ base: '*:aria-hidden:hidden' }),
+  // The rail. `bg-control` is the shared unselected-track fill — the same token
+  // the Switch groove and the SegmentedControl track use, so the three read as
+  // one control family. Not `bg-border`: that token is for structural lines
+  // (dividers, grid lines, table rules), and being translucent it also
+  // compounded when it was painted twice.
   track: cva({
     base: [
-      'relative bg-border rounded-full flex w-full touch-none select-none items-center',
+      'relative bg-control rounded-full flex w-full touch-none select-none items-center',
       'orientation-vertical:h-full orientation-vertical:w-auto orientation-vertical:flex-col',
       'group-disabled/field:bg-disabled-surface group-disabled/field:cursor-not-allowed',
     ],

--- a/themes/theme-rui/src/tokens.css
+++ b/themes/theme-rui/src/tokens.css
@@ -76,8 +76,36 @@
 
   /* --- Neutral Backgrounds & States --- */
   --color-muted: var(--color-charcoal-50);
-  --color-control: var(--color-charcoal-300);
   --color-hover: var(--color-charcoal-200);
+
+  /* Resting fill of an unselected control track, and only that: the Switch
+     groove, the SegmentedControl track, the Slider rail. Not the surface of a
+     control in general — bordered controls (inputs, selects) sit on `surface` and
+     draw their shape with `control-border`. The name reads broader than the role;
+     see the callout in /foundations/token-overview.
+
+     Alpha, not a palette rung, so the track holds one *contrast* against
+     whatever ground it lands on instead of one lightness. A track appears on at
+     least four grounds — `surface`, `background`, `muted`, and a hovered
+     `hover` row — and a fixed rung drifts across them: charcoal-300 measured
+     1.53:1 on white but only 1.21:1 inside a hovered Table row, where the groove
+     half-dissolved into the row it sits in. At 0.16 the four land within 0.02 of
+     each other (1.41–1.43:1). Same reasoning as `--color-border` below.
+
+     0.16 rather than the 0.18 that would match charcoal-300's weight on white:
+     the tracks read a touch lighter by intent. The cost is the white-on-track
+     relationship — the Switch thumb and the SegmentedControl indicator are
+     opaque `surface`, so their contrast against the track now varies with the
+     ground (1.43:1 on white, 1.79:1 on a hovered row) where a rung held a flat
+     1.53:1. Track-vs-ground and thumb-vs-track cannot both be constant while the
+     thumb is opaque; ground legibility wins because it decides whether the
+     control reads as a control at all.
+
+     Note this composites near-neutral on white (chroma 0.008 at 16% is ~0.001),
+     so on a Card the track carries less of the palette's hue-54 warmth than a
+     rung would. On warmer grounds it picks the warmth back up. See DST-1672 for
+     the alpha-vs-rung rationale and the sampling method. */
+  --color-control: oklch(from var(--color-charcoal-950) l c h / 0.16);
 
   --color-selected: var(--color-charcoal-300);
   --color-selected-bold: var(--color-charcoal-900);

--- a/themes/theme-rui/src/tokens.css
+++ b/themes/theme-rui/src/tokens.css
@@ -79,33 +79,29 @@
   --color-hover: var(--color-charcoal-200);
 
   /* Resting fill of an unselected control track, and only that: the Switch
-     groove, the SegmentedControl track, the Slider rail. Not the surface of a
-     control in general — bordered controls (inputs, selects) sit on `surface` and
-     draw their shape with `control-border`. The name reads broader than the role;
-     see the callout in /foundations/token-overview.
+     groove, the SegmentedControl track, the Slider rail. Bordered controls
+     (inputs, selects) sit on `surface` and use `control-border` instead — the
+     name reads broader than the role, see /foundations/token-overview.
 
-     Alpha, not a palette rung, so the track holds one *contrast* against
-     whatever ground it lands on instead of one lightness. A track appears on at
-     least four grounds — `surface`, `background`, `muted`, and a hovered
-     `hover` row — and a fixed rung drifts across them: charcoal-300 measured
-     1.53:1 on white but only 1.21:1 inside a hovered Table row, where the groove
-     half-dissolved into the row it sits in. At 0.16 the four land within 0.02 of
-     each other (1.41–1.43:1). Same reasoning as `--color-border` below.
+     Alpha, not a palette rung, so a track holds one contrast against every
+     ground it lands on instead of one lightness. charcoal-300 measured 1.53:1 on
+     `surface` but 1.21:1 inside a hovered row; at 0.16 the four grounds
+     (`surface`, `background`, `muted`, hovered `hover`) land within 0.02 of each
+     other. Same reasoning as `--color-border` below; see DST-1672 for the
+     alpha-vs-rung rationale and the sampling method.
 
-     0.16 rather than the 0.18 that would match charcoal-300's weight on white:
-     the tracks read a touch lighter by intent. The cost is the white-on-track
-     relationship — the Switch thumb and the SegmentedControl indicator are
-     opaque `surface`, so their contrast against the track now varies with the
-     ground (1.43:1 on white, 1.79:1 on a hovered row) where a rung held a flat
-     1.53:1. Track-vs-ground and thumb-vs-track cannot both be constant while the
-     thumb is opaque; ground legibility wins because it decides whether the
-     control reads as a control at all.
+     Two knock-on effects, both accepted: the opaque white Switch thumb and
+     SegmentedControl indicator now vary against the track by ground (1.43:1 on
+     white, 1.79:1 on a hovered row) where a rung held a flat 1.53:1, and at
+     chroma ~0.001 the track composites near-neutral on white.
 
-     Note this composites near-neutral on white (chroma 0.008 at 16% is ~0.001),
-     so on a Card the track carries less of the palette's hue-54 warmth than a
-     rung would. On warmer grounds it picks the warmth back up. See DST-1672 for
-     the alpha-vs-rung rationale and the sampling method. */
-  --color-control: oklch(from var(--color-charcoal-950) l c h / 0.16);
+     `--control-alpha` is exposed because a control that paints *over* the track
+     has to compensate for it — see the indicator rim in
+     SegmentedControl.styles.ts. Retuning the track here retunes that with it. */
+  --control-alpha: 0.16;
+  --color-control: oklch(
+    from var(--color-charcoal-950) l c h / var(--control-alpha)
+  );
 
   --color-selected: var(--color-charcoal-300);
   --color-selected-bold: var(--color-charcoal-900);


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

Three related changes to the "unselected control track" — the `Switch` groove, the `SegmentedControl` track and the `Slider` rail.

**1. The `Slider` rail was the wrong token, painted twice.** It used `bg-border`, the token for *structural lines* (dividers, grid lines, table rules), where the other two tracks use `bg-control`. On top of that, `Slider` applied its `track` style to two exactly-overlapping elements — the `SliderTrack` and an inner rail `div`, both `h-2` at the same position — so the translucent fill composited with itself and rendered at ~0.26 effective alpha instead of 0.14: `#c0bfbe` on white where the token specifies `#dddddc`. The two defects pushed in opposite directions, which is why the rail looked *darker* than `bg-control` while naming a token that would have made it *lighter*. The redundant element is gone; the `SliderTrack` is the rail. Geometry is unchanged, and `touch-none`, `select-none` and the disabled cursor stay on the interactive track element.

**2. `--color-control` is now translucent** — `charcoal-950 / 16%`, was the opaque `charcoal-300`. A track is not painted on one known background: it appears on a white Card, the gray page ground, a `muted` fill, and inside a hovered `Table` or `ListBox` row. A fixed palette step drifts across those — charcoal-300 measured 1.53:1 on white but only **1.21:1 inside a hovered row**, where the groove half-dissolved into the row it sits in. At 16% the four grounds land within 0.02 of each other (1.41–1.43:1), so a track weighs the same wherever it goes. Same rationale as `border` in DST-1672.

Before/after on a white surface: all three tracks go from `#d4d0ce` (and `#c0bfbe` for the Slider rail) to `#d8d8d7`.

**3. The `SegmentedControl` indicator is larger and its focus ring matches the rest of the system.** The frame of track around the selected thumb went 4px → 3px, so the thumb is 30px tall instead of 28px; the thumb's own 1px rim takes the innermost pixel, leaving 2px of bare track visible. Separately, the thumb's focus ring was a hand-rolled outline that reproduced only *half* of `ui-state-focus` — it drew the 3px `outline-ring/50` but never firmed `--ui-border-color` to the opaque ring colour, so a focused thumb read noticeably lighter than a focused `Input`. It now uses `ui-state-focus` itself, and resolves identically to an `Input`: 3px `outline-ring/50` at `outline-offset-0` plus a 1px opaque `oklch(0.52 0.008 54)` rim.

3px is the *minimum* frame that clears the ring: the list is a scroll container and clips at its padding box, so that padding is the only room an outset ring can grow into. Below 3px the first and last thumbs get a visibly shaved ring.

Closes DST-1686

## Screenshots / Preview

<img width="1240" height="900" alt="image" src="https://github.com/user-attachments/assets/8abecdcc-915c-4f6c-85e3-95d3850a4e75" />

## Test Instructions

1. Run `pnpm sb` and open `Components/Slider` → **Basic**. The unfilled rail should be the same grey as the `Switch` track in `Components/Switch` → **Basic** and the `SegmentedControl` track in `Components/SegmentedControl` → **Basic**. All three should sample `#d8d8d7` on the white panel.
2. In `Components/SegmentedControl` → **Basic**, confirm the selected thumb is larger than before, with a thin frame of track around it.
3. Tab into the SegmentedControl. The focus ring should sit **outside** the thumb and look the same weight as the ring on a focused TextField (`Components/TextField` → **Basic**) — a 3px translucent ring plus a crisp dark 1px edge.
4. Arrow-key to the **first** and **last** segment and confirm the ring is not clipped at the track's edges.
5. Check a track on a non-white ground — e.g. a `Switch` inside a hovered `Table` row — and confirm the groove stays visible against the hover fill.
6. `Components/SegmentedControl` → **Overflow** / **OverflowSmallScreen**: confirm horizontal scrolling and the edge fade still behave, and that thumbs aren't clipped.

## Breaking Changes

No — no token was renamed or removed and no public API changed.

Worth flagging for consumers, though: `bg-control` is now **translucent**, so two stacked elements that both carry it composite into a darker track than the token specifies (that is exactly the `Slider` bug fixed here). The token docs gained a "Never paint it twice" callout. The changeset is currently a `patch`; a reviewer may reasonably argue for `minor`, since the rendered value of a public token changes.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

<!--
Reviewer notes on the unticked boxes:

- No stories/unit tests added: this is a theme-only change. The existing 32 story
  tests across Slider/Switch/SegmentedControl pass, but nothing pins the *focused*
  thumb, which is the state that changed most. Happy to add a focus-state story if
  you want VRT coverage of it.
- VRT: not run yet. Comment `/run-chromatic` to get visual coverage before merge —
  this touches three components plus a shared token, so expect real diffs.
- A11y: verified the focus indicator now matches `ui-state-focus` (3px ring +
  opaque rim, unclipped at every thumb position). Contrast was measured on rendered
  pixels across four grounds. Note the theme's tracks remain below WCAG 1.4.11's
  3:1 for non-text contrast — a pre-existing, documented deliberate call where the
  focus ring is the perceivable affordance, not changed here.
-->