### PR TITLE
fix(DST-1647): honor RouterProvider useHref in sidebar links

### DIFF
--- a/.changeset/dst-1647-sidebar-router-usehref.md
+++ b/.changeset/dst-1647-sidebar-router-usehref.md
@@ -1,0 +1,18 @@
+---
+'@marigold/components': patch
+'@marigold/docs': patch
+---
+
+fix(DST-1647): honor the router's `useHref` in sidebar links
+
+`Sidebar.Item` and `Sidebar.RailItem` rendered the raw `href` prop straight onto
+their anchor, which shadowed the value produced by `RouterProvider`'s optional
+`useHref`. Applications served from a prefix, such as a Next.js `basePath`, ended
+up with sidebar markup pointing at an unprefixed URL, so middle click and "copy
+link address" resolved to the wrong page. Both components now render the
+transformed href and keep handing the unprefixed path to `navigate`, matching how
+React Aria's own `useLink` behaves. Consumers that do not pass `useHref` see no
+change, because the default leaves the href untouched.
+
+The `RouterProvider` docs now cover `useHref` next to `navigate`, and the
+component gained a matching Storybook story and prop description.

--- a/docs/content/components/application/routerprovider/index.mdx
+++ b/docs/content/components/application/routerprovider/index.mdx
@@ -21,6 +21,18 @@ Similar to React Router you can pass in the `navigate` prop the routes you get f
 
 Also for more information please visit React Aria's documentation about it [here](https://react-spectrum.adobe.com/react-aria/routing.html#nextjs).
 
+### Rewriting hrefs
+
+The `navigate` prop decides how a click gets handled. The optional `useHref` prop decides what a link renders as its `href` attribute. Reach for it when your router serves the app from a prefix, such as a Next.js `basePath`.
+
+```tsx
+<RouterProvider navigate={navigate} useHref={href => `${basePath}${href}`}>
+  {children}
+</RouterProvider>
+```
+
+Components still hand the unprefixed path to `navigate`, so your route definitions stay free of the prefix. Only the rendered attribute changes, which is what middle click, "copy link address" and search engine crawlers read.
+
 ## Props
 
 <StorybookHintMessage component={'RouterProvider'} />

--- a/packages/components/src/RouterProvider/RouterProvider.stories.tsx
+++ b/packages/components/src/RouterProvider/RouterProvider.stories.tsx
@@ -83,7 +83,12 @@ export const Basic = meta.story({
  * `useHref` prefixes the rendered href, while `navigate` still receives the
  * unprefixed path.
  */
+// No snapshot: the whole point of this story is an `href` attribute value, and
+// `/base/start` renders the same pixels as `/start`. The rendering itself is
+// two default `Link`s, already captured by `Link.Basic`. The behaviour is
+// covered by the unit tests in `Sidebar.test.tsx` and `SidebarRail.test.tsx`.
 export const WithBasePath = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
   render: () => {
     const [navigated, setNavigated] = useState<string>('/start');
     return (

--- a/packages/components/src/RouterProvider/RouterProvider.stories.tsx
+++ b/packages/components/src/RouterProvider/RouterProvider.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components/Tabs';
 import preview from '.storybook/preview';
+import { Link } from '../Link/Link';
 import { RouterProvider } from './RouterProvider';
 
 const meta = preview.meta({
@@ -15,6 +16,15 @@ const meta = preview.meta({
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: './start' },
+      },
+    },
+    useHref: {
+      control: false,
+      description:
+        'Rewrites the href that links render, for example to prepend a router base path. The unprefixed path is still what `navigate` receives.',
+      table: {
+        type: { summary: '(href: string) => string' },
+        defaultValue: { summary: 'href => href' },
       },
     },
   },
@@ -63,6 +73,32 @@ export const Basic = meta.story({
         <pre>
           <strong>URL:</strong>
           {url}
+        </pre>
+      </>
+    );
+  },
+});
+
+/**
+ * `useHref` prefixes the rendered href, while `navigate` still receives the
+ * unprefixed path.
+ */
+export const WithBasePath = meta.story({
+  render: () => {
+    const [navigated, setNavigated] = useState<string>('/start');
+    return (
+      <>
+        <RouterProvider
+          navigate={setNavigated}
+          useHref={href => `/base${href}`}
+        >
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Link href="/start">Start</Link>
+            <Link href="/reports">Reports</Link>
+          </div>
+        </RouterProvider>
+        <pre>
+          <strong>Path passed to navigate</strong> {navigated}
         </pre>
       </>
     );

--- a/packages/components/src/Sidebar/Sidebar.test.tsx
+++ b/packages/components/src/Sidebar/Sidebar.test.tsx
@@ -136,6 +136,7 @@ test('branch items render as links with auto-derived href', () => {
 });
 
 test('router useHref rewrites the rendered href while navigate gets the raw path', async () => {
+  // Arrange
   const navigate = vi.fn();
   render(
     <RouterProvider navigate={navigate} useHref={href => `/base${href}`}>
@@ -152,10 +153,13 @@ test('router useHref rewrites the rendered href while navigate gets the raw path
   );
   const link = screen.getByRole('link', { name: 'Overview' });
 
+  // Assert (rendered href is prefixed)
   expect(link).toHaveAttribute('href', '/base/overview');
 
+  // Act
   await user.click(link);
 
+  // Assert (navigate still receives the unprefixed path)
   expect(navigate).toHaveBeenCalledWith('/overview', undefined);
 });
 

--- a/packages/components/src/Sidebar/Sidebar.test.tsx
+++ b/packages/components/src/Sidebar/Sidebar.test.tsx
@@ -135,6 +135,30 @@ test('branch items render as links with auto-derived href', () => {
   expect(managementLink).toHaveAttribute('href', '/users');
 });
 
+test('router useHref rewrites the rendered href while navigate gets the raw path', async () => {
+  const navigate = vi.fn();
+  render(
+    <RouterProvider navigate={navigate} useHref={href => `/base${href}`}>
+      <MarigoldProvider theme={theme}>
+        <Sidebar.Provider>
+          <Sidebar>
+            <Sidebar.Nav>
+              <Sidebar.Item href="/overview">Overview</Sidebar.Item>
+            </Sidebar.Nav>
+          </Sidebar>
+        </Sidebar.Provider>
+      </MarigoldProvider>
+    </RouterProvider>
+  );
+  const link = screen.getByRole('link', { name: 'Overview' });
+
+  expect(link).toHaveAttribute('href', '/base/overview');
+
+  await user.click(link);
+
+  expect(navigate).toHaveBeenCalledWith('/overview', undefined);
+});
+
 test('sub-panel opens when child is active', () => {
   render(<WithActiveBranch.Component />);
 

--- a/packages/components/src/Sidebar/SidebarLink.tsx
+++ b/packages/components/src/Sidebar/SidebarLink.tsx
@@ -32,14 +32,14 @@ export const SidebarLink = ({
   const ref = useObjectRef(forwardedRef);
   const router = useRouter();
   // Sole source of the rendered href, since a raw `href` would shadow the
-  // router's `useHref`. Only spread when there is one: without an href
-  // `useLinkProps` yields href="", which would make a branch trigger a link.
-  const routerLinkProps = useLinkProps({ href });
+  // router's `useHref`. Pass undefined when there is none, or `useLinkProps`
+  // yields href="", which would make a branch trigger a link.
+  const routerLinkProps = useLinkProps(href ? { href } : undefined);
   const { tabIndex, onFocus } = useRovingItem(dataKey!);
 
   return (
     <a
-      {...(href ? routerLinkProps : {})}
+      {...routerLinkProps}
       data-active={dataActive}
       data-key={dataKey}
       ref={ref}

--- a/packages/components/src/Sidebar/SidebarLink.tsx
+++ b/packages/components/src/Sidebar/SidebarLink.tsx
@@ -31,14 +31,15 @@ export const SidebarLink = ({
 }: SidebarLinkProps) => {
   const ref = useObjectRef(forwardedRef);
   const router = useRouter();
-  // Sole source of the rendered href. A raw `href` here would shadow the
-  // router's `useHref`, while `navigate` still wants the untransformed one.
+  // Sole source of the rendered href, since a raw `href` would shadow the
+  // router's `useHref`. Only spread when there is one: without an href
+  // `useLinkProps` yields href="", which would make a branch trigger a link.
   const routerLinkProps = useLinkProps({ href });
   const { tabIndex, onFocus } = useRovingItem(dataKey!);
 
   return (
     <a
-      {...routerLinkProps}
+      {...(href ? routerLinkProps : {})}
       data-active={dataActive}
       data-key={dataKey}
       ref={ref}

--- a/packages/components/src/Sidebar/SidebarLink.tsx
+++ b/packages/components/src/Sidebar/SidebarLink.tsx
@@ -31,6 +31,8 @@ export const SidebarLink = ({
 }: SidebarLinkProps) => {
   const ref = useObjectRef(forwardedRef);
   const router = useRouter();
+  // Sole source of the rendered href. A raw `href` here would shadow the
+  // router's `useHref`, while `navigate` still wants the untransformed one.
   const routerLinkProps = useLinkProps({ href });
   const { tabIndex, onFocus } = useRovingItem(dataKey!);
 
@@ -40,7 +42,6 @@ export const SidebarLink = ({
       data-active={dataActive}
       data-key={dataKey}
       ref={ref}
-      href={href}
       role={href ? undefined : 'button'}
       className={className}
       tabIndex={tabIndex}

--- a/packages/components/src/Sidebar/SidebarRail.test.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.test.tsx
@@ -492,6 +492,7 @@ describe('modified clicks & keyboard activation', () => {
     // No href and no section nav → rendered as <a role="button">, which gets
     // no native keyboard activation from the browser.
     const item = screen.getByRole('button', { name: 'Support' });
+    expect(item).not.toHaveAttribute('href');
     item.focus();
 
     await user.keyboard('{Enter}');

--- a/packages/components/src/Sidebar/SidebarRail.test.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { theme } from '@marigold/theme-rui';
 import { MarigoldProvider } from '../Provider/MarigoldProvider';
+import { RouterProvider } from '../RouterProvider/RouterProvider';
 import { ensureOverlayContainer, mockMatchMedia } from '../test.utils';
 import { Sidebar } from './Sidebar';
 import { Rail, RailControlled } from './SidebarRail.stories';
@@ -500,6 +501,35 @@ describe('modified clicks & keyboard activation', () => {
     await user.keyboard(' ');
 
     expect(handlePress).toHaveBeenCalledTimes(2);
+  });
+
+  test('router useHref rewrites the rendered href while navigate gets the raw path', async () => {
+    const navigate = vi.fn();
+    render(
+      <RouterProvider navigate={navigate} useHref={href => `/base${href}`}>
+        <MarigoldProvider theme={theme}>
+          <Sidebar.Provider>
+            <Sidebar>
+              <Sidebar.Rail current="/tickets">
+                <Sidebar.RailItem id="tickets" icon={<i />} href="/tickets">
+                  Tickets
+                </Sidebar.RailItem>
+                <Sidebar.RailItem id="reports" icon={<i />} href="/reports">
+                  Berichte
+                </Sidebar.RailItem>
+              </Sidebar.Rail>
+            </Sidebar>
+          </Sidebar.Provider>
+        </MarigoldProvider>
+      </RouterProvider>
+    );
+    const link = screen.getByRole('link', { name: 'Berichte' });
+
+    expect(link).toHaveAttribute('href', '/base/reports');
+
+    await user.click(link);
+
+    expect(navigate).toHaveBeenCalledWith('/reports', undefined);
   });
 });
 

--- a/packages/components/src/Sidebar/SidebarRail.test.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.test.tsx
@@ -505,6 +505,7 @@ describe('modified clicks & keyboard activation', () => {
   });
 
   test('router useHref rewrites the rendered href while navigate gets the raw path', async () => {
+    // Arrange
     const navigate = vi.fn();
     render(
       <RouterProvider navigate={navigate} useHref={href => `/base${href}`}>
@@ -526,10 +527,13 @@ describe('modified clicks & keyboard activation', () => {
     );
     const link = screen.getByRole('link', { name: 'Berichte' });
 
+    // Assert (rendered href is prefixed)
     expect(link).toHaveAttribute('href', '/base/reports');
 
+    // Act
     await user.click(link);
 
+    // Assert (navigate still receives the unprefixed path)
     expect(navigate).toHaveBeenCalledWith('/reports', undefined);
   });
 });

--- a/packages/components/src/Sidebar/SidebarRail.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, Ref } from 'react';
 import { Focusable } from 'react-aria-components/Focusable';
 import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { isFocusVisible } from '@react-aria/interactions';
-import { handleLinkClick, useRouter } from '@react-aria/utils';
+import { handleLinkClick, useLinkProps, useRouter } from '@react-aria/utils';
 import { cn } from '@marigold/system';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { intlMessages } from '../intl/messages';
@@ -70,6 +70,9 @@ const RailItemLink = ({
   className,
 }: RailItemLinkProps) => {
   const router = useRouter();
+  // Sole source of the rendered href. A raw `href` here would shadow the
+  // router's `useHref`, while `navigate` still wants the untransformed one.
+  const routerLinkProps = useLinkProps({ href: node.href });
 
   // A section is only the current page's ancestor (`true`); a direct-link item
   // that is the page announces `page`. The leaf itself is marked in the panel.
@@ -81,7 +84,7 @@ const RailItemLink = ({
     <Tooltip.Trigger disabled={!collapsed}>
       <Focusable>
         <a
-          href={node.href}
+          {...routerLinkProps}
           role={node.href ? undefined : 'button'}
           aria-current={ariaCurrent}
           data-active={selected || undefined}

--- a/packages/components/src/Sidebar/SidebarRail.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.tsx
@@ -71,9 +71,11 @@ const RailItemLink = ({
 }: RailItemLinkProps) => {
   const router = useRouter();
   // Sole source of the rendered href, since a raw `href` would shadow the
-  // router's `useHref`. Only spread when there is one: without an href
-  // `useLinkProps` yields href="", which would make a section tile a link.
-  const routerLinkProps = useLinkProps({ href: node.href });
+  // router's `useHref`. Pass undefined when there is none, or `useLinkProps`
+  // yields href="", which would make a section tile a link.
+  const routerLinkProps = useLinkProps(
+    node.href ? { href: node.href } : undefined
+  );
 
   // A section is only the current page's ancestor (`true`); a direct-link item
   // that is the page announces `page`. The leaf itself is marked in the panel.
@@ -85,7 +87,7 @@ const RailItemLink = ({
     <Tooltip.Trigger disabled={!collapsed}>
       <Focusable>
         <a
-          {...(node.href ? routerLinkProps : {})}
+          {...routerLinkProps}
           role={node.href ? undefined : 'button'}
           aria-current={ariaCurrent}
           data-active={selected || undefined}

--- a/packages/components/src/Sidebar/SidebarRail.tsx
+++ b/packages/components/src/Sidebar/SidebarRail.tsx
@@ -70,8 +70,9 @@ const RailItemLink = ({
   className,
 }: RailItemLinkProps) => {
   const router = useRouter();
-  // Sole source of the rendered href. A raw `href` here would shadow the
-  // router's `useHref`, while `navigate` still wants the untransformed one.
+  // Sole source of the rendered href, since a raw `href` would shadow the
+  // router's `useHref`. Only spread when there is one: without an href
+  // `useLinkProps` yields href="", which would make a section tile a link.
   const routerLinkProps = useLinkProps({ href: node.href });
 
   // A section is only the current page's ancestor (`true`); a direct-link item
@@ -84,7 +85,7 @@ const RailItemLink = ({
     <Tooltip.Trigger disabled={!collapsed}>
       <Focusable>
         <a
-          {...routerLinkProps}
+          {...(node.href ? routerLinkProps : {})}
           role={node.href ? undefined : 'button'}
           aria-current={ariaCurrent}
           data-active={selected || undefined}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`SidebarLink` (single-column items) and `SidebarRail`'s `RailItemLink` rendered the raw `href` prop directly onto their anchor, which shadowed the value produced by `RouterProvider`'s optional `useHref`. Applications served from a prefix, such as a Next.js `basePath`, ended up with sidebar markup pointing at an unprefixed URL, so middle click and "copy link address" resolved to the wrong page.

`navigate` was never affected and always worked, since `handleLinkClick` reads the raw prop rather than anything `useLinkProps` produces. Both components now let `useLinkProps` supply the rendered href while still handing the unprefixed path to `navigate`, matching how react-aria's own `useLink` is built. Consumers that do not pass `useHref` see no change, because the default leaves the href untouched.

One wrinkle worth a reviewer's eye: `useLinkProps` applies `router.useHref(props?.href ?? '')` unconditionally, so an undefined href comes back as `href=""` rather than being omitted. The second commit therefore only handed the hook an href when one actually exists, which keeps no-href branch triggers and `onPress`-only rail tiles free of the attribute. CI caught that regression on the first commit. The third commit folds that guard into the hook call itself (`useLinkProps(href ? { href } : undefined)`) so the "no href, no attribute" contract lives at one site instead of being enforced by a spread guard in the JSX — `useLinkProps` returns `{}` for an undefined argument, and `router.useHref('')` is called either way, so the hook count and behaviour are unchanged.

These two are the only raw `<a>` elements in `packages/components/src`. Everything else renders through RAC `Link`, which already handled `useHref` correctly.

**This supersedes `507a47b8a`** (the DST-1609 review cleanup), which removed this same pattern from `RailItemLink` on the grounds that it was dead code. That premise was wrong: the spread was never dead, it was shadowed by the raw `href` rendered after it, so "immediately overridden by the raw href" described the bug rather than a reason to drop the spread. DST-1647 was originally filed on that same incorrect premise and has been rewritten to match the real conclusion. Nothing to correct in the changelog — `.changeset/dst-1609-two-level-sidebar.md` is still unreleased and never mentioned the cleanup, so the wrong claim only ever lived in a commit message.

**No visual changes.** Without a `useHref` provider the rendered markup is byte-identical, and only an `href` attribute value can differ. Chromatic ran green on this branch with no visual changes detected, so the Screenshots section is omitted deliberately.

Closes DST-1647

## Test Instructions

1. `pnpm test:unit --project=unit-tests packages/components/src/Sidebar/` — two new tests (one per component) assert both halves of the contract: the anchor renders `/base/...` while `navigate` receives the unprefixed path. Asserting only the DOM attribute would miss a regression that hands the transformed href to `navigate()`.
2. Wrap a sidebar in `<RouterProvider navigate={navigate} useHref={href => '/base' + href}>` and confirm rail tiles, panel items, and the mobile drawer rows all render prefixed hrefs while `navigate` still gets the app-level path.
3. Confirm the no-href cases stay non-links: a branch whose leaves have no `href`, and an `onPress`-only rail tile, should render `role="button"` and no `href` attribute.
4. Storybook → `Components/RouterProvider/WithBasePath` shows the prefixed href next to the path passed to `navigate`.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

