### PR TITLE
refactor(DST-1627): extract shared CalendarBody for Calendar/RangeCalendar layout

### DIFF
--- a/.changeset/dst-1627-shared-calendar-body.md
+++ b/.changeset/dst-1627-shared-calendar-body.md
@@ -1,0 +1,7 @@
+---
+'@marigold/components': patch
+---
+
+refactor(DST-1627): extract a shared `CalendarBody` for the `Calendar`/`RangeCalendar` grid layout
+
+The multi-month and single-month layout markup was duplicated verbatim in `Calendar` and `RangeCalendar`, so every layout tweak had to be made twice and the copies could silently drift. Both components now render that markup through one internal `<CalendarBody>`, which reads the theme classes, visible months, min/max value, disabled state and a new `isRange` flag off the existing `CalendarContext`, keeping the touch pointerup guard (DSTSUP-257) range-only. Pure refactor: the rendered DOM, the styling and the behavior are unchanged.

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -129,6 +129,7 @@ const _Calendar = ({
         minValue,
         maxValue,
         disabled,
+        // No window pointerup commit to guard here, unlike RangeCalendar (DSTSUP-257).
         isRange: false,
       }}
     >

--- a/packages/components/src/Calendar/Calendar.tsx
+++ b/packages/components/src/Calendar/Calendar.tsx
@@ -3,18 +3,9 @@ import type RAC from 'react-aria-components';
 import { Calendar, DateValue } from 'react-aria-components/Calendar';
 import { DatePickerStateContext } from 'react-aria-components/DatePicker';
 import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
-import { CalendarGrid } from './CalendarGrid';
-import { CalendarHeader } from './CalendarHeader';
-import { CalendarListBox } from './CalendarListBox';
+import { CalendarBody } from './CalendarBody';
 import { CalendarPresets, CalendarPresetsShell } from './CalendarPresets';
-import { CalendarContext } from './Context';
-import MonthControls from './MonthControls';
-import MonthListBox from './MonthListBox';
-import YearListBox from './YearListBox';
-import {
-  hasOnlyOneSelectableMonth,
-  hasOnlyOneSelectableYear,
-} from './calendarListBoxSelectableCheck';
+import { CalendarContext, type CalendarDropdownView } from './Context';
 import type { DatePreset } from './presets';
 
 // Props
@@ -79,8 +70,6 @@ export interface CalendarProps extends Omit<
   presets?: readonly DatePreset[];
 }
 
-type ViewMapKeys = 'month' | 'year';
-
 // Component
 // ---------------
 const _Calendar = ({
@@ -98,7 +87,6 @@ const _Calendar = ({
   ...rest
 }: CalendarProps) => {
   const visibleMonths = visibleDuration?.months ?? 1;
-  const isMultiMonth = visibleMonths > 1;
   const hasPresets = !!presets?.length;
 
   const props: RAC.CalendarProps<DateValue> = {
@@ -114,8 +102,10 @@ const _Calendar = ({
 
   const classNames = useClassNames({ component: 'Calendar', size, variant });
 
+  // Lives here, not in <CalendarBody>: a picker's preset view switch unmounts
+  // the body, and an open dropdown has to survive that.
   const [selectedDropdown, setSelectedDropdown] = useState<
-    ViewMapKeys | undefined
+    CalendarDropdownView | undefined
   >();
 
   const pickerState = use(DatePickerStateContext);
@@ -124,66 +114,11 @@ const _Calendar = ({
     'calendar'
   );
 
-  const ViewMap = {
-    month: <MonthListBox setSelectedDropdown={setSelectedDropdown} />,
-    year: <YearListBox setSelectedDropdown={setSelectedDropdown} />,
-  } satisfies { [key in ViewMapKeys]: React.JSX.Element };
-
-  const content = isMultiMonth ? (
-    <div className={classNames.calendarContainer}>
-      {[...Array(visibleMonths).keys()].map(i => (
-        <div key={i} className={classNames.calendarMonth}>
-          <CalendarHeader
-            monthOffset={i}
-            showPrevious={i === 0}
-            showNext={i === visibleMonths - 1}
-          />
-          <CalendarGrid offset={{ months: i }} />
-        </div>
-      ))}
-    </div>
-  ) : (
-    <>
-      <div
-        className={cn(
-          'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
-          selectedDropdown && 'pointer-events-auto opacity-100'
-        )}
-      >
-        {ViewMap[selectedDropdown as ViewMapKeys]}
-      </div>
-
-      <div
-        className={cn(
-          'flex flex-col',
-          selectedDropdown && 'pointer-events-none opacity-0'
-        )}
-      >
-        <div className="mb-6 flex items-center justify-between gap-4 max-sm:gap-2">
-          <div className="flex w-fit gap-4 max-sm:gap-3">
-            <CalendarListBox
-              key="month"
-              type="month"
-              isDisabled={
-                hasOnlyOneSelectableMonth(minValue, maxValue) ||
-                props.isDisabled
-              }
-              setSelectedDropdown={setSelectedDropdown}
-            />
-            <CalendarListBox
-              key="year"
-              type="year"
-              isDisabled={
-                hasOnlyOneSelectableYear(minValue, maxValue) || props.isDisabled
-              }
-              setSelectedDropdown={setSelectedDropdown}
-            />
-          </div>
-          <MonthControls />
-        </div>
-        <CalendarGrid />
-      </div>
-    </>
+  const body = (
+    <CalendarBody
+      selectedDropdown={selectedDropdown}
+      setSelectedDropdown={setSelectedDropdown}
+    />
   );
 
   return (
@@ -194,6 +129,7 @@ const _Calendar = ({
         minValue,
         maxValue,
         disabled,
+        isRange: false,
       }}
     >
       <Calendar
@@ -217,10 +153,10 @@ const _Calendar = ({
               <CalendarPresets presets={presets} {...presetProps} />
             )}
           >
-            {content}
+            {body}
           </CalendarPresetsShell>
         ) : (
-          content
+          body
         )}
       </Calendar>
     </CalendarContext>

--- a/packages/components/src/Calendar/CalendarBody.tsx
+++ b/packages/components/src/Calendar/CalendarBody.tsx
@@ -15,10 +15,7 @@ import {
 // Props
 // ---------------
 interface CalendarBodyProps {
-  /**
-   * Which month/year dropdown is open, if any. Owned by the calendar so it
-   * outlives a preset view switch, which unmounts this component.
-   */
+  /** Which month/year dropdown is open, if any. Owned by the parent, see there for why. */
   selectedDropdown?: CalendarDropdownView;
   setSelectedDropdown: Dispatch<
     SetStateAction<CalendarDropdownView | undefined>

--- a/packages/components/src/Calendar/CalendarBody.tsx
+++ b/packages/components/src/Calendar/CalendarBody.tsx
@@ -1,0 +1,124 @@
+import { type Dispatch, type SetStateAction, useCallback } from 'react';
+import { cn } from '@marigold/system';
+import { CalendarGrid } from './CalendarGrid';
+import { CalendarHeader } from './CalendarHeader';
+import { CalendarListBox } from './CalendarListBox';
+import { type CalendarDropdownView, useCalendarContext } from './Context';
+import MonthControls from './MonthControls';
+import MonthListBox from './MonthListBox';
+import YearListBox from './YearListBox';
+import {
+  hasOnlyOneSelectableMonth,
+  hasOnlyOneSelectableYear,
+} from './calendarListBoxSelectableCheck';
+
+// Props
+// ---------------
+interface CalendarBodyProps {
+  /**
+   * Which month/year dropdown is open, if any. Owned by the calendar so it
+   * outlives a preset view switch, which unmounts this component.
+   */
+  selectedDropdown?: CalendarDropdownView;
+  setSelectedDropdown: Dispatch<
+    SetStateAction<CalendarDropdownView | undefined>
+  >;
+}
+
+// Component
+// ---------------
+/**
+ * Grid layout shared by `Calendar` and `RangeCalendar`. Renders unwrapped, so
+ * the dropdown overlay keeps positioning against the calendar root.
+ */
+export const CalendarBody = ({
+  selectedDropdown,
+  setSelectedDropdown,
+}: CalendarBodyProps) => {
+  const { classNames, visibleMonths, minValue, maxValue, disabled, isRange } =
+    useCalendarContext();
+
+  // Range only: `useRangeCalendar` commits an in-progress range on any window
+  // `pointerup` outside a button. `usePress` listens on `document`, that commit on
+  // `window`, so stopping overlay pointerups at `document` (not the node, not
+  // `window`) keeps press handling alive and never reaches the commit (DSTSUP-257).
+  // Native listener because react-aria's is native too.
+  const dropdownOverlayRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !isRange) return;
+      const ownerDocument = node.ownerDocument;
+      const stop = (event: PointerEvent) => {
+        if (node.contains(event.target as Node | null)) event.stopPropagation();
+      };
+      ownerDocument.addEventListener('pointerup', stop);
+      return () => ownerDocument.removeEventListener('pointerup', stop);
+    },
+    [isRange]
+  );
+
+  if (visibleMonths > 1) {
+    return (
+      <div className={classNames.calendarContainer}>
+        {[...Array(visibleMonths).keys()].map(i => (
+          <div key={i} className={classNames.calendarMonth}>
+            <CalendarHeader
+              monthOffset={i}
+              showPrevious={i === 0}
+              showNext={i === visibleMonths - 1}
+            />
+            <CalendarGrid offset={{ months: i }} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        ref={dropdownOverlayRef}
+        className={cn(
+          'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
+          selectedDropdown && 'pointer-events-auto opacity-100'
+        )}
+      >
+        {selectedDropdown === 'month' && (
+          <MonthListBox setSelectedDropdown={setSelectedDropdown} />
+        )}
+        {selectedDropdown === 'year' && (
+          <YearListBox setSelectedDropdown={setSelectedDropdown} />
+        )}
+      </div>
+
+      <div
+        className={cn(
+          'flex flex-col',
+          selectedDropdown && 'pointer-events-none opacity-0'
+        )}
+      >
+        <div className="mb-6 flex items-center justify-between gap-4 max-sm:gap-2">
+          <div className="flex w-fit gap-4 max-sm:gap-3">
+            <CalendarListBox
+              key="month"
+              type="month"
+              isDisabled={
+                hasOnlyOneSelectableMonth(minValue, maxValue) || disabled
+              }
+              setSelectedDropdown={setSelectedDropdown}
+            />
+            <CalendarListBox
+              key="year"
+              type="year"
+              isDisabled={
+                hasOnlyOneSelectableYear(minValue, maxValue) || disabled
+              }
+              setSelectedDropdown={setSelectedDropdown}
+            />
+          </div>
+          <MonthControls />
+        </div>
+        <CalendarGrid />
+      </div>
+    </>
+  );
+};

--- a/packages/components/src/Calendar/CalendarListBox.tsx
+++ b/packages/components/src/Calendar/CalendarListBox.tsx
@@ -1,13 +1,19 @@
-import { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { cn } from '@marigold/system';
 import { ChevronsVertical } from '../icons/ChevronsVertical';
-import { useCalendarContext, useCalendarOrRangeState } from './Context';
+import {
+  type CalendarDropdownView,
+  useCalendarContext,
+  useCalendarOrRangeState,
+} from './Context';
 import { useFormattedMonths } from './useFormattedMonths';
 
 interface CalendarButtonListBoxProps {
-  type: string;
+  type: CalendarDropdownView;
   isDisabled?: boolean;
-  setSelectedDropdown: Dispatch<SetStateAction<string | undefined>>;
+  setSelectedDropdown: Dispatch<
+    SetStateAction<CalendarDropdownView | undefined>
+  >;
 }
 
 export const CalendarListBox = ({

--- a/packages/components/src/Calendar/Context.tsx
+++ b/packages/components/src/Calendar/Context.tsx
@@ -5,8 +5,10 @@ import { RangeCalendarStateContext } from 'react-aria-components/RangeCalendar';
 import type { ComponentClassNames } from '@marigold/system';
 
 export type CalendarSharedClassNames =
-  | ComponentClassNames<'Calendar'>
-  | ComponentClassNames<'RangeCalendar'>;
+  ComponentClassNames<'Calendar'> | ComponentClassNames<'RangeCalendar'>;
+
+/** Which of the calendar header's dropdowns is open, if any. */
+export type CalendarDropdownView = 'month' | 'year';
 
 export interface CalendarContextValue {
   classNames: CalendarSharedClassNames;
@@ -14,6 +16,8 @@ export interface CalendarContextValue {
   minValue?: DateValue | null;
   maxValue?: DateValue | null;
   disabled?: boolean;
+  /** Whether this is a `<RangeCalendar>`. Statically known by both parents. */
+  isRange: boolean;
 }
 
 export const CalendarContext = createContext<CalendarContextValue | null>(null);

--- a/packages/components/src/Calendar/Context.tsx
+++ b/packages/components/src/Calendar/Context.tsx
@@ -7,7 +7,6 @@ import type { ComponentClassNames } from '@marigold/system';
 export type CalendarSharedClassNames =
   ComponentClassNames<'Calendar'> | ComponentClassNames<'RangeCalendar'>;
 
-/** Which of the calendar header's dropdowns is open, if any. */
 export type CalendarDropdownView = 'month' | 'year';
 
 export interface CalendarContextValue {

--- a/packages/components/src/Calendar/MonthListBox.tsx
+++ b/packages/components/src/Calendar/MonthListBox.tsx
@@ -1,10 +1,12 @@
-import { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { CalendarMonthPicker } from 'react-aria-components/Calendar';
-import { useCalendarOrRangeState } from './Context';
+import { type CalendarDropdownView, useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 
 interface MonthDropdownProps {
-  setSelectedDropdown: Dispatch<SetStateAction<string | undefined>>;
+  setSelectedDropdown: Dispatch<
+    SetStateAction<CalendarDropdownView | undefined>
+  >;
 }
 
 const MonthListBox = ({ setSelectedDropdown }: MonthDropdownProps) => {

--- a/packages/components/src/Calendar/YearListBox.tsx
+++ b/packages/components/src/Calendar/YearListBox.tsx
@@ -1,10 +1,12 @@
-import { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { CalendarYearPicker } from 'react-aria-components';
-import { useCalendarOrRangeState } from './Context';
+import { type CalendarDropdownView, useCalendarOrRangeState } from './Context';
 import { ListBox } from './ListBox';
 
 interface YearDropdownProps {
-  setSelectedDropdown: Dispatch<SetStateAction<string | undefined>>;
+  setSelectedDropdown: Dispatch<
+    SetStateAction<CalendarDropdownView | undefined>
+  >;
 }
 
 const YearListBox = ({ setSelectedDropdown }: YearDropdownProps) => {

--- a/packages/components/src/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/DatePicker/DatePicker.stories.tsx
@@ -453,3 +453,22 @@ PresetsMobile.test(
     ).toHaveAttribute('aria-selected', 'true');
   }
 );
+
+PresetsMobile.test(
+  'keeps an open month dropdown across a trip to the preset list',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button'));
+    const tray = await canvas.findByRole('dialog');
+    await within(tray).findByRole('grid');
+
+    await userEvent.click(within(tray).getByRole('button', { name: 'Mar' }));
+    await userEvent.click(
+      within(tray).getByRole('button', { name: 'Quick selection' })
+    );
+    await userEvent.click(within(tray).getByRole('button', { name: 'Back' }));
+
+    await expect(
+      within(tray).getByRole('listbox', { name: 'month' })
+    ).toBeVisible();
+  }
+);

--- a/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/components/src/DateRangePicker/DateRangePicker.stories.tsx
@@ -438,3 +438,22 @@ PresetsMobile.test(
     ).toHaveAttribute('aria-selected', 'true');
   }
 );
+
+PresetsMobile.test(
+  'keeps an open month dropdown across a trip to the preset list',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button'));
+    const tray = await canvas.findByRole('dialog');
+    await within(tray).findByRole('grid');
+
+    await userEvent.click(within(tray).getByRole('button', { name: 'Mar' }));
+    await userEvent.click(
+      within(tray).getByRole('button', { name: 'Quick selection' })
+    );
+    await userEvent.click(within(tray).getByRole('button', { name: 'Back' }));
+
+    await expect(
+      within(tray).getByRole('listbox', { name: 'month' })
+    ).toBeVisible();
+  }
+);

--- a/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.stories.tsx
@@ -215,6 +215,30 @@ Basic.test(
   }
 );
 
+Basic.test(
+  'does not commit an in-progress range when tapping a month',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: { onChange: fn() },
+  },
+  async ({ args, canvas, userEvent }) => {
+    const tap = (target: Element) =>
+      userEvent.pointer([{ keys: '[TouchA>]', target }, { keys: '[/TouchA]' }]);
+
+    // Anchor an in-progress range: start picked, end not yet.
+    await tap(canvas.getByLabelText(/Tuesday, August 12, 2025/i));
+
+    await expect(args.onChange).not.toHaveBeenCalled();
+
+    await tap(canvas.getByRole('button', { name: 'Aug' }));
+    const monthOptions = canvas.getByRole('listbox', { name: 'month' });
+    await tap(within(monthOptions).getByRole('option', { name: /Mar/i }));
+
+    // The in-progress range must survive the trip (DSTSUP-257).
+    await expect(args.onChange).not.toHaveBeenCalled();
+  }
+);
+
 export const Disabled = Basic.extend({
   args: {
     disabled: true,

--- a/packages/components/src/RangeCalendar/RangeCalendar.tsx
+++ b/packages/components/src/RangeCalendar/RangeCalendar.tsx
@@ -1,4 +1,4 @@
-import { type ContextType, use, useCallback, useMemo, useState } from 'react';
+import { type ContextType, use, useMemo, useState } from 'react';
 import type RAC from 'react-aria-components';
 import { DateRangePickerStateContext } from 'react-aria-components/DateRangePicker';
 import { FieldErrorContext } from 'react-aria-components/FieldError';
@@ -7,21 +7,15 @@ import {
   DateValue,
 } from 'react-aria-components/RangeCalendar';
 import { WidthProp, cn, createWidthVar, useClassNames } from '@marigold/system';
-import { CalendarGrid } from '../Calendar/CalendarGrid';
-import { CalendarHeader } from '../Calendar/CalendarHeader';
-import { CalendarListBox } from '../Calendar/CalendarListBox';
+import { CalendarBody } from '../Calendar/CalendarBody';
 import {
   CalendarPresetsShell,
   RangeCalendarPresets,
 } from '../Calendar/CalendarPresets';
-import { CalendarContext } from '../Calendar/Context';
-import MonthControls from '../Calendar/MonthControls';
-import MonthListBox from '../Calendar/MonthListBox';
-import YearListBox from '../Calendar/YearListBox';
 import {
-  hasOnlyOneSelectableMonth,
-  hasOnlyOneSelectableYear,
-} from '../Calendar/calendarListBoxSelectableCheck';
+  CalendarContext,
+  type CalendarDropdownView,
+} from '../Calendar/Context';
 import type { DateRangePreset } from '../Calendar/presets';
 import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 
@@ -97,8 +91,6 @@ export interface RangeCalendarProps<T extends DateValue = DateValue>
   presets?: readonly DateRangePreset[];
 }
 
-type ViewMapKeys = 'month' | 'year';
-
 const EMPTY_VALIDITY_STATE: ValidityState = {
   badInput: false,
   customError: false,
@@ -134,7 +126,6 @@ const _RangeCalendar = <T extends DateValue>({
   ...rest
 }: RangeCalendarProps<T>) => {
   const visibleMonths = visibleDuration.months;
-  const isMultiMonth = visibleMonths > 1;
   const hasPresets = !!presets?.length;
 
   const props: RAC.RangeCalendarProps<T> = {
@@ -156,8 +147,10 @@ const _RangeCalendar = <T extends DateValue>({
     variant,
   });
 
+  // Lives here, not in <CalendarBody>: a picker's preset view switch unmounts
+  // the body, and an open dropdown has to survive that.
   const [selectedDropdown, setSelectedDropdown] = useState<
-    ViewMapKeys | undefined
+    CalendarDropdownView | undefined
   >();
 
   // Non-null exactly when this calendar is the one embedded in a
@@ -169,29 +162,6 @@ const _RangeCalendar = <T extends DateValue>({
   const [pickerView, setPickerView] = useState<'calendar' | 'presets'>(
     'calendar'
   );
-
-  // react-aria's `useRangeCalendar` commits an in-progress range on any window
-  // `pointerup` that isn't on a button (our role="option" items included). The key
-  // detail: `usePress` listens for the touch press-end on `document`, while the
-  // range-commit listens on `window`. We stop overlay pointerups at `document` (not
-  // the node, not `window`) so both `usePress` and our guard still fire, but the
-  // `window` range-commit never does — which is exactly what keeps touch selection
-  // working (DSTSUP-257). Native listener because react-aria also listens natively,
-  // outside React's events.
-  const dropdownOverlayRef = useCallback((node: HTMLDivElement | null) => {
-    if (!node) return;
-    const ownerDocument = node.ownerDocument;
-    const stop = (event: PointerEvent) => {
-      if (node.contains(event.target as Node | null)) event.stopPropagation();
-    };
-    ownerDocument.addEventListener('pointerup', stop);
-    return () => ownerDocument.removeEventListener('pointerup', stop);
-  }, []);
-
-  const ViewMap = {
-    month: <MonthListBox setSelectedDropdown={setSelectedDropdown} />,
-    year: <YearListBox setSelectedDropdown={setSelectedDropdown} />,
-  } satisfies { [key in ViewMapKeys]: React.JSX.Element };
 
   const fieldErrorValue = useMemo<ContextType<typeof FieldErrorContext>>(
     () =>
@@ -205,62 +175,11 @@ const _RangeCalendar = <T extends DateValue>({
     [error]
   );
 
-  const content = isMultiMonth ? (
-    <div className={classNames.calendarContainer}>
-      {[...Array(visibleMonths).keys()].map(i => (
-        <div key={i} className={classNames.calendarMonth}>
-          <CalendarHeader
-            monthOffset={i}
-            showPrevious={i === 0}
-            showNext={i === visibleMonths - 1}
-          />
-          <CalendarGrid offset={{ months: i }} />
-        </div>
-      ))}
-    </div>
-  ) : (
-    <>
-      <div
-        ref={dropdownOverlayRef}
-        className={cn(
-          'pointer-events-none absolute top-1/2 left-0 w-full -translate-y-1/2 opacity-0',
-          selectedDropdown && 'pointer-events-auto opacity-100'
-        )}
-      >
-        {ViewMap[selectedDropdown as ViewMapKeys]}
-      </div>
-
-      <div
-        className={cn(
-          'flex flex-col',
-          selectedDropdown && 'pointer-events-none opacity-0'
-        )}
-      >
-        <div className="mb-6 flex items-center justify-between gap-4 max-sm:gap-2">
-          <div className="flex w-fit gap-4 max-sm:gap-3">
-            <CalendarListBox
-              key="month"
-              type="month"
-              isDisabled={
-                hasOnlyOneSelectableMonth(minValue, maxValue) ||
-                props.isDisabled
-              }
-              setSelectedDropdown={setSelectedDropdown}
-            />
-            <CalendarListBox
-              key="year"
-              type="year"
-              isDisabled={
-                hasOnlyOneSelectableYear(minValue, maxValue) || props.isDisabled
-              }
-              setSelectedDropdown={setSelectedDropdown}
-            />
-          </div>
-          <MonthControls />
-        </div>
-        <CalendarGrid />
-      </div>
-    </>
+  const body = (
+    <CalendarBody
+      selectedDropdown={selectedDropdown}
+      setSelectedDropdown={setSelectedDropdown}
+    />
   );
 
   return (
@@ -271,6 +190,7 @@ const _RangeCalendar = <T extends DateValue>({
         minValue,
         maxValue,
         disabled,
+        isRange: true,
       }}
     >
       <FieldErrorContext value={fieldErrorValue}>
@@ -314,10 +234,10 @@ const _RangeCalendar = <T extends DateValue>({
                   <RangeCalendarPresets presets={presets} {...presetProps} />
                 )}
               >
-                {content}
+                {body}
               </CalendarPresetsShell>
             ) : (
-              content
+              body
             )}
           </AriaRangeCalendar>
         </FieldBase>


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | style | perf | build | ci | revert
-->

# Description

The multi-month and single-month layout markup was duplicated verbatim in `Calendar` and `RangeCalendar`, so every layout tweak had to be made twice and the two copies could silently drift. Both components now render that markup through one internal `<CalendarBody>`, which reads the theme classes, visible months, min/max value, disabled state and a required `isRange` flag off the existing `CalendarContext`.

The extraction also centralizes the dropdown view type. `main` declared `type ViewMapKeys = 'month' | 'year'` separately in both files and needed a `selectedDropdown as ViewMapKeys` cast at each use site. That becomes one `CalendarDropdownView` in `Context.tsx`, adopted by the three dropdown components in place of their looser `string` setter types, and the cast is gone.

Pure refactor: no visual, DOM or behavior change. The duplication predates #5631 and was filed as a follow-up rather than expanding that PR's scope.

Two decisions worth a reviewer's attention:

- **`isRange` is passed explicitly** rather than derived from `RangeCalendarStateContext`, because subscribing to RAC's state context would defeat the element-identity render bailout. It exists to keep the touch pointerup guard (DSTSUP-257) range-only, and it is a required field so a future provider cannot omit it and silently drop that guard.

  The flag's two directions are not symmetric, which `73ebe4e9` records in a comment at the `isRange: false` site. Omitting the guard for `RangeCalendar` reintroduces DSTSUP-257, and `RangeCalendar`'s "does not commit an in-progress range when tapping a month" story test covers that: flipping `isRange` to `false` kills that test and no other. A wrong `true` on the non-range `Calendar` has no observable effect, because the guard only stops pointerup from reaching `window` and plain `useCalendar` has no window range-commit to suppress. Flipping it to `true` leaves all 69 story tests and 97 unit tests passing, so there is no black-box assertion to add for that direction.
- **`selectedDropdown` stays owned by both parents** instead of moving into `<CalendarBody>`, because a picker's preset view switch unmounts the body and an open dropdown has to survive that. Both `DatePicker` and `DateRangePicker` now carry a `PresetsMobile` story test for it.

Closes DST-1627

## Screenshots / Preview

No visual change is expected anywhere, so a Before/After table would be misleading. The proof for this PR is a **zero-diff Chromatic run** rather than screenshots.

[Chromatic build 190](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=190) on `80973b9b6`, the current head: **"No changes were found in this build."** 742 stories across 97 components, 64 snapshots captured via TurboSnap. ([Build 188](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=188) was the same result on the earlier `73ebe4e9`.)

## Test Instructions

1. `pnpm sb`, then open `Components/Calendar` and `Components/RangeCalendar`. Confirm the single-month and multi-month (`visibleDuration`) layouts look unchanged, and that the month and year dropdowns still open, select and close.
2. In `RangeCalendar`, using touch or emulated touch, tap a start date to begin a range, then open the month dropdown and tap a month. The in-progress range must not commit (DSTSUP-257). The `Basic` story test "does not commit an in-progress range when tapping a month" covers this. Anchoring the range first is what makes the guard observable, so the earlier "Commits a month selection via touch" test does not cover it.
3. At phone width in `DatePicker` and `DateRangePicker` with presets, open the month dropdown, tap "Quick selection", then tap "Back". The dropdown must still be open.
4. `pnpm test:sb` and `pnpm test:unit`.

Verified locally: `typecheck:only` clean, `eslint` 0 errors, 69 story tests and 97 unit tests passing across Calendar, RangeCalendar, DatePicker and DateRangePicker. The new test was mutation-checked both ways, failing with the guard removed and passing with it in place.

## Breaking Changes

No.

`CalendarContextValue.isRange` changed from optional to required, but that interface is internal and is not exported from `packages/components/src/index.ts`, so no consumer can observe it.

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [x] Visual regression tests updated (for UI changes), see [build 190](https://www.chromatic.com/build?appId=6a0c09c122d3a0a4a6da5d41&number=190), zero diff
- [x] Changeset added (`pnpm changeset`)

The three blank items, left blank rather than ticked because none of them happened:

- **Unit tests**: no new unit test. The extraction is covered by the existing 97 unit tests plus three new story tests, the two `PresetsMobile` dropdown-survival ones and the `RangeCalendar` range-commit regression, and the Coverage Report check passes.
- **Component documentation**: `<CalendarBody>` is internal and is not exported from `packages/components/src/index.ts`. No public API changed, so the `Calendar` and `RangeCalendar` docs are untouched.
- **Accessibility**: no new or changed interactive component. Every role, accessible name and focus behavior comes from subcomponents this PR does not touch (`CalendarGrid`, `CalendarHeader`, `CalendarListBox`, `MonthControls`), and the only addition to the rendered tree is a `ref` on the existing overlay `div`. So there was nothing new to audit against the APG.
