### PR TITLE
docs(DST-1691): move v18 release notes to 11 Aug and fold in later changesets

### DIFF
--- a/MIGRATION-v18.md
+++ b/MIGRATION-v18.md
@@ -943,5 +943,5 @@ declares a `style` export condition. Import `theme.css` for a full app or
 
 ---
 
-_Source of truth for this guide: the [v18.0.0 release notes](https://www.marigold-ui.io/releases/blog/release-2026-08-17),
+_Source of truth for this guide: the [v18.0.0 release notes](https://www.marigold-ui.io/releases/blog/release-2026-08-11),
 the `marigold migrate v18` codemod, and `marigold docs <Component>`._

--- a/docs/content/releases/blog/release-2026-08-11.mdx
+++ b/docs/content/releases/blog/release-2026-08-11.mdx
@@ -1,6 +1,6 @@
 ---
 title: Marigold v18.0.0
-date: 2026-08-17
+date: 2026-08-11
 type: Blog
 changed:
   - foundations/token-overview
@@ -63,6 +63,7 @@ changed:
   - components/content/section-message
   - components/content/loader
   - components/hooks-and-utils/useLandmark
+  - components/application/routerprovider
   - patterns/user-input/forms
   - patterns/user-input/bulk-actions
   - patterns/user-input/filter
@@ -114,19 +115,19 @@ export const Sw = ({ c }) => (
   />
 );
 
-| Step | Old (`stone`)                | New (`charcoal`)                                         | Typical role                      |
-| ---- | ---------------------------- | -------------------------------------------------------- | --------------------------------- |
-| 50   | <Sw c="#fafaf9" /> `#fafaf9` | <Sw c="oklch(0.985 0.002 54)" /> `oklch(0.985 0.002 54)` | Subtle tint, `primary-foreground` |
-| 100  | <Sw c="#f5f5f4" /> `#f5f5f4` | <Sw c="oklch(0.965 0.003 54)" /> `oklch(0.965 0.003 54)` | Page background                   |
-| 200  | <Sw c="#e7e5e4" /> `#e7e5e4` | <Sw c="oklch(0.92 0.004 54)" /> `oklch(0.92 0.004 54)`   | Hover, `disabled-surface`         |
-| 300  | <Sw c="#d6d3d1" /> `#d6d3d1` | <Sw c="oklch(0.86 0.005 54)" /> `oklch(0.86 0.005 54)`   | Borders, control fill, selected   |
-| 400  | <Sw c="#a8a29e" /> `#a8a29e` | <Sw c="oklch(0.74 0.006 54)" /> `oklch(0.74 0.006 54)`   | Disabled text                     |
-| 500  | <Sw c="#78716c" /> `#78716c` | <Sw c="oklch(0.62 0.007 54)" /> `oklch(0.62 0.007 54)`   | -                                 |
-| 600  | <Sw c="#57534e" /> `#57534e` | <Sw c="oklch(0.52 0.008 54)" /> `oklch(0.52 0.008 54)`   | Focus ring, `secondary` text      |
-| 700  | <Sw c="#44403c" /> `#44403c` | <Sw c="oklch(0.42 0.008 54)" /> `oklch(0.42 0.008 54)`   | -                                 |
-| 800  | <Sw c="#292524" /> `#292524` | <Sw c="oklch(0.32 0.008 54)" /> `oklch(0.32 0.008 54)`   | -                                 |
-| 900  | <Sw c="#1c1917" /> `#1c1917` | <Sw c="oklch(0.22 0.008 54)" /> `oklch(0.22 0.008 54)`   | Primary text                      |
-| 950  | <Sw c="#0c0a09" /> `#0c0a09` | <Sw c="oklch(0.15 0.008 54)" /> `oklch(0.15 0.008 54)`   | Primary action, scrollbar hover   |
+| Step | Old (`stone`)                | New (`charcoal`)                                         | Typical role                                               |
+| ---- | ---------------------------- | -------------------------------------------------------- | ---------------------------------------------------------- |
+| 50   | <Sw c="#fafaf9" /> `#fafaf9` | <Sw c="oklch(0.985 0.002 54)" /> `oklch(0.985 0.002 54)` | Subtle tint, `primary-foreground`                          |
+| 100  | <Sw c="#f5f5f4" /> `#f5f5f4` | <Sw c="oklch(0.965 0.003 54)" /> `oklch(0.965 0.003 54)` | Page background                                            |
+| 200  | <Sw c="#e7e5e4" /> `#e7e5e4` | <Sw c="oklch(0.92 0.004 54)" /> `oklch(0.92 0.004 54)`   | Hover, `disabled-surface`                                  |
+| 300  | <Sw c="#d6d3d1" /> `#d6d3d1` | <Sw c="oklch(0.86 0.005 54)" /> `oklch(0.86 0.005 54)`   | Selected state, disabled border                            |
+| 400  | <Sw c="#a8a29e" /> `#a8a29e` | <Sw c="oklch(0.74 0.006 54)" /> `oklch(0.74 0.006 54)`   | Disabled text                                              |
+| 500  | <Sw c="#78716c" /> `#78716c` | <Sw c="oklch(0.62 0.007 54)" /> `oklch(0.62 0.007 54)`   | -                                                          |
+| 600  | <Sw c="#57534e" /> `#57534e` | <Sw c="oklch(0.52 0.008 54)" /> `oklch(0.52 0.008 54)`   | Focus ring, `secondary` text                               |
+| 700  | <Sw c="#44403c" /> `#44403c` | <Sw c="oklch(0.42 0.008 54)" /> `oklch(0.42 0.008 54)`   | -                                                          |
+| 800  | <Sw c="#292524" /> `#292524` | <Sw c="oklch(0.32 0.008 54)" /> `oklch(0.32 0.008 54)`   | -                                                          |
+| 900  | <Sw c="#1c1917" /> `#1c1917` | <Sw c="oklch(0.22 0.008 54)" /> `oklch(0.22 0.008 54)`   | Primary text                                               |
+| 950  | <Sw c="#0c0a09" /> `#0c0a09` | <Sw c="oklch(0.15 0.008 54)" /> `oklch(0.15 0.008 54)`   | Primary action, boundary and track alphas, scrollbar hover |
 
 The new scale is more even across the light end (50 → 300), which gives more room for subtle UI layers on white surfaces, and it lands slightly cooler at the dark end so that body text reads with less warm cast. Full reference lives on the new [Token Overview](/foundations/token-overview) page.
 
@@ -159,6 +160,7 @@ If you read these values directly as CSS custom properties (`var(--color-brand)`
 
 Additional tokens join the semantic set to cover roles that were previously expressed with raw utility classes:
 
+- **`control`**: the resting fill of an unselected control track, and only that: the `<Switch>` groove, the `<SegmentedControl>` track, the `<Slider>` rail. Bordered controls (inputs, selects) sit on `surface` and use `control-border`. It resolves to `charcoal-950` at 16% rather than a palette step, so a track holds the same contrast on a white Card, the gray page ground, a `muted` fill, or a hovered table row, where a fixed lightness drifts. If you use `bg-control` yourself, note that it is translucent: two stacked elements that both carry it composite into a darker track than the token specifies, and anything painting a translucent edge over a track has to account for the track underneath.
 - **`disabled-surface`**: background for disabled control surfaces (switch tracks, selected-but-disabled states, inert chips). Resolves to `charcoal-200` in the default theme.
 - **`overlay-backdrop`**: the scrim behind modals, drawers, and trays. Previously the backdrop was styled with a raw `bg-black/50`. Routing it through a token lets themes tune both the color and the opacity.
 - **`surface-border`** and **`control-border`**: the two boundary tokens of the new elevation model (see _Design_ below). `--color-border` narrows to structural lines only (dividers, grid lines, table rules).
@@ -965,6 +967,9 @@ If you maintain a custom theme, the `Menu` entry now also requires a `keyboard` 
 - **`<Panel.Collapsible>` caret parity.** The collapsible header caret now renders at 16px in `text-secondary`, matching the Accordion chevron, with the color themeable via a new `collapsibleIcon` slot.
 - **Slider thumb clipping.** The `<Slider>` thumb is centered on the track position, so at its min and max values it overhung the track ends by half its width, and scroll containers such as `Drawer.Content` sliced the overhang off into a half circle. The track is now inset by half the thumb width so the thumb always stays inside the Slider's own box.
 - **Date presets in trays.** The preset quick-selection rows now span edge-to-edge on small screens and line up with the tray's navigation row, instead of sitting inset by the listbox's focus-ring gutter.
+- **Slider rail token.** The `<Slider>` rail used `bg-border`, the token for structural lines, where the `<Switch>` groove and the `<SegmentedControl>` track both use `bg-control`. It was also painted on two exactly-overlapping elements, so the translucent fill composited with itself and rendered at roughly twice the specified density. The redundant inner element is gone, the `SliderTrack` itself is the rail, and geometry is unchanged.
+- **Long unbreakable option labels.** A label with no break opportunity (one long word) set the automatic minimum of a list item's label track to its own width and pushed the item out of a narrow `<Select>`, `<ComboBox>`, `<Autocomplete>`, `<TagField>`, `<ListBox>`, or the date pickers' preset list. Items now break anywhere, matching how labels with spaces already wrapped.
+- **`useHref` in sidebar links.** `<Sidebar.Item>` and `<Sidebar.RailItem>` rendered the raw `href` prop onto their anchor, which shadowed the value produced by `RouterProvider`'s optional `useHref`. Apps served from a prefix, such as a Next.js `basePath`, ended up with sidebar markup pointing at unprefixed URLs, so middle click and "copy link address" resolved to the wrong page. Both now render the transformed href and keep handing the unprefixed path to `navigate`, matching how React Aria's own `useLink` behaves. Consumers that do not pass `useHref` see no change.
 
 ## Docs and examples
 
@@ -1100,7 +1105,7 @@ Tailwind v4's CSS resolver uses `conditionNames: ["style"]`. Bare `.css` export 
 ## Dependency updates
 
 - **React 19** is now the required baseline (see _Before you upgrade_).
-- **`react-aria-components`, `@react-aria/*`, `@react-stately/*`, `@react-types/*`, and `@internationalized/*`** are bumped to their latest versions. Most consumers do not need to do anything. If you import directly from `react-aria-components`, re-read the [react-aria changelog](https://github.com/adobe/react-spectrum/releases) for the version range.
+- **`react-aria-components` moves to 1.20.0**, which pins `react-aria` 3.51.0 and `react-stately` 3.49.0, with the `@react-aria/*`, `@react-stately/*`, `@react-types/*`, and `@internationalized/*` floors lifted to match. There is no API change in Marigold components. You pick up the upstream fixes, including Table focus restoration, `FocusScope` restore-without-scrolling, and DatePicker focus handling in Firefox. If you import directly from `react-aria-components`, re-read the [react-aria changelog](https://github.com/adobe/react-spectrum/releases) for the version range.
 - **`react-select`** is no longer a dependency. `<Multiselect>` was the only component pulling it in, and removing it shrinks the `@marigold/components` bundle for every app that had already migrated to `<TagField>`.
 
 ---

--- a/docs/content/releases/blog/release-2026-08-11.mdx
+++ b/docs/content/releases/blog/release-2026-08-11.mdx
@@ -1,5 +1,5 @@
 ---
-title: Marigold v18.0.0
+title: Marigold v18.0.0 (rc)
 date: 2026-08-11
 type: Blog
 changed:

--- a/docs/content/releases/blog/release-2026-08-11.mdx
+++ b/docs/content/releases/blog/release-2026-08-11.mdx
@@ -78,8 +78,16 @@ And this release opens that chapter loudly. v18 is by far the biggest release we
 It is a lot. Take your time with the breaking changes below. They all point in the same direction, and the app you end up with will be simpler for it.
 
 <Callout title="Before you upgrade" type="warning">
-  Marigold v18 requires React 19. If you are still on React 18, upgrade React
-  first, verify your app still builds, then bump Marigold.
+  v18.0.0 is currently a **release candidate**. It publishes to the `rc`
+  dist-tag, so a plain `npm install @marigold/components` still resolves v17.
+  Install it explicitly with `@marigold/components@rc`. Everything below
+  describes the release as it stands, and we do not expect further breaking
+  changes, but the token and design work is still settling, so small visual
+  adjustments are possible before the final release.
+
+Marigold v18 also requires React 19. If you are still on React 18, upgrade
+React first, verify your app still builds, then bump Marigold.
+
 </Callout>
 
 <Callout title="Upgrading? Follow the migration guide" type="info">


### PR DESCRIPTION
# Description

Brings the v18.0.0 release notes up to date.

**Date.** The release moves to **11 August 2026**. The frontmatter `date` is updated and the file is renamed `release-2026-08-17.mdx` → `release-2026-08-11.mdx`, matching the convention every other release post follows. The link in `MIGRATION-v18.md` is repointed to the new slug.

**Changesets since the draft.** The post was written on 2026-08-04 (#5304); six changesets have landed since. Each was checked against the v17 baseline to decide whether it is a real v17 → v18 change or beta-internal churn — the release notes carry only the end result, not intermediate beta states.

Added:

| Changeset | What went in |
| --- | --- |
| `slider-track-control-surface` (DST-1686) | `control` is now translucent (`charcoal-950` at 16%, was `charcoal-300`). Documents the token under _New surface and overlay tokens_, corrects the charcoal role table for steps 300 and 950, and adds a Fixes entry for the Slider rail (wrong token, painted twice). |
| `listbox-item-wrap-anywhere` (DSTSUP-269) | Fixes entry — v17's ListBox item was already `grid-cols-[auto_1fr]` with no wrap rule, so this is a real v17 → v18 fix. |
| `dst-1647-sidebar-router-usehref` (DST-1647) | Fixes entry — `Sidebar.Item` and `href` existed in v17, the bug is pre-existing. Also adds `components/application/routerprovider` to the frontmatter `changed` list. |
| `react-aria-1-20-0` (DST-1680) | _Dependency updates_ now names `react-aria-components` 1.20.0 and the notable upstream fixes instead of saying "latest versions". |

Left out:

| Changeset | Why |
| --- | --- |
| `combobox-tray-aria-hidden` (DST-1680) | v17 rendered a `Popover`, not a `Tray`, for ComboBox/Autocomplete on small screens — the regression was introduced *and* fixed inside the beta, so it never shipped broken. |
| `dst-1627-shared-calendar-body` (DST-1627) | Pure internal refactor; DOM, styling and behaviour unchanged. |
| SegmentedControl polish from DST-1686 | Indicator size, focus ring and concentric corners are beta-internal tuning of a component that is new in v18. |
| `pre.json` (`beta` → `rc`), #5700–#5703 | Release plumbing, lockfile advisories, `play` → `.test()` story migration. Nothing consumer-facing. |

Closes DST-1691

## Test Instructions

1. `pnpm start`, open `/releases/blog/release-2026-08-11` — the post renders and the date reads 11 August 2026.
2. Check the charcoal palette table (step 300 = "Selected state, disabled border", step 950 = "Primary action, boundary and track alphas, scrollbar hover") and the new `control` bullet under _New surface and overlay tokens_.
3. Check the three new bullets at the end of the _Fixes_ list and the reworded `react-aria-components` bullet under _Dependency updates_.
4. Confirm the old `/releases/blog/release-2026-08-17` slug is gone and `MIGRATION-v18.md` links to the new one.

## Breaking Changes

No

## Checklist

- [x] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable) — n/a, docs content only
- [ ] Unit tests added/updated — n/a, docs content only
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) — n/a, no interactive components changed
- [ ] Visual regression tests updated (for UI changes) — n/a, no UI changes
- [ ] Changeset added (`pnpm changeset`) — n/a, this *is* the release note for v18; nothing to bump
