### PR TITLE
fix(DST-1696): mark a row header column in the table demos

### DIFF
--- a/.changeset/table-demos-row-header.md
+++ b/.changeset/table-demos-row-header.md
@@ -1,0 +1,11 @@
+---
+'@marigold/docs': patch
+---
+
+fix(DST-1696): mark a row header column in the EmptyState and DateFormat table demos
+
+Two rendered demos declared a `<Table>` without marking any column as `rowHeader`, so react-aria threw `A table must have at least one Column with the isRowHeader prop set to true` whenever the table's collection was rebuilt. The first commit runs with `isSSR` and stays silent, so the error only surfaced on a later re-render (the DateFormat demo's tabular-digits switch triggers it on the first toggle). React recovered with a synchronous re-render, leaving a console error on two published docs pages.
+
+Both demos now mark their first column as `rowHeader`, which is also what assistive technology announces when navigating rows. The DateFormat table gained its missing `aria-label`.
+
+[DST-1696](https://reservix.atlassian.net/browse/DST-1696)

--- a/docs/content/components/content/empty-state/empty-state-table.demo.tsx
+++ b/docs/content/components/content/empty-state/empty-state-table.demo.tsx
@@ -3,7 +3,7 @@ import { Button, EmptyState, Table } from '@marigold/components';
 export default () => (
   <Table aria-label="Events Table">
     <Table.Header>
-      <Table.Column>Event Name</Table.Column>
+      <Table.Column rowHeader>Event Name</Table.Column>
       <Table.Column>Date</Table.Column>
       <Table.Column>Venue</Table.Column>
       <Table.Column>Status</Table.Column>

--- a/docs/content/components/formatters/dateformat/dateformat-tabular-format.demo.tsx
+++ b/docs/content/components/formatters/dateformat/dateformat-tabular-format.demo.tsx
@@ -25,9 +25,9 @@ export default () => {
         onChange={setTabular}
       />
 
-      <Table>
+      <Table aria-label="Events">
         <Table.Header>
-          <Table.Column>Event</Table.Column>
+          <Table.Column rowHeader>Event</Table.Column>
           <Table.Column>Price</Table.Column>
           <Table.Column>Date</Table.Column>
         </Table.Header>


### PR DESCRIPTION
# Description

The EmptyState and DateFormat table demos declared a `<Table>` without marking any column as `rowHeader`. React Aria throws `A table must have at least one Column with the isRowHeader prop set to true` when the table's collection is rebuilt, so both docs pages logged a console error.

The error looked intermittent because the first collection commit runs with `isSSR` and stays silent. It only surfaced on a later re-render, and the DateFormat demo's tabular-digits switch triggers it on the first toggle. React recovered by rendering the root synchronously, so the tables still displayed.

Both demos now mark their first column as `rowHeader`, which is what assistive technology announces when navigating rows. The DateFormat table also gained its missing `aria-label`. Both tables use the default row variant, whose styles don't distinguish `role=gridcell` from `role=rowheader`, so there is no visual delta.

No VRT impact — docs demos only, no Storybook stories, component source, or theme touched.

Closes DST-1696

## Test Instructions

1. Run `pnpm start` and open http://localhost:3000/components/formatters/dateformat
2. With the browser console open, toggle "Use tabular digits" and confirm no `isRowHeader` error is logged
3. Open http://localhost:3000/components/content/empty-state and confirm the table demo still renders its empty state
4. With a screen reader, navigate either table and confirm the first column value is announced as the row header

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [x] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)