### PR TITLE
docs(DST-1697): update test docs for Storybook 10 conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ The CLI fetches from the Marigold docs site, caches for 24h, and works offline (
 
 - **Test runner**: Vitest (not Jest)
 - **Run tests**: `pnpm test` (all), `pnpm test:unit` (unit tests), `pnpm test:sb` (story tests)
-- **Story tests**: Add `play` functions with `tags: ['component-test']` - runs in real browser via Playwright
+- **Story tests**: Attach `.test()` to a story tagged `component-test` - runs in real browser via Playwright
 - **Unit tests**: Import stories (e.g., `<Basic.Component />`) instead of creating test fixtures
 - **Browser tests**: Playwright integration via `@vitest/browser-playwright`
 - **Coverage**: `pnpm test:coverage` (requires 90% statements, functions, lines; 85% branches)
@@ -225,12 +225,13 @@ export const Toast: ThemeComponent = {
 
 ## Testing Patterns
 
-### Story Play Functions
+### Story Tests (`.test()`)
 
-Add `play` functions to stories for interaction testing. Runs in real browser via Playwright.
+Attach interaction tests to a story with `.test(name, options?, fn)` (enabled by
+`features.experimentalTestSyntax`). Do not write `play` functions. Runs in real browser via Playwright.
 
 ```typescript
-import { expect, fn, userEvent } from 'storybook/test';
+import { expect, fn } from 'storybook/test';
 import preview from '.storybook/preview';
 
 const meta = preview.meta({
@@ -239,17 +240,28 @@ const meta = preview.meta({
 });
 
 export const Basic = meta.story({
-  tags: ['component-test'],  // Required for test runner
-  args: {
-    onPress: fn(),
-  },
+  tags: ['component-test'], // Required for test runner; .test() children inherit it
   render: args => <Button {...args}>Click me</Button>,
-  play: async ({ args, canvas }) => {
-    await userEvent.click(canvas.getByRole('button'));
-    await expect(args.onPress).toHaveBeenCalled();
-  },
 });
+
+Basic.test(
+  'Calls onPress when clicked',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: { onPress: fn() },
+  },
+  async ({ args, canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole('button'));
+
+    await expect(args.onPress).toHaveBeenCalled();
+  }
+);
 ```
+
+- Destructure `canvas`, `userEvent`, `args`, `step` from the test context - never `within(canvasElement)`, never a module-scope `userEvent`
+- `options` takes the same `parameters`/`args`/`decorators` a story does, so per-test setup stays out of the story
+- Default to `chromatic: { disableSnapshot: true }`; use `false` when the interaction's end state is a visual state worth guarding
+- Wrap each act-assert cycle in `step()` when a behaviour needs more than one
 
 Run with `pnpm test:sb`.
 
@@ -262,8 +274,9 @@ import { render, screen } from '@testing-library/react';
 import { Basic } from './Button.stories';
 
 test('renders correctly', () => {
-  render(<Basic.Component data-testid="button" />);
-  expect(screen.getByTestId('button')).toBeInTheDocument();
+  render(<Basic.Component />);
+
+  expect(screen.getByRole('button')).toBeInTheDocument();
 });
 
 test('supports custom props', () => {


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`CLAUDE.md` documented Storybook 8 test conventions that no longer exist in the
codebase. The `## Testing Patterns` section showed a `play` function, which has
been replaced by `.test()` children on a story: 324 `.test()` calls across 62
files, versus 2 remaining `play` functions. Because `CLAUDE.md` is loaded as
authoritative project instruction in every AI coding session, the stale example
was actively producing code that does not compile.

Three changes:

- **`## Testing Patterns` rewritten** around `.test(name, options?, fn)`, with
  `userEvent` taken from the test context instead of a module-scope import,
  `args`/`fn()` moved into the test's options so the spy no longer sits on the
  story, plus bullets covering context destructuring, the Chromatic
  `disableSnapshot` default and `step()`.
- **Unit-test example fixed.** It demonstrated `data-testid` and `getByTestId`
  while the "Avoid `getByTestId`" rule sits 180 lines above it in the same file.
- **File casing fixed.** The file was tracked as lowercase `claude.md`. It
  resolves on a case-insensitive filesystem, but a case-sensitive checkout
  (Linux CI, a Docker build) would not find `CLAUDE.md`. Git records this as a
  93% similarity rename.

The companion Confluence page was rewritten in the same effort:
[Writing tests for Marigold components](https://reservix.atlassian.net/wiki/spaces/DST/pages/3626336415/Writing+tests+for+Marigold+components).

N/A: no UI changes, so no screenshots, no VRT and no changeset (nothing under
`packages/**/src/**` or `themes/**` is touched).

Closes DST-1697

## Test Instructions

1. Confirm the file is now `CLAUDE.md` on a case-sensitive checkout:
   `git ls-files | grep -i claude` returns `CLAUDE.md`.
2. Read the `## Testing Patterns` section and compare it against a real story,
   e.g. `packages/components/src/ToggleButton/ToggleButton.stories.tsx`.
3. No CI verification needed beyond the existing checks.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)