### PR TITLE
docs: add the missing changeset for the orphaned demo cleanup

### DIFF
--- a/.changeset/remove-orphaned-table-demos.md
+++ b/.changeset/remove-orphaned-table-demos.md
@@ -1,0 +1,8 @@
+---
+'@marigold/docs': patch
+---
+
+docs: remove orphaned Table demo files
+
+Deletes ten `*.demo.tsx` files under the Table component docs that nothing had
+rendered since the old docs pages were removed. No rendered output changes.


### PR DESCRIPTION
# Description

Adds the `@marigold/docs: patch` changeset that #5721 merged without.

`@marigold/docs` is `private: true`, which stops npm publishing but not versioning: it is at `18.0.0-rc.5`, has its own `CHANGELOG.md`, and sits in the `fixed` group with `@marigold/system` and `@marigold/components` in `.changeset/config.json`. Without an entry, the cleanup lands with nothing in the changelog.

Caught by @sarahgm on #5708, which had the same gap for the same wrong reason. That one is fixed in the PR itself; this is the follow-up for #5721, which had already been approved and merged by the time I got to it.

Changeset only — no code changes.

## Test Instructions

1. Nothing to test manually. The changeset bot should report **Changeset detected** on this PR.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available — n/a
- [ ] Stories added/updated — n/a
- [ ] Unit tests added/updated — n/a
- [ ] Component documentation added/updated — n/a
- [ ] Accessibility reviewed — n/a
- [ ] Visual regression tests updated — n/a
- [x] Changeset added (`pnpm changeset`) — this PR is the changeset
