### PR TITLE
chore: fix broken README badges and drop dead coverage-badge plumbing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,8 +168,6 @@ jobs:
     env:
       CI: true
       PR_NUMBER: ${{ github.event.number }}
-      GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
-      GIST_ID: ${{ secrets.GIST_ID }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Node (using .node-version)
@@ -228,74 +226,3 @@ jobs:
           pr-number: 'auto'
           json-summary-path: './coverage/coverage-summary.json'
           json-final-path: './coverage/coverage-final.json'
-
-      # Coverage badge
-      - name: Read coverage and prepare badge JSON
-        id: prepare_badge
-        run: |
-          node -e "
-          const fs = require('fs');
-          const path = require('path');
-          const summaryPath = path.join(process.cwd(), 'coverage', 'coverage-summary.json');
-          if (!fs.existsSync(summaryPath)) {
-            console.error('coverage-summary.json not found at', summaryPath);
-            process.exit(1);
-          }
-          const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
-          const pct = Number(summary?.total?.lines?.pct ?? 0);
-          const message = pct.toFixed(0) + '%';
-          let color = 'red';
-          if (pct >= 90) color = 'brightgreen';
-          else if (pct >= 80) color = 'green';
-          else if (pct >= 65) color = 'orange';
-          else if (pct >= 50) color = 'yellow';
-
-          const badge = {
-            schemaVersion: 1,
-            label: 'Vitest',
-            message,
-            color,
-            labelColor: 'black',
-            namedLogo: 'vitest',
-            logoColor: 'white'
-          };
-          const outDir = path.join(process.cwd(), 'artifacts');
-          fs.mkdirSync(outDir, { recursive: true });
-          const outFile = path.join(outDir, 'vitest-coverage-badge.json');
-          fs.writeFileSync(outFile, JSON.stringify(badge));
-          console.log('Badge JSON written to', outFile);
-
-          // Also expose outputs
-          const githubOutput = process.env.GITHUB_OUTPUT;
-          if (githubOutput) {
-            fs.appendFileSync(githubOutput, 'coverage_pct=' + pct + '\n');
-            fs.appendFileSync(githubOutput, 'badge_path=' + outFile + '\n');
-          }
-          "
-
-      - name: Upload badge JSON as artifact (for debugging)
-        uses: actions/upload-artifact@v7
-        with:
-          name: vitest-coverage-badge
-          path: artifacts/vitest-coverage-badge.json
-
-      - name: Upload badge to Gist (only for main target)
-        if: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main')) && (env.GIST_TOKEN != '' && env.GIST_ID != '') }}
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: ${{ secrets.GIST_ID }}
-          filename: vitest-coverage-badge.json
-          label: Vitest
-          message: ${{ steps.prepare_badge.outputs.coverage_pct }}%
-          color: >-
-            ${{
-              steps.prepare_badge.outputs.coverage_pct >= 90 && 'brightgreen' ||
-              steps.prepare_badge.outputs.coverage_pct >= 80 && 'green' ||
-              steps.prepare_badge.outputs.coverage_pct >= 65 && 'orange' ||
-              steps.prepare_badge.outputs.coverage_pct >= 50 && 'yellow' ||
-              'red'
-            }}
-          labelColor: black
-          namedLogo: vitest
-          logoColor: white

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br>
 <br>
 
-[![ci][ci-badge]][ci] [![Coverage][coverage-badge-gist]] [![MIT License][license-badge]][license] [![version][version-badge]][package]
+[![ci][ci-badge]][ci] [![MIT License][license-badge]][license] [![version][version-badge]][package]
 
 [![Open in Visual Studio Code](https://shields.io/badge/-Open%20in%20Visual%20Studio%20Code-blue?logo=visualstudiocode&style=for-the-badge)](https://open.vscode.dev/marigold-ui/marigold)
 
@@ -112,3 +112,12 @@ Two things worth knowing:
 - Switching channel leaves the old dist-tag pinned at its last version. Consumers on the old tag keep
   resolving a stale version without any error, so repoint (`npm dist-tag add <pkg>@<new-version> <old-tag>`)
   or remove (`npm dist-tag rm <pkg> <old-tag>`) it per package after the first publish on the new channel.
+
+<!-- LINKS + BADGES -->
+
+[ci]: https://github.com/marigold-ui/marigold/actions/workflows/build.yml
+[ci-badge]: https://github.com/marigold-ui/marigold/actions/workflows/build.yml/badge.svg
+[license]: https://github.com/marigold-ui/marigold/blob/main/LICENSE
+[license-badge]: https://img.shields.io/github/license/marigold-ui/marigold?style=flat-square
+[package]: https://www.npmjs.com/package/@marigold/components
+[version-badge]: https://img.shields.io/npm/v/@marigold/components?style=flat-square


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

The badge row at the top of our README has been rendering as literal markdown source since April, on a public repo.

Before (what visitors actually saw):

```
[![ci][ci-badge]][ci] [![Coverage][coverage-badge-gist]] [![MIT License][license-badge]][license] [![version][version-badge]][package]
```

After: three working badges (ci, MIT License, version).

**Cause.** 582c7d93e ("docs([DST-1321]): Delete contributors", #5305) deleted everything from the contributors heading to end of file. The `<!-- LINKS + BADGES -->` reference definitions lived in that trailing region, so nothing resolved `[ci-badge]`, `[license]`, `[version-badge]` and friends. This restores that block and repoints the license link from `blob/master`, a branch that no longer exists, to `blob/main`.

**The coverage badge is dropped rather than repaired.** It was broken twice over: wrapped in stray brackets with no link target, on top of the missing definition. It also sat visibly broken for four months without anyone raising it, and the number it showed duplicates checks we already run. `nyc check-coverage` fails CI below 90/85/90/90, and `vitest-coverage-report-action` posts per-file coverage on every PR. There is also no coverage report page to point it at, so restoring it would have meant an unlinked image restating an existing hard gate. Happy to revisit if someone wants it back.

With no consumer left in the repo, the three `test.yml` steps that existed only to feed that badge are dead output and go with it:

- `Read coverage and prepare badge JSON`
- `Upload badge JSON as artifact (for debugging)`
- `Upload badge to Gist (only for main target)`

Plus the now-unreferenced job-level `GIST_TOKEN` and `GIST_ID` env entries.

**Deliberately unchanged:** coverage collection, the `nyc check-coverage` threshold gate, and the `Report Coverage` PR comment. The `coverage-report` job goes from 11 steps to 8.

The `GIST_TOKEN` / `GIST_ID` repo secrets and the backing gist are left in place. They cost nothing now that nothing writes to them, and keeping them means bringing the badge back later does not require a fresh PAT and a new gist URL.

No Jira ticket, following the `chore:` housekeeping precedent of #5716 and #5721.

N/A for this PR: no changeset, since the root README and `.github/` are not part of any published package, and no VRT, since there are no component, story, or theme changes.

## Test Instructions

1. Open the **Files changed** tab, view `README.md` in rendered mode, and confirm the badge row shows three working badges with no literal `[![...]]` text.
2. Click each badge: ci goes to the build workflow, MIT License goes to `LICENSE` on main, version goes to the npm package page.
3. Confirm the `coverage-report` job on this PR still passes and still posts its "Marigold Code Coverage" comment, so coverage reporting and the threshold gate survived the step removal.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)


[DST-1321]: https://reservix.atlassian.net/browse/DST-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ