### PR TITLE
chore(DST-1691): exit changesets pre mode so v18 ships on latest

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@marigold/eslint-config": "1.0.2",

--- a/docs/content/releases/blog/release-2026-08-11.mdx
+++ b/docs/content/releases/blog/release-2026-08-11.mdx
@@ -1,5 +1,5 @@
 ---
-title: Marigold v18.0.0 (rc)
+title: Marigold v18.0.0
 date: 2026-08-11
 type: Blog
 changed:
@@ -80,12 +80,11 @@ And this release opens that chapter loudly. v18 is by far the biggest release we
 It is a lot. Take your time with the breaking changes below. They all point in the same direction, and the app you end up with will be simpler for it.
 
 <Callout title="Before you upgrade" type="warning">
-  v18.0.0 is currently a **release candidate**. It publishes to the `rc`
-  dist-tag, so a plain `npm install @marigold/components` still resolves v17.
-  Install it explicitly with `@marigold/components@rc`. Everything below
-  describes the release as it stands, and we do not expect further breaking
-  changes, but the token and design work is still settling, so small visual
-  adjustments are possible before the final release.
+  v18.0.0 is a stable release on the `latest` dist-tag, so a plain `npm install
+  @marigold/components` resolves it. If you tracked the release candidates
+  through `@marigold/components@rc`, move your dependency back to a normal
+  version range: the `rc` tag stays pinned at `18.0.0-rc.5` and will not receive
+  further updates.
 
 Marigold v18 also requires React 19. If you are still on React 18, upgrade
 React first, verify your app still builds, then bump Marigold.


### PR DESCRIPTION
# Description

Takes v18 off the `rc` channel. `pnpm changeset pre exit` flips `.changeset/pre.json` to `"mode": "exit"`. The next `changeset version` on `main` consumes that: it versions the 201 pending changesets as normal releases instead of `-rc.N` bumps and deletes `pre.json`. With the file gone, `changeset publish` derives `latest` as the dist-tag instead of `rc`.

I verified by running `changeset version` on this branch and then resetting. The resulting versions:

| Package | Now | After |
| --- | --- | --- |
| `@marigold/components` | `18.0.0-rc.5` | `18.0.0` |
| `@marigold/system` | `18.0.0-rc.5` | `18.0.0` |
| `@marigold/theme-rui` | `6.0.0-rc.5` | `6.0.0` |
| `@marigold/icons` | `1.3.x` | `2.0.0` |
| `@marigold/cli` | `0.5.0-rc.1` | `1.0.0` |
| `@marigold/types` | `1.4.0` | `1.4.0` (unchanged) |

Worth a second opinion on `@marigold/cli` going to `1.0.0` and `@marigold/icons` to `2.0.0`. Both fall out of major bumps already sitting in the changesets rather than out of this change, but this is the PR that makes them real.

### Why `pre exit` rather than deleting the file

Honestly: not because deleting breaks anything. I ran both variants and diffed the results, and they are identical here — same versions, same 201 changesets consumed, same CHANGELOG output. That holds because `changeset version` in pre mode never deletes the changeset `.md` files (which is why all 201 are still on disk after five rc releases), so either route applies the same set. `pre exit` is used because it is the documented command and the flow the README already describes, not because `rm .changeset/pre.json` would produce different numbers.

The one real difference is that `pre.json` stays on `main` until the version PR consumes it, so anyone reading `main` can see the release is mid-exit. Deleting drops the `changesets` array, which is the only record of which changesets shipped in the rc series. Nothing consumes that after exit.

### Docs

The release post is updated to match: the title drops its `(rc)` suffix, and the "Before you upgrade" callout now describes a stable release on `latest` and tells rc consumers to move off the `rc` tag. The `18.0.0-rc.*` mention under the ui-surface rename is left alone, since that one is a statement about history and stays true.

## After this merges

Merging this publishes nothing. The release workflow opens a "release: version packages" PR, and publishing happens when that one is merged.

The dist-tags on npm today are `latest: 17.9.1`, `beta: 18.0.0-beta.4`, `rc: 18.0.0-rc.5`. After the first `latest` publish, both `beta` and `rc` keep resolving stale prereleases with no error for anyone still pointed at them, so repoint or remove them per package (`npm dist-tag rm <pkg> rc`, same for `beta`). This is the caveat already written up in the prereleases section of the README.

Nothing inside the repo pins an `@marigold/*` dependency to the `rc` tag, so there is nothing else to unpin here.

## Test Instructions

1. `git diff main...HEAD` — confirm only `.changeset/pre.json` (the `mode` field) and the release post change.
2. Optional, reproduces my check: run `pnpm changeset version`, confirm the versions in the table above and that `.changeset/pre.json` is gone, then `git reset --hard HEAD` to undo. Do not commit that.
3. Run `pnpm start`, open `/releases/blog/release-2026-08-11`, and confirm the title reads "Marigold v18.0.0" and the upgrade callout no longer tells people to install `@rc`.

## Breaking Changes

No — no source or API change. It changes which dist-tag the next publish targets.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
