### PR TITLE
style(DST-1711): make the undo toast's action button visible without a hover

### DIFF
--- a/.changeset/undo-toast-button-weight.md
+++ b/.changeset/undo-toast-button-weight.md
@@ -1,0 +1,9 @@
+---
+'@marigold/components': patch
+---
+
+style(DST-1711): give the undo toast's action button a visible weight.
+
+`addUndoToast` rendered its Undo button as `variant="ghost"`, which has no fill and no border until it is hovered. It is now the default `secondary` button, so the way back out of a deletion is visible at a glance.
+
+Review feedback on the [Destructive Actions](https://www.marigold-ui.io/patterns/feedback/destructive-actions) pattern found the button easy to overlook: the toast arrives far from the control that triggered it and leaves again after five seconds, which is the worst case for an affordance that only appears on hover. It is deliberately not a `destructive` button — undo is the safe action, and red beside a completed deletion reads as a second delete.

--- a/docs/content/patterns/feedback/destructive-actions/index.mdx
+++ b/docs/content/patterns/feedback/destructive-actions/index.mdx
@@ -114,6 +114,8 @@ Assembled by hand, this pattern has three ways to lose data quietly, and `addUnd
 
 It also drops the toast's close button. Undo and Close side by side is a trap: to most people a close button reads as "get this out of my way", not "go through with it", yet closing is what puts the deletion through. With no close button the only two ways out are Undo and the window running out, and both mean what they look like.
 
+The Undo button it renders is a filled `secondary` button, not a ghost one. The toast arrives far from the control that triggered it and leaves after five seconds, so the way back has to be visible at a glance rather than on hover. It is not a `destructive` button either: undo is the safe action here, and red beside a completed deletion reads as a second delete.
+
 <GuidelineTiles>
   <Do>
     <DoDescription>

--- a/packages/components/src/Toast/ToastQueue.tsx
+++ b/packages/components/src/Toast/ToastQueue.tsx
@@ -174,10 +174,6 @@ export function useToast() {
         action: (
           <Button
             size="small"
-            // Filled, not `ghost`: the toast sits far from the button that
-            // triggered it and leaves after five seconds, so the way back has
-            // to be visible without a hover. Not `destructive` either — undo is
-            // the safe action, and red would read as a second delete.
             variant="secondary"
             // Toasts stack, so a bare "Undo" is ambiguous to a screen reader.
             aria-label={stringFormatter.format('undoNamed', { title })}

--- a/packages/components/src/Toast/ToastQueue.tsx
+++ b/packages/components/src/Toast/ToastQueue.tsx
@@ -174,7 +174,11 @@ export function useToast() {
         action: (
           <Button
             size="small"
-            variant="ghost"
+            // Filled, not `ghost`: the toast sits far from the button that
+            // triggered it and leaves after five seconds, so the way back has
+            // to be visible without a hover. Not `destructive` either — undo is
+            // the safe action, and red would read as a second delete.
+            variant="secondary"
             // Toasts stack, so a bare "Undo" is ambiguous to a screen reader.
             aria-label={stringFormatter.format('undoNamed', { title })}
             onPress={() => {


### PR DESCRIPTION
# Description

`addUndoToast` rendered its Undo button as `variant="ghost"` — no fill and no border until it is hovered. Review feedback on the Destructive Actions pattern found it easy to overlook, and the placement makes that worse: the toast arrives far from the control that triggered it and leaves again after five seconds, which is the worst case for an affordance that only shows itself on hover.

It is now the default `secondary` button (`ui-soft` — background plus edge). Deliberately not `destructive`: undo is the safe action, and red beside a completed deletion reads as a second delete. The pattern page gains a paragraph recording the rule so it does not quietly get reverted.

Closes DST-1711

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

## Test Instructions

1. Run `pnpm start` and open `/patterns/feedback/destructive-actions`.
2. In the "Offering undo" demo, delete a mailing list.
3. Confirm the Undo button in the toast has a visible fill and border before you hover it, and that pressing it restores the row.
4. Check the same toast in dark mode — `ui-soft` on a dark surface is the case worth a second look.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)