### PR TITLE
docs(DST-1714): stretch the placeholder cards in the Tiles demos

### DIFF
--- a/docs/content/components/layout/tiles/tiles-autoRows.demo.tsx
+++ b/docs/content/components/layout/tiles/tiles-autoRows.demo.tsx
@@ -3,18 +3,18 @@ import { Rectangle } from '@/ui/Rectangle';
 
 export default () => (
   <Tiles space={1} tilesWidth="200px" equalHeight>
-    <Card>
+    <Card stretch>
       <Card.Content>
         <Rectangle height="100px" />
       </Card.Content>
     </Card>
-    <Card>
+    <Card stretch>
       <Card.Content>
         <Rectangle height="100px" />
         <Rectangle height="100px" />
       </Card.Content>
     </Card>
-    <Card>
+    <Card stretch>
       <Card.Content>
         <Rectangle height="100px" />
       </Card.Content>

--- a/docs/content/components/layout/tiles/tiles-stretch.demo.tsx
+++ b/docs/content/components/layout/tiles/tiles-stretch.demo.tsx
@@ -8,22 +8,22 @@ export default () => {
     <Stack space={2}>
       <Switch label="Toggle stretch" onChange={() => setStretch(!stretch)} />
       <Tiles space={2} stretch={stretch} tilesWidth="100px">
-        <Card>
+        <Card stretch>
           <Card.Content>
             <Rectangle height="100px" />
           </Card.Content>
         </Card>
-        <Card>
+        <Card stretch>
           <Card.Content>
             <Rectangle height="100px" />
           </Card.Content>
         </Card>
-        <Card>
+        <Card stretch>
           <Card.Content>
             <Rectangle height="100px" />
           </Card.Content>
         </Card>
-        <Card>
+        <Card stretch>
           <Card.Content>
             <Rectangle height="100px" />
           </Card.Content>


### PR DESCRIPTION
# Description

The "Equal heights" and "Stretch width" demos on the Tiles docs page rendered their placeholder rectangles as 4px-wide dashed slivers instead of rectangles.

The cause isn't `Rectangle` — `<Card>` renders `w-fit` unless `stretch` is set (`packages/components/src/Card/Card.tsx:150`), and a shrink-to-fit box gives a percentage-width child nothing to resolve against, so `Rectangle`'s `width: 100%` collapsed to just its 2px dashed border on each side. Passing `stretch` lets each card fill its grid column. That also makes the `stretch` toggle demonstrate its own behaviour: cards now grow from 100px to 181.75px per column instead of staying pinned at their fit-content width. `tiles-complex` was already fine — its `Card.Media` image gives the card an intrinsic width.

No changeset: docs-only, the diff doesn't touch `packages/**` or `themes/**`.

Closes DST-1714

## Screenshots / Preview

| Before | After |
| ------ | ----- |
|        |       |

<!-- Docs preview: /components/layout/tiles — "Equal heights" and "Stretch width". -->

## Test Instructions

1. `pnpm start`, open http://localhost:3000/components/layout/tiles
2. "Equal heights": three cards, each placeholder rectangle spans the card (176 × 100 in a 200px tile) instead of showing a vertical sliver
3. "Stretch width": flip "Toggle stretch" — the four tiles widen from 100px to ~182px and the rectangles widen with them

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)