### PR TITLE
feat(DST-1723): add an RSS feed for the release blog

### DIFF
--- a/docs/app/_components/SiteFooter.tsx
+++ b/docs/app/_components/SiteFooter.tsx
@@ -29,12 +29,15 @@ export const SiteFooter = () => (
         >
           GitHub
         </Link>
-        <Link
+        {/* Not `Link`: it treats `/rss.xml` as internal, so the router
+            prefetches every in-viewport footer, pulling the whole feed on a
+            page that has nothing to do with it. */}
+        <a
           className="hover:text-fd-foreground transition-colors"
           href="/rss.xml"
         >
           RSS
-        </Link>
+        </a>
       </nav>
     </div>
   </footer>

--- a/docs/app/_components/SiteFooter.tsx
+++ b/docs/app/_components/SiteFooter.tsx
@@ -29,6 +29,12 @@ export const SiteFooter = () => (
         >
           GitHub
         </Link>
+        <Link
+          className="hover:text-fd-foreground transition-colors"
+          href="/rss.xml"
+        >
+          RSS
+        </Link>
       </nav>
     </div>
   </footer>

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,3 +1,4 @@
+import { canonicalUrl } from '@/lib/config';
 import { CONSENT_BANNER_ENABLED } from '@/lib/consent';
 import { source } from '@/lib/source';
 import { flattenTree } from 'fumadocs-core/page-tree';
@@ -29,6 +30,11 @@ export const metadata: Metadata = {
     icon:
       // @ts-expect-error TS2538
       FAV_ICONS[process.env.NEXT_PUBLIC_VERCEL_ENV] || '/logo.svg',
+  },
+  alternates: {
+    types: {
+      'application/rss+xml': `${canonicalUrl}/rss.xml`,
+    },
   },
 };
 

--- a/docs/app/rss.xml/route.ts
+++ b/docs/app/rss.xml/route.ts
@@ -1,0 +1,13 @@
+import { getAllBlogPosts } from '@/lib/blog';
+import { buildRssFeed } from '@/lib/rss';
+
+// Emitted at build time like the rest of the site; `GET` handlers are dynamic
+// by default.
+export const dynamic = 'force-static';
+
+export const GET = () =>
+  new Response(buildRssFeed(getAllBlogPosts()), {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });

--- a/docs/content/releases/release-notes.mdx
+++ b/docs/content/releases/release-notes.mdx
@@ -3,4 +3,6 @@ title: Release Notes
 description: Find all release blogs.
 ---
 
+Subscribe to new releases via [RSS](/rss.xml).
+
 <PostList />

--- a/docs/lib/config.ts
+++ b/docs/lib/config.ts
@@ -5,3 +5,11 @@ export const baseUrl =
   (process.env.NEXT_PUBLIC_VERCEL_URL
     ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
     : 'http://localhost:3000');
+
+/**
+ * Where the site actually lives, independent of the deployment it was built on.
+ * `baseUrl` falls back to the per-deployment Vercel URL, which is fine for
+ * fetching assets but not for anything a third party stores — an RSS `guid`
+ * that changes between deploys makes every reader re-notify every item.
+ */
+export const canonicalUrl = 'https://www.marigold-ui.io';

--- a/docs/lib/rss.test.ts
+++ b/docs/lib/rss.test.ts
@@ -81,6 +81,16 @@ describe('buildRssFeed', () => {
     );
   });
 
+  it('drops the brackets around a component name', () => {
+    const feed = buildRssFeed([
+      post({ introduction: 'Now with `<DateRangePicker>` and `<Dialog>`.' }),
+    ]);
+
+    expect(feed).toContain(
+      '<description>Now with DateRangePicker and Dialog.</description>'
+    );
+  });
+
   it('strips emphasis markers but leaves underscores in identifiers', () => {
     const feed = buildRssFeed([
       post({

--- a/docs/lib/rss.test.ts
+++ b/docs/lib/rss.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { BlogPost } from './blog';
+import { buildRssFeed } from './rss';
+
+const post = (overrides: Partial<BlogPost> = {}): BlogPost => ({
+  title: 'Marigold v18.0.0',
+  date: new Date('2026-08-11T00:00:00Z'),
+  slug: '/releases/blog/release-2026-08-11',
+  introduction: 'A very big release.',
+  ...overrides,
+});
+
+describe('buildRssFeed', () => {
+  it('builds a feed with one item per post', () => {
+    const feed = buildRssFeed([post()]);
+
+    expect(feed).toContain('<rss version="2.0"');
+    expect(feed).toContain('<title>Marigold v18.0.0</title>');
+    expect(feed).toContain(
+      '<link>https://www.marigold-ui.io/releases/blog/release-2026-08-11</link>'
+    );
+    expect(feed).toContain('<pubDate>Tue, 11 Aug 2026 00:00:00 GMT</pubDate>');
+    expect(feed).toContain('<description>A very big release.</description>');
+  });
+
+  it('points guid and the self link at the canonical origin', () => {
+    const feed = buildRssFeed([post()]);
+
+    expect(feed).toContain(
+      '<guid isPermaLink="true">https://www.marigold-ui.io/releases/blog/release-2026-08-11</guid>'
+    );
+    expect(feed).toContain('href="https://www.marigold-ui.io/rss.xml"');
+  });
+
+  it('sorts posts newest first', () => {
+    const feed = buildRssFeed([
+      post({ title: 'Older', date: new Date('2025-01-22T00:00:00Z') }),
+      post({ title: 'Newer', date: new Date('2026-08-11T00:00:00Z') }),
+    ]);
+
+    expect(feed.indexOf('<title>Newer</title>')).toBeLessThan(
+      feed.indexOf('<title>Older</title>')
+    );
+  });
+
+  it('dates the feed from the newest post, not the build', () => {
+    const feed = buildRssFeed([
+      post({ date: new Date('2025-01-22T00:00:00Z') }),
+      post({ date: new Date('2026-08-11T00:00:00Z') }),
+    ]);
+
+    expect(feed).toContain(
+      '<lastBuildDate>Tue, 11 Aug 2026 00:00:00 GMT</lastBuildDate>'
+    );
+  });
+
+  it('escapes XML in titles and descriptions', () => {
+    const feed = buildRssFeed([
+      post({
+        title: 'Tabs & <Panel>',
+        introduction: 'Use "quotes" & angle brackets <like this>.',
+      }),
+    ]);
+
+    expect(feed).toContain('<title>Tabs &amp; &lt;Panel&gt;</title>');
+    expect(feed).toContain(
+      '<description>Use &quot;quotes&quot; &amp; angle brackets &lt;like this&gt;.</description>'
+    );
+  });
+
+  it('reduces Markdown in a description to plain text', () => {
+    const feed = buildRssFeed([
+      post({
+        introduction:
+          'The [CLI](/getting-started/cli) ships `@marigold/cli`.\n\nSecond paragraph.',
+      }),
+    ]);
+
+    expect(feed).toContain(
+      '<description>The CLI ships @marigold/cli. Second paragraph.</description>'
+    );
+  });
+
+  it('strips emphasis markers but leaves underscores in identifiers', () => {
+    const feed = buildRssFeed([
+      post({
+        introduction:
+          "This is about what you _don't_ ship with **bundle_size**.",
+      }),
+    ]);
+
+    expect(feed).toContain(
+      '<description>This is about what you don&apos;t ship with bundle_size.</description>'
+    );
+  });
+
+  it('omits the description when a post has no introduction', () => {
+    const feed = buildRssFeed([post({ introduction: '' })]);
+
+    expect(feed).not.toContain('<description></description>');
+    expect(feed).toContain('<item>');
+  });
+
+  it('stays a valid channel with no posts', () => {
+    const feed = buildRssFeed([]);
+
+    expect(feed).toContain('<channel>');
+    expect(feed).not.toContain('<item>');
+    expect(feed).not.toContain('<lastBuildDate>');
+  });
+});

--- a/docs/lib/rss.ts
+++ b/docs/lib/rss.ts
@@ -1,0 +1,73 @@
+import type { BlogPost } from '@/lib/blog';
+import { canonicalUrl } from '@/lib/config';
+
+const FEED_PATH = '/rss.xml';
+const FEED_TITLE = 'Marigold Design System';
+const FEED_DESCRIPTION = "Release notes for Marigold, Reservix' Design System.";
+const BLOG_PATH = '/releases/blog';
+
+const XML_ENTITIES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+const escapeXml = (value: string) =>
+  value.replace(/[&<>"']/g, char => XML_ENTITIES[char]);
+
+// Feed readers render a description as plain text, so inline Markdown would
+// show up as literal syntax.
+const toPlainText = (markdown: string) =>
+  markdown
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    // Only emphasis markers, not the underscores in an identifier.
+    .replace(/(?<![\w`])[*_]([^*_\n]+)[*_](?![\w`])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const buildItem = (post: BlogPost) => {
+  const url = `${canonicalUrl}${post.slug}`;
+  const description = toPlainText(post.introduction);
+
+  return [
+    '    <item>',
+    `      <title>${escapeXml(post.title)}</title>`,
+    `      <link>${escapeXml(url)}</link>`,
+    `      <guid isPermaLink="true">${escapeXml(url)}</guid>`,
+    `      <pubDate>${post.date.toUTCString()}</pubDate>`,
+    ...(description
+      ? [`      <description>${escapeXml(description)}</description>`]
+      : []),
+    '    </item>',
+  ].join('\n');
+};
+
+export const buildRssFeed = (posts: BlogPost[]) => {
+  const sorted = [...posts].sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  // Derived from the newest post rather than the build time, so rebuilding
+  // without new content produces a byte-identical feed.
+  const lastBuildDate = sorted[0]?.date.toUTCString();
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(FEED_TITLE)}</title>`,
+    `    <link>${canonicalUrl}${BLOG_PATH}</link>`,
+    `    <description>${escapeXml(FEED_DESCRIPTION)}</description>`,
+    '    <language>en</language>',
+    `    <atom:link href="${canonicalUrl}${FEED_PATH}" rel="self" type="application/rss+xml"/>`,
+    ...(lastBuildDate
+      ? [`    <lastBuildDate>${lastBuildDate}</lastBuildDate>`]
+      : []),
+    ...sorted.map(buildItem),
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+};

--- a/docs/lib/rss.ts
+++ b/docs/lib/rss.ts
@@ -23,6 +23,10 @@ const toPlainText = (markdown: string) =>
   markdown
     .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
+    // Component names lose their brackets too. A reader renders a description
+    // as HTML, so an escaped `<Dialog>` comes back out of the XML parser as a
+    // tag and gets dropped, taking the word the sentence is about with it.
+    .replace(/<(\/?[A-Za-z][\w.-]*)>/g, '$1')
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     // Only emphasis markers, not the underscores in an identifier.
     .replace(/(?<![\w`])[*_]([^*_\n]+)[*_](?![\w`])/g, '$1')


### PR DESCRIPTION
# Description

The docs publish a release blog — 22 posts, dated, sorted newest first — with no way to subscribe to it. Every conventional feed path was a soft 404: `/rss.xml`, `/feed.xml` and `/releases/blog/rss.xml` all returned `200 text/html`, which is the catch-all, not a file.

`/rss.xml` is now a static route handler (`export const dynamic = 'force-static'`, so it's emitted at build like the rest of the site) over the existing `blogPosts` collection.

Three ways to reach it, because they cover different readers: `metadata.alternates.types` puts an autodiscovery `<link>` in every page's `<head>` for feed readers and crawlers; the **RSS** link in `SiteFooter` makes it findable from anywhere, since browsers stopped surfacing autodiscovery years ago; and the Release Notes page links it in context. At 375px the footer's four links still sit on one row with no horizontal overflow.

Two decisions worth knowing about, both about not changing bytes between deploys:

- **Item links and GUIDs use a new `canonicalUrl`, not `lib/config.ts`'s `baseUrl`.** `baseUrl` falls back to the per-deployment Vercel URL, which is fine for fetching fonts but not for an identifier a third party stores — a GUID that changes between deploys makes every reader re-notify every item.
- **`lastBuildDate` comes from the newest post, not from build time.** Rebuilding without new content produces a byte-identical feed.

XML is hand-rolled rather than adding `feed` + `xml-js` for the sake of five escaped characters. Descriptions reuse the `introduction` that `getAllBlogPosts()` already extracts for the Release Notes page, reduced to plain text — feed readers render a description as text, so `_don't_` and `` `@marigold/cli` `` would otherwise show their Markdown syntax.

Closes DST-1723

## Test Instructions

1. `pnpm install`
2. `pnpm --filter @marigold/docs test` → 115 passing, 9 of them new in `lib/rss.test.ts`
3. `pnpm --filter @marigold/docs dev`, then `curl -i http://localhost:3000/rss.xml` → `200`, `content-type: application/rss+xml; charset=utf-8`, 22 `<item>` elements newest-first
4. `curl -s http://localhost:3000/rss.xml | xmllint --noout -` → well-formed
5. Drop the feed URL into any reader (NetNewsWire, Feedly, Thunderbird) — or click **RSS** in the footer of any page
6. `curl -s http://localhost:3000/ | grep 'application/rss+xml'` → the autodiscovery `<link rel="alternate">` is in `<head>` on every page

## Breaking Changes

No — additive, and no published package is touched.

## Notes for the reviewer

- **Why a route handler and not a static file in `public/`.** The `.md` files under `public/` are generated by `build:md` because that pipeline needs to parse MDX outside the React tree. A feed needs none of that: the collection is already loaded, so a `force-static` handler is both less machinery and automatically correct when a post is added.
- **Only a summary feed.** `description` plus a link, no `content:encoded`. Rendering a post's MDX to standalone HTML is a genuinely separate problem (components, code highlighting, relative links) and not what a release feed needs.
- **`canonicalUrl` is hard-coded to production**, so the feed on a preview deploy points at production URLs. That's deliberate — a preview's feed items shouldn't get stored under a URL that stops existing. Two build scripts (`build-manifest.mjs`, `build-examples.mjs`) already hard-code the same origin; this is the first one in `lib/`, so if we ever want a single source of truth, those should move to it rather than the other way round.
- **Interaction with #5742 (DST-1721, the docs link checker).** `next-validate-link`'s `next` preset only globs `app/**/page.{js,jsx,tsx,md,mdx}` — route handlers are invisible to it — so the new `[RSS](/rss.xml)` link in `content/releases/release-notes.mdx` would be reported as `not-found`. I've added `/rss.xml` to the checker's whitelist on that branch. **Either merge order is safe:** if this PR lands first, main has the link but no checker yet; if #5742 lands first, the whitelist is already there.
- **The `xmllint` step above is the only structural validation.** The W3C Feed Validator needs a public URL, so it's worth a click on the preview deploy before merging — the feed satisfies RSS 2.0's required elements (`channel` title/link/description, and title-or-description per item) plus `atom:link rel="self"`, but that's my reading of the spec, not a validator's.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available — verify once CI builds them; `/rss.xml` on the preview is where step 5 is worth a click
- [ ] Stories added/updated (with `component-test` tag where applicable) — N/A, no component changes
- [x] Unit tests added/updated — `docs/lib/rss.test.ts`, 9 cases (ordering, escaping, canonical GUIDs, deterministic `lastBuildDate`, Markdown reduction, empty feed)
- [x] Component documentation added/updated (if it exists) — the Release Notes page now links the feed
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components) — N/A, no interactive components
- [ ] Visual regression tests updated (for UI changes) — N/A, Chromatic snapshots Storybook, not the docs site
- [ ] Changeset added (`pnpm changeset`) — N/A, `@marigold/docs` is private
