### PR TITLE
fix(DST-1728): give the whole Switch the pointer cursor

### DIFF
--- a/.changeset/switch-label-cursor.md
+++ b/.changeset/switch-label-cursor.md
@@ -1,0 +1,8 @@
+---
+'@marigold/theme-rui': patch
+---
+
+Fix the `Switch` cursor so it covers the whole control. Hovering the label text
+showed the default arrow instead of the pointer, because `cursor-pointer` sat
+only on the track. Moving it to the container also fixes the disabled and
+read-only cursors, which the track's own rule was overriding.

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -145,6 +145,61 @@ Basic.test(
   }
 );
 
+// There is no accessible way to reach the track. It is the first rounded
+// element in the label; the thumb is nested inside it.
+const getTrack = (switchEl: HTMLElement) => {
+  const track = switchEl
+    .closest('label')
+    ?.querySelector('[class*="rounded-full"]');
+
+  expect(track).not.toBeNull();
+
+  return track!;
+};
+
+const cursorOf = (el: Element) => getComputedStyle(el).cursor;
+
+// One test per state, because each needs its own `args`. Note `.test()` calls are
+// collected statically — registering them from a loop yields no tests at all.
+Basic.test(
+  'The label shares the track cursor',
+  { parameters: { chromatic: { disableSnapshot: true } } },
+  async ({ canvas }) => {
+    const switchEl = await canvas.findByRole('switch');
+
+    expect(cursorOf(canvas.getByText('Default Switch'))).toBe('pointer');
+    expect(cursorOf(getTrack(switchEl))).toBe('pointer');
+  }
+);
+
+Basic.test(
+  'Disabled swaps the cursor on the whole hit area',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: { disabled: true },
+  },
+  async ({ canvas }) => {
+    const switchEl = await canvas.findByRole('switch');
+
+    expect(cursorOf(canvas.getByText('Default Switch'))).toBe('not-allowed');
+    expect(cursorOf(getTrack(switchEl))).toBe('not-allowed');
+  }
+);
+
+Basic.test(
+  'Read only swaps the cursor on the whole hit area',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: { readOnly: true },
+  },
+  async ({ canvas }) => {
+    const switchEl = await canvas.findByRole('switch');
+
+    expect(cursorOf(canvas.getByText('Default Switch'))).toBe('default');
+    expect(cursorOf(getTrack(switchEl))).toBe('default');
+  }
+);
+
 export const WithDescription = meta.story({
   tags: ['component-test'],
   args: {

--- a/themes/theme-rui/src/components/Switch.styles.ts
+++ b/themes/theme-rui/src/components/Switch.styles.ts
@@ -4,6 +4,10 @@ export const Switch: ThemeComponent<'Switch'> = {
   container: cva({
     base: [
       'grid gap-x-2 items-center',
+      // Cursor lives here, on the whole hit area, so the label reads as clickable
+      // too — and inherits down to the track, where a local rule would otherwise
+      // outrank the disabled/read-only cursors below.
+      'cursor-pointer read-only:cursor-default',
       'disabled:cursor-not-allowed disabled:text-disabled',
       'group-data-booleanfield/booleanfield:grid-cols-subgrid group-data-booleanfield/booleanfield:col-span-full',
     ],
@@ -20,7 +24,7 @@ export const Switch: ThemeComponent<'Switch'> = {
   track: cva({
     base: [
       'h-4 w-7',
-      'flex shrink-0 cursor-pointer items-center rounded-full transition-colors',
+      'flex shrink-0 items-center rounded-full transition-colors',
       'border-2 border-transparent',
       'group-disabled/switch:bg-disabled-surface group-disabled/switch:text-disabled group-selected/switch:group-disabled/switch:bg-disabled-surface group-selected/switch:group-disabled/switch:text-disabled',
       'group-selected/switch:bg-selected-bold bg-control',


### PR DESCRIPTION
Closes [DST-1728](https://reservix.atlassian.net/browse/DST-1728)

Noticed while working on DST-1386: hovering a `Switch`'s **label text** showed the default arrow instead of the pointer, so the label didn't read as clickable — even though clicking it toggles the switch. `Checkbox` and `Radio` both put the pointer on their label; `Switch` was the odd one out.

Chasing it down surfaced a second, related defect. `cursor-pointer` lived on the `track` while the disabled cursor lived on the `container`, and a rule on the track outranks one *inherited* from its parent — so a **disabled or read-only Switch still showed a pointer** over the track.

## The fix

`cursor` is an inherited property, so declaring it once on the container covers the label, the track, and the thumb — and lets the state variants on the container win, because nothing below re-declares it.

```diff
  container: cva({
    base: [
      'grid gap-x-2 items-center',
+     'cursor-pointer read-only:cursor-default',
      'disabled:cursor-not-allowed disabled:text-disabled',

  track: cva({
    base: [
      'h-4 w-7',
-     'flex shrink-0 cursor-pointer items-center rounded-full transition-colors',
+     'flex shrink-0 items-center rounded-full transition-colors',
```

`cursor-pointer read-only:cursor-default` is lifted verbatim from `Checkbox.styles.ts`, so the two controls now declare this the same way.

## Result

The whole hit area — label text, track, and thumb — agrees on one cursor per state:

| State | Before (label / track) | After (label + track) |
| --- | --- | --- |
| default | `default` / `pointer` | `pointer` |
| `disabled` | `not-allowed` / `pointer` | `not-allowed` |
| `readOnly` | `default` / `pointer` | `default` |

## Testing

Three story tests, each asserting the computed `cursor` on **both** the label text and the track. Confirmed to have teeth: all three fail on `main` and pass with the fix.

```
× The label shares the track cursor
× Disabled swaps the cursor on the whole hit area
× Read only swaps the cursor on the whole hit area
```

`read-only:` resolving on the `SwitchButton` was the one uncertain part — RAC does stamp `data-readonly` there, verified in Firefox rather than assumed.

Full suite green: 1569 unit tests, 562 story tests, typecheck, lint (0 errors), format.

## Not included

Where the cursor is *declared* still differs across the three boolean controls — `Switch` in the theme, `Checkbox` split between component and theme, `Radio` as a JS ternary in `Radio.tsx`. Worth unifying, but that's a separate refactor and I've left it out of a fix this small.

[DST-1728]: https://reservix.atlassian.net/browse/DST-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ