### PR TITLE
feat(DST-1521): commit the /grill scoping skill and the .memory store

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -30,6 +30,10 @@ One shape, no exceptions:
 
 The `description` is the only part of a skill that enters the context window before it runs — everything else loads on invocation. So write it as a trigger, not a summary: say what the skill does *and* the phrases that should reach for it. A vague description is why a good skill never fires.
 
+Open it with `Marigold repo — ` so ours group visibly in a `/` menu that also lists plugin and personal skills. Use the em dash, not a colon: descriptions are read raw rather than as quoted YAML, so quotes leak through literally, and `Marigold repo: ` would need them.
+
+Don't put that marker in the `name`. Plugin and directory-scoped skills are namespaced by the harness with a colon (`vercel:react-best-practices`, `apps/web:deploy`), so a hand-written prefix in the name impersonates a mechanism it isn't part of. The invocation stays `/create-pr`.
+
 Keep the body in `SKILL.md` and push bulk into `references/`. Skills are cheap when idle and expensive when bloated at the top level.
 
 ## Skills with side effects

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Create a GitHub pull request for the Marigold Design System repo that follows the project's PR template and Conventional Commits title convention with a DST Jira scope (e.g. `feat(DST-1234): ...`). Use whenever the user asks to "create a PR", "open a pull request", "submit this for review", "ship this branch", or types `/create-pr`. Inspects the branch diff to infer change type, extracts the Jira ticket from the branch name or commit history, auto-fills the PR body, and auto-ticks checklist items it can verify (changeset, stories, tests, docs).
+description: Marigold repo — Create a GitHub pull request that follows the project's PR template and Conventional Commits title convention with a DST Jira scope (e.g. `feat(DST-1234): ...`). Use whenever the user asks to "create a PR", "open a pull request", "submit this for review", "ship this branch", or types `/create-pr`. Inspects the branch diff to infer change type, extracts the Jira ticket from the branch name or commit history, auto-fills the PR body, and auto-ticks checklist items it can verify (changeset, stories, tests, docs).
 ---
 
 # Create-PR Skill for Marigold Design System

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill
-description: Interrogate an under-specified idea one question at a time until every decision branch is resolved, recommending an answer for each. When the work concerns this codebase, also maintain the glossary in .memory/CONTEXT.md and record hard-to-reverse decisions as ADRs under .memory/adr/. Use before writing a ticket, before starting non-trivial work, when a plan needs stress-testing, or when the user types `/grill`.
+description: Marigold repo — Interrogate an under-specified idea one question at a time until every decision branch is resolved, recommending an answer for each. When the work concerns this codebase, also maintain the glossary in .memory/CONTEXT.md and record hard-to-reverse decisions as ADRs under .memory/adr/. Use before writing a ticket, before starting non-trivial work, when a plan needs stress-testing, or when the user types `/grill`.
 ---
 
 # Grill

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: grill
+description: Interrogate an under-specified idea one question at a time until every decision branch is resolved, recommending an answer for each. When the work concerns this codebase, also maintain the glossary in .memory/CONTEXT.md and record hard-to-reverse decisions as ADRs under .memory/adr/. Use before writing a ticket, before starting non-trivial work, when a plan needs stress-testing, or when the user types `/grill`.
+---
+
+# Grill
+
+Turn an under-specified idea into a scoped one by interrogating it, then leave behind the part worth keeping.
+
+Two jobs, and the second only sometimes:
+
+1. **Always** — interrogate. One question at a time, each with your recommended answer, until every branch of the decision tree is resolved.
+2. **When the session concerns this codebase** — record. Vocabulary goes to `.memory/CONTEXT.md`; decisions that are hard to reverse go to `.memory/adr/`.
+
+Read [.memory/README.md](../../../.memory/README.md) before writing anything to `.memory/`. It defines what belongs there and — more importantly — what does not.
+
+## Usage
+
+```
+/grill                 # scope whatever is being discussed
+/grill <idea>          # scope a specific idea
+```
+
+## Workflow
+
+### 1. Establish what is being scoped
+
+State the idea back in one or two sentences before asking anything. If that restatement is already wrong, the interrogation is about to go the wrong way, and the user can correct it for free.
+
+### 2. Interrogate, one question at a time
+
+The rules that make this useful rather than annoying:
+
+- **One question per turn.** A list of six questions gets one answer and five shrugs.
+- **Always recommend.** Every question carries your recommended answer and the reason. The user is confirming or overruling a position, not filling in a blank form.
+- **Answer from the code, don't ask.** If a question is answerable by reading the repo, read the repo. Asking the user what the code already says wastes the turn and reduces trust in the questions that genuinely need them.
+- **Resolve dependencies in order.** When answer A changes which questions B and C even are, ask A first.
+- **Challenge vague terms against the code.** When someone says "the layout component" or "the wrapper", find out which one they mean. Half of scoping is discovering that two people have been using one word for two things — that discovery is what step 4 records.
+
+Stop when the remaining questions no longer change what gets built.
+
+### 3. Decide whether the documentation layer applies
+
+It applies when the session is about this codebase — a component, an API, an architectural call, a convention.
+
+It does not apply to one-off questions, throwaway exploration, or scoping that concerns process rather than code. In those sessions, finish at step 6 and write nothing. **A `/grill` session that records nothing is a normal outcome, not a failure.**
+
+### 4. Update the glossary
+
+If the session settled what a term means, add or correct its entry in `.memory/CONTEXT.md`.
+
+One term per `###` heading, kept alphabetical. Define the term and name what it is *not* when there is a neighbouring term it gets confused with — that confusion is usually why the entry is needed.
+
+Do not add rules here. A rule the agent must follow belongs in `CLAUDE.md`. The glossary says what words mean; it does not say what to do.
+
+### 5. Write an ADR when the bar is met
+
+Write one only when at least one of these holds:
+
+- **Hard to reverse.** Undoing it means a migration, a breaking change, or touching many files.
+- **Surprising without context.** Someone reading the code cold would "fix" it back, not understanding why it is the way it is.
+- **A live alternative was rejected.** Without the record, the same alternative gets proposed again next quarter.
+
+Copy `.memory/adr/TEMPLATE.md` to `.memory/adr/NNNN-<slug>.md`, taking the next free number. Fill in the frontmatter — `id`, `status`, `date`, and an `applies_to` glob narrow enough that the record only loads for work it governs.
+
+Set `status: proposed`. It becomes `accepted` when the PR carrying it merges.
+
+**Never edit an accepted ADR to change its decision.** Write a new one and set the old record's status to `superseded-by ADR-NNNN`. The history is the point; correcting the past in place destroys it.
+
+If none of the three criteria hold, write nothing. Records with the thinking removed are worse than absence — they look like documentation while doing nothing, and they cost context on every future session that loads them.
+
+### 6. Close with a scoped summary
+
+End with a short summary the user can act on: what is being built, the decisions that were settled, and anything explicitly ruled out of scope.
+
+Offer to hand it to `/create-ticket` once that skill exists. Do not file the ticket from here.
+
+If you wrote to `.memory/`, say exactly which files changed. These are committed, reviewed files — the user needs to know they are in the diff.
+
+## Limits worth knowing
+
+Records under `.memory/` are **advisory**. They enter the context window and influence what the agent does; nothing verifies compliance. An ADR that no check enforces is a well-argued comment, and a probabilistic reader cannot turn it into a guarantee. Write them because they compress genuine context, not because they constrain anything.

--- a/.claude/skills/grill/SKILL.md
+++ b/.claude/skills/grill/SKILL.md
@@ -47,11 +47,9 @@ It does not apply to one-off questions, throwaway exploration, or scoping that c
 
 ### 4. Update the glossary
 
-If the session settled what a term means, add or correct its entry in `.memory/CONTEXT.md`.
+If the session settled what a term means, add or correct its entry in `.memory/CONTEXT.md`, following the glossary conventions in [.memory/README.md](../../../.memory/README.md).
 
-One term per `###` heading, kept alphabetical. Define the term and name what it is *not* when there is a neighbouring term it gets confused with — that confusion is usually why the entry is needed.
-
-Do not add rules here. A rule the agent must follow belongs in `CLAUDE.md`. The glossary says what words mean; it does not say what to do.
+The one worth repeating because it is what gets this step wrong: do not add rules here. A rule the agent must follow belongs in `CLAUDE.md`. The glossary says what words mean; it does not say what to do.
 
 ### 5. Write an ADR when the bar is met
 
@@ -61,11 +59,9 @@ Write one only when at least one of these holds:
 - **Surprising without context.** Someone reading the code cold would "fix" it back, not understanding why it is the way it is.
 - **A live alternative was rejected.** Without the record, the same alternative gets proposed again next quarter.
 
-Copy `.memory/adr/TEMPLATE.md` to `.memory/adr/NNNN-<slug>.md`, taking the next free number. Fill in the frontmatter — `id`, `status`, `date`, and an `applies_to` glob narrow enough that the record only loads for work it governs.
+Copy `.memory/adr/TEMPLATE.md` to `.memory/adr/NNNN-<slug>.md` and fill in the frontmatter. `NNNN` is the DST ticket the decision was made under, not the next free number — the reason is in [.memory/README.md](../../../.memory/README.md), along with the rest of the ADR conventions and the rule against editing an accepted record.
 
-Set `status: proposed`. It becomes `accepted` when the PR carrying it merges.
-
-**Never edit an accepted ADR to change its decision.** Write a new one and set the old record's status to `superseded-by ADR-NNNN`. The history is the point; correcting the past in place destroys it.
+Set `status: proposed`, and tell the user it is the author's job to flip it to `accepted` in the PR once the review approves. Nothing does that automatically.
 
 If none of the three criteria hold, write nothing. Records with the thinking removed are worse than absence — they look like documentation while doing nothing, and they cost context on every future session that loads them.
 
@@ -79,4 +75,4 @@ If you wrote to `.memory/`, say exactly which files changed. These are committed
 
 ## Limits worth knowing
 
-Records under `.memory/` are **advisory**. They enter the context window and influence what the agent does; nothing verifies compliance. An ADR that no check enforces is a well-argued comment, and a probabilistic reader cannot turn it into a guarantee. Write them because they compress genuine context, not because they constrain anything.
+Records under `.memory/` are **advisory**, and nothing loads them on its own — see "What this is not" in [.memory/README.md](../../../.memory/README.md). Write them because they compress genuine context, not because they constrain anything.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Review a GitHub PR for Marigold Design System code quality, TypeScript standards, React best practices, and accessibility compliance. Optionally links Jira tickets for context. Use when asked to "review PR", "check PR", or "review pull request".
+description: Marigold repo — Review a GitHub PR for code quality, TypeScript standards, React best practices, and accessibility compliance. Optionally links Jira tickets for context. Use when asked to "review PR", "check PR", or "review pull request".
 ---
 
 # PR Review Skill for Marigold Design System

--- a/.claude/skills/vrt/SKILL.md
+++ b/.claude/skills/vrt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vrt
-description: Trigger the Visual-Regression-Tests (Chromatic) GitHub Actions workflow on the current or a given branch. Use ONLY when the user explicitly asks to run visual regression tests, run Chromatic, or types `/vrt`. Dispatching consumes Chromatic snapshot quota, so never invoke this proactively, never as a follow-up to unrelated work, and never to "verify" a change nobody asked to verify.
+description: Marigold repo — Trigger the Visual-Regression-Tests (Chromatic) GitHub Actions workflow on the current or a given branch. Use ONLY when the user explicitly asks to run visual regression tests, run Chromatic, or types `/vrt`. Dispatching consumes Chromatic snapshot quota, so never invoke this proactively, never as a follow-up to unrelated work, and never to "verify" a change nobody asked to verify.
 allowed-tools: Bash(gh workflow run *), Bash(gh run list *), Bash(gh run view *), Bash(gh run watch *), Bash(git branch --show-current), Bash(git rev-list *)
 ---
 

--- a/.memory/CONTEXT.md
+++ b/.memory/CONTEXT.md
@@ -1,0 +1,17 @@
+# Glossary
+
+What our terms mean, so an agent does not have to re-derive them — or guess — every session.
+
+Conventions and the boundary with `CLAUDE.md` are in [README.md](README.md). In short: one term per `###` heading, alphabetical, definitions only. Rules belong in `CLAUDE.md`.
+
+<!--
+Entry shape:
+
+### Term
+
+What it means, in one or two sentences.
+
+Not to be confused with <neighbouring term>, which is <distinction>.
+-->
+
+**This file is intentionally empty.** DST-1521 established the store and its conventions; the starter vocabulary is authored in DST-1530. Until then it fills up the way it is meant to — one term at a time, whenever a `/grill` session settles what a word actually means.

--- a/.memory/README.md
+++ b/.memory/README.md
@@ -12,6 +12,7 @@ Context an agent would otherwise re-derive every session: what our words mean, a
 | -------------------- | ------------------------------ | ----------------------------------- |
 | `CONTEXT.md`         | Glossary — what our terms mean | Descriptive, corrected in place     |
 | `adr/NNNN-<slug>.md` | Why a decision was made        | Historical, immutable once accepted |
+| `tasks/`             | Reserved — per-ticket specs    | Not in use yet; `/pick-up` fills it |
 
 ## The boundary with CLAUDE.md
 
@@ -39,19 +40,21 @@ Prune on sight. A wrong entry is worse than a missing one, because the agent has
 
 One term per `###` heading, alphabetical. Define the term, and name what it is _not_ when a neighbouring term gets confused with it.
 
-Split the file once it passes roughly 200 lines — long files get read less faithfully, and a glossary nobody finishes reading is a glossary that quietly stops working.
+Split the file once it passes roughly 200 lines — long files get read less faithfully, and a glossary nobody finishes reading is a glossary that quietly stops working. Split into `CONTEXT/<area>.md` and keep `CONTEXT.md` as the index that links them, so the one path `CLAUDE.md` and the skill both point at stays valid.
 
 **One term per heading is a merge-safety rule, not just tidiness.** Two branches appending different definitions of the same term in the same place produce a git conflict, which someone resolves. Two branches appending to a shared blob merge cleanly and leave the file holding two definitions that cannot both be true — with nothing failing to tell you.
 
 ## ADR conventions
 
-One decision per file, `adr/NNNN-<slug>.md`, numbered sequentially from `0001`. Start from `TEMPLATE.md`.
+One decision per file, `adr/NNNN-<slug>.md`, where `NNNN` is the DST ticket the decision was made under — `1521-memory-store-conventions.md` is `ADR-1521`. Start from `TEMPLATE.md`.
+
+**The number comes from the ticket, not from a sequence**, because a sequence is not merge-safe. Two branches each taking the next free `0002` produce two different filenames, so git merges both without complaint and leaves two records claiming the same `id` — the same clean-merge-into-contradiction this file warns about for the glossary above. Ticket numbers are already unique, already on the branch and the commits, and they link the record to the discussion for free. Two ADRs from one ticket is the only collision left, and it happens inside a single branch where you can see it: suffix the second `NNNN-b-<slug>`.
 
 Frontmatter carries:
 
-- **`id`** — stable and citable (`ADR-0001`), so a review comment can name the record it means.
-- **`status`** — `proposed` → `accepted`, then `superseded-by ADR-NNNN`. Never anything else.
-- **`applies_to`** — globs for the paths the decision governs. Narrow ones let an agent load only the records relevant to the file it is editing rather than the whole set.
+- **`id`** — stable and citable (`ADR-1521`), so a review comment can name the record it means.
+- **`status`** — `proposed` → `accepted`, then `superseded-by ADR-NNNN`. Never anything else. **The author flips `proposed` to `accepted` in the same PR, once the review approves and before it merges.** Nothing does this for you, and a status nobody moves stops meaning anything.
+- **`applies_to`** — globs for the paths the decision governs, so a reader pointed at this directory can tell in one line whether a record concerns the file in front of them. Nothing loads records on its own: no script consumes the glob and nothing puts `adr/` into a session by itself. Keep them narrow anyway — the day something does the selecting, wide globs are what makes it useless.
 
 Keep each record under ~200 lines. It competes for context with the code the agent actually needs to read.
 

--- a/.memory/README.md
+++ b/.memory/README.md
@@ -1,0 +1,64 @@
+# `.memory` — persistent context for agents
+
+Context an agent would otherwise re-derive every session: what our words mean, and why decisions were made the way they were.
+
+**This directory is committed and must not be added to `.gitignore`.** That is the whole point. Shared context has to travel with the repo and go through review like code — an agent-written note that nobody reviewed is not team knowledge, it is a rumour with a file path. It also happens to be the control that matters most for safety: `/grill` sessions read Jira tickets, PR comments and web pages, and content from those sources can end up proposed as a memory. Review is what stops a bad one from becoming something every future session treats as fact.
+
+`/grill` writes here. So can you, by hand.
+
+## What lives here
+
+| Path                 | Holds                          | Nature                              |
+| -------------------- | ------------------------------ | ----------------------------------- |
+| `CONTEXT.md`         | Glossary — what our terms mean | Descriptive, corrected in place     |
+| `adr/NNNN-<slug>.md` | Why a decision was made        | Historical, immutable once accepted |
+
+## The boundary with CLAUDE.md
+
+No rule lives in two places. Copies do not stay in sync; they disagree within a couple of months and then the agent picks one arbitrarily.
+
+- **`CLAUDE.md`** — normative. Rules the agent must follow. "Use `useClassNames`", "never expose `className`". Loaded every session.
+- **`.memory/CONTEXT.md`** — descriptive. What a term means. No rules, no instructions.
+- **`.memory/adr/`** — historical. Why a decision was made and what was rejected. Loaded when relevant.
+
+If you are about to write a rule into `CONTEXT.md`, it belongs in `CLAUDE.md`. If you are about to restate a `CLAUDE.md` rule in an ADR, link to it instead.
+
+## The write rule
+
+Persist something only if all three hold:
+
+1. **Durable** — it will still be true in three months.
+2. **Cross-session** — it is not specific to the task at hand.
+3. **Confident** — it was settled, not guessed.
+
+Anything task-local, fast-changing or uncertain stays in the session. The store is only useful while it is small enough to load and trustworthy enough to believe; every marginal entry costs context on every future session and dilutes both.
+
+Prune on sight. A wrong entry is worse than a missing one, because the agent has no way to doubt it.
+
+## Glossary conventions
+
+One term per `###` heading, alphabetical. Define the term, and name what it is _not_ when a neighbouring term gets confused with it.
+
+Split the file once it passes roughly 200 lines — long files get read less faithfully, and a glossary nobody finishes reading is a glossary that quietly stops working.
+
+**One term per heading is a merge-safety rule, not just tidiness.** Two branches appending different definitions of the same term in the same place produce a git conflict, which someone resolves. Two branches appending to a shared blob merge cleanly and leave the file holding two definitions that cannot both be true — with nothing failing to tell you.
+
+## ADR conventions
+
+One decision per file, `adr/NNNN-<slug>.md`, numbered sequentially from `0001`. Start from `TEMPLATE.md`.
+
+Frontmatter carries:
+
+- **`id`** — stable and citable (`ADR-0001`), so a review comment can name the record it means.
+- **`status`** — `proposed` → `accepted`, then `superseded-by ADR-NNNN`. Never anything else.
+- **`applies_to`** — globs for the paths the decision governs. Narrow ones let an agent load only the records relevant to the file it is editing rather than the whole set.
+
+Keep each record under ~200 lines. It competes for context with the code the agent actually needs to read.
+
+**Accepted ADRs are not edited to change a decision.** Supersede them: write the new record, then set the old one's status to `superseded-by ADR-NNNN`. Fixing the past in place destroys the reason the file existed.
+
+## What this is not
+
+These records are **advisory**. They enter the context window and influence what an agent does. Nothing verifies compliance — no check reads an ADR and blocks a change that violates it. A record that nothing enforces is a well-argued comment, and no amount of careful writing turns a probabilistic reader into a guarantee.
+
+Worth revisiting if a decision here ever matters enough to need one: pairing a record with a runnable check is what would turn it into a constraint.

--- a/.memory/adr/TEMPLATE.md
+++ b/.memory/adr/TEMPLATE.md
@@ -1,9 +1,9 @@
 ---
-id: ADR-NNNN
+id: ADR-NNNN # NNNN = the DST ticket this was decided under
 status: proposed # proposed | accepted | superseded-by ADR-NNNN
 date: YYYY-MM-DD
 applies_to:
-  - 'packages/components/src/**'
+  - 'CHANGEME/**'
 ---
 
 # NNNN. Short imperative title

--- a/.memory/adr/TEMPLATE.md
+++ b/.memory/adr/TEMPLATE.md
@@ -1,0 +1,25 @@
+---
+id: ADR-NNNN
+status: proposed # proposed | accepted | superseded-by ADR-NNNN
+date: YYYY-MM-DD
+applies_to:
+  - 'packages/components/src/**'
+---
+
+# NNNN. Short imperative title
+
+## Context
+
+What forced a decision. The constraints, the pressure, what was true at the time. Enough that someone reading this cold understands why it was not obvious.
+
+## Decision
+
+What we decided, in plain active voice. Use "must" and "must not" where the decision is binding.
+
+## Alternatives rejected
+
+What else was on the table and why it lost. **This is the section that stops the same proposal coming back next quarter** — a record without it is a decision with the thinking removed.
+
+## Consequences
+
+What this makes easy, what it makes hard, and what someone will have to live with. Include the bad parts; a record listing only benefits is not being honest about a trade-off.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,14 @@ Run with `pnpm test:unit`.
 
 Committed skills live in `.claude/skills/`; plugins are declared in `.claude/settings.json`. See [.claude/README.md](.claude/README.md) for the conventions they follow and the extra rules for skills with side effects.
 
+### Scoping work: `/grill`
+
+Start non-trivial work with `/grill`. It interrogates an under-specified idea one question at a time — each with a recommended answer — until every decision branch is resolved, and answers from the codebase rather than asking whenever it can.
+
+When the session concerns this codebase, it also records what is worth keeping, without being asked: settled vocabulary goes to `.memory/CONTEXT.md`, and decisions that are hard to reverse become ADRs under `.memory/adr/`. Sessions that are not about the code record nothing.
+
+`.memory/` is committed and reviewed like code — see [.memory/README.md](.memory/README.md) for what belongs there, what does not, and the rule that keeps it from duplicating this file.
+
 ## MCP Servers
 
 This project provides MCP servers for AI-assisted development:


### PR DESCRIPTION
# Description

Moves the `grill-me` skill out of personal config (`~/.claude/skills/`) and into the repo, so the team gets it from a fresh clone and it is reviewed like code. Adds the `.memory/` store it maintains: a glossary at `CONTEXT.md` and ADRs under `adr/`, both committed and deliberately **not** gitignored.

Closes DST-1521

> [!IMPORTANT]
> **Draft — blocked by #5750 (DST-1528/1529).**
> This builds on the skill conventions committed there, so it cannot merge until that does. GitHub retargets this to `main` automatically when #5750 merges, at which point this comes out of draft.
>
> #5754 (DST-1530) is in turn stacked on this one.

## What's here

| Path | |
| --- | --- |
| `.claude/skills/grill/SKILL.md` | The skill. One interrogation workflow; the documentation layer is gated on step 3 and stays off for sessions that aren't about the code. |
| `.memory/README.md` | Scope, the write rule, the boundary with `CLAUDE.md`, merge-safety and ADR conventions. |
| `.memory/CONTEXT.md` | Glossary skeleton. **Intentionally empty** — the ticket scopes seeding to DST-1530. |
| `.memory/adr/TEMPLATE.md` | ADR template with a mandatory "alternatives rejected" section. |
| `CLAUDE.md` | A "Scoping work: `/grill`" entry under AI Toolkit. |

## Five additions beyond the ticket

The ticket's decisions all stand — location, commit policy, one skill not two. Research into how teams are actually running repo-committed agent memory surfaced five gaps worth closing before the pattern sets. Recorded in full [on the ticket](https://reservix.atlassian.net/browse/DST-1521).

1. **ADR frontmatter**, not just a filename — a stable citable `id`, a `status` with a supersede chain, and `applies_to` globs so an agent loads only the records governing the file it's editing.
2. **An explicit boundary with `CLAUDE.md`** — rules there, meanings in `CONTEXT.md`, history in `adr/`. No rule lives in two places. Duplicated rules disagree within a couple of months and the model then picks one arbitrarily; DST-1529 was this exact failure with an inventory instead of a rule.
3. **Merge safety** — one term per heading, one decision per file. Two branches appending contradictory notes to a shared blob merge cleanly in git and leave a file holding two things that can't both be true, with nothing failing to signal it.
4. **A write rule** — persist only what's durable, cross-session and settled.
5. **A stated ceiling** — these records are advisory. Nothing checks compliance. Recorded so nobody later mistakes an ADR for a guarantee.

`.memory/` being committed is also the security control: persistent memory poisoning is tracked as OWASP ASI06 in the 2026 Agentic AI Top 10, and Anthropic's agent-memory docs warn that a writable store plus untrusted input lets an injection write content later sessions read as trusted. `/grill` reads Jira tickets, PR comments and web pages. Review-on-merge is what stops a bad entry becoming something every future session believes.

## Potential follow-up: namespacing first-party skills

This PR takes the cheap version — every repo skill's description now opens with `Marigold repo — `, so ours group visibly in a `/` menu that also lists plugin and personal skills. Invocation is unchanged (`/grill`, not `/mg-grill`).

The heavier option is a real prefix. Deliberately **not** done here; noted so the trade-off is on record.

**Pros**
- Unambiguous ownership at the call site — `/mg-review-pr` can't be confused with a personal or plugin skill of the same name.
- Pre-empts collisions. `review-pr` and `create-pr` are generic enough that someone's personal config could plausibly claim them.
- Makes "is this reviewed team tooling?" answerable without knowing where skills live.

**Cons**
- **A colon impersonates a real mechanism.** The harness already namespaces plugin skills (`vercel:react-best-practices`) and directory-scoped skills (`apps/web:deploy`) with `:`. A hand-written `mg:grill` is one flat literal name that every reader parses as a plugin called `mg`.
- **The problem is largely already solved.** Plugin skills arrive pre-namespaced. What's left unprefixed is personal skills — few, per-developer, and currently zero collisions against our four.
- **Permanent per-invocation cost for a cosmetic gain.** Typing the prefix forever, on every use.
- **Nothing enforces it.** The first skill that lands without the prefix makes absence meaningless and the convention becomes misleading rather than merely useless — the class of drift DST-1529 concluded we should stop committing.
- **Location already answers it and can't drift.** `.claude/skills/` is ours; `.claude/README.md` says so.
- Per our own conventions the **description** does the triggering, not the name — so a prefix adds tokens without buying any.

If we ever want real namespacing, the honest route is packaging these as a local plugin and letting the harness produce `marigold:grill` for free. The cost is that plugins are installed per-user and versioned upstream, which gives up the "committed, ours to edit" property that made moving `/grill` in-repo worth doing in the first place.

## Test Instructions

1. `.memory/` is committed on purpose — confirm `git check-ignore .memory` reports nothing.
2. Open a fresh session and check `/grill` appears, with `Marigold repo — ` leading its description alongside `/create-pr`, `/review-pr`, `/vrt`.
3. Read `.memory/README.md` and push on the boundary rule — it's the one thing here that decides whether this store stays useful or rots.
4. A live `/grill` run on a real under-specified idea is the actual test; that's happening next and findings will be reported here.

## Breaking Changes

No. Nothing outside `.claude/`, `.memory/` and `CLAUDE.md`; no package or theme code touched, so no changeset.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes) — N/A, no UI changes
- [ ] Changeset added (`pnpm changeset`) — N/A, no published package touched
