### PR TITLE
fix(DST-1730): remove theme z-index, guard *.styles.ts, reconcile the scale

### DIFF
--- a/.changeset/toggle-button-theme-zindex.md
+++ b/.changeset/toggle-button-theme-zindex.md
@@ -1,0 +1,13 @@
+---
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1730): drop the duplicated focus z-index from `ToggleButton`'s theme styles.
+
+`in-[.group]:focus-visible:z-10` sat in both the theme's `button` slot and `ToggleButton` itself.
+Rendered output is unchanged — `cn()` was deduping the pair, which the component's inline class
+snapshots confirm by still passing untouched. What it removes is the drift: two copies of one
+stacking decision, either of which could be changed without the other.
+
+Stacking order is a guarantee the component makes, not something a theme should be able to
+reorder. `pnpm check:theme-zindex` now fails CI on any z-index in a `*.styles.ts`.

--- a/.github/workflows/theme-conventions.yml
+++ b/.github/workflows/theme-conventions.yml
@@ -1,0 +1,23 @@
+name: theme conventions
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  theme-conventions:
+    name: Check theme conventions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Node (using .node-version)
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+      # Reads source files only — no install, no build.
+      - name: Assert no z-index in theme style files
+        run: node scripts/check-theme-zindex.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,23 +170,32 @@ Z-index values are centralized and standardized across the design system to ensu
 **Z-Index Scale** (the agreed convention for which utility maps to which layer):
 
 ```text
-/* Content Layer (0-10) */
-z-1    /* Sticky headers (Table, Accordion, ListBox) */
-z-10   /* Focus states (Calendar) */
+/* Content layer — inside the component's own stacking context */
+z-0    /* Holds a part behind its siblings without taking it out of flow */
+z-1    /* Sticky content in a scroll container */
+z-10   /* Lifts one item above its immediate siblings */
 
-/* Floating Layer (20-49) */
-z-20   /* Dropdowns (Select, ComboBox) */
-z-30   /* Popovers, Menus, Tooltips, ActionBar */
+/* Floating layer — anchored to a trigger, escaping the content flow */
+z-30   /* Popover, Tooltip, ActionBar */
 
-/* Overlay Layer (50-79) */
-z-50   /* Modal overlays, Drawer overlays, Underlay */
+/* Overlay layer */
+z-50   /* Modal surfaces and the underlay behind them */
 
-/* Notification Layer (80-99) */
-z-80   /* Toast notifications, Drawer close button */
+/* Notification layer */
+z-80   /* Must stay above a modal */
 
-/* System Layer (100+) */
-z-100  /* Touch hitbox utility */
+/* System layer */
+z-100  /* ui-touch-hitbox — the one z-index outside a component; see Rules */
 ```
+
+Each rung is defined by its **role**, because that is the part that stays true. For which
+components sit on a rung today, ask the code: `grep -rnE '\bz-[0-9]' packages/components/src`.
+An earlier version of this scale named components per rung, and every single rung had drifted.
+
+**There is deliberately no `z-20`.** It used to read "Dropdowns (Select, ComboBox)", but both
+render their list through `Popover` and therefore already stack at `z-30` — nothing has ever
+carried `z-20`. Giving dropdowns their own rung would change the stacking order, which is a
+different decision from writing down the one we have.
 
 **Component Examples**:
 
@@ -214,9 +223,10 @@ export const Toast: ThemeComponent = {
 **Rules**:
 
 - Always apply z-index classes in component implementations using Tailwind utilities (`z-1`, `z-30`, etc.)
-- Never add z-index classes to theme style files (`*.styles.ts`)
+- Never add z-index classes to theme style files (`*.styles.ts`). `pnpm check:theme-zindex` enforces this in CI — a theme must not be able to reorder the layers
 - Use `cn()` utility to combine z-index with other classNames
 - Exception: Some third-party libraries may require an inline `zIndex` prop
+- Exception: `themes/theme-rui/src/ui.css` sets `z-100` on the `ui-touch-hitbox` utility. The pseudo-element it stacks has no component to own it, so this is the one sanctioned z-index outside `packages/components/src/`. It lives in a `.css` file, which is why the guard's `*.styles.ts` glob does not reach it
 
 **Stacking Hierarchy**:
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "clean": "rm -rf `find . -type d -name 'node_modules' -o -name 'dist' -o -name '.next' -o -name '.turbo' -o -name 'storybook-static' -o -name 'coverage'`",
     "clean:build": "rm -rf `find . -type d -name 'dist'` coverage",
     "lint": "eslint . --no-warn-ignored",
+    "check:theme-zindex": "node scripts/check-theme-zindex.mjs",
     "format": "prettier --write \"**/*\"",
     "format:check": "prettier --check \"**/*\"",
     "format:fix": "prettier --write \"**/*\" --fix",

--- a/packages/components/src/ToggleButton/ToggleButton.tsx
+++ b/packages/components/src/ToggleButton/ToggleButton.tsx
@@ -43,6 +43,9 @@ export const _ToggleButton = ({
     <ToggleButton
       isSelected={selected}
       isDisabled={disabled}
+      // With the group no longer clipping, the standard ui-state-focus outline
+      // (from ui-button-base) renders unclipped. Lift it above the neighbouring
+      // segments so the full ring shows. (DST-1597)
       className={cn(classNames.button, 'in-[.group]:focus-visible:z-10')}
       {...props}
     >

--- a/scripts/check-theme-zindex.mjs
+++ b/scripts/check-theme-zindex.mjs
@@ -12,10 +12,16 @@
  * harmless on the day, drift bait afterwards, and nothing noticed for two tickets. That is
  * the argument for a guard rather than a third cleanup.
  *
- * Deliberately not covered: `themes/theme-rui/src/ui.css`. Its `z-100` sits on the
- * `ui-touch-hitbox` pseudo-element, which has no component to own it. That is the one
- * sanctioned exception, and it is a `.css` file rather than a `*.styles.ts`, so the glob
- * excludes it structurally rather than by a special case.
+ * Scope is `*.styles.{ts,tsx}` — the theme's class definitions, which is exactly what the
+ * CLAUDE.md rule names. Plain `.css` in a theme is not scanned at all: raw CSS sometimes has
+ * to stack something that has no component to own it, which is why `themes/theme-rui/src/ui.css`
+ * legitimately sets `z-100` on the `ui-touch-hitbox` pseudo-element. That exemption is the
+ * glob's shape, not a named special case — but it does mean a z-index added to any other theme
+ * `.css` file would also go unseen.
+ *
+ * Known limit: this reads source text, so a class assembled at runtime (`'z-' + level`) is
+ * invisible to it. Closing that would need a TypeScript AST, which is far more machinery than
+ * a convention guard is worth. It catches what people actually write.
  *
  * Run locally: `pnpm check:theme-zindex`
  */
@@ -31,15 +37,20 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 // the hyphen before `z` is a word boundary too.
 // The trailing lookahead rather than `\b`: an arbitrary value ends in `]`, and `\b` cannot
 // match between `]` and the closing quote, so `z-[100]` would slip through.
-const Z_UTILITY = /(?<=^|[\s'"`:{[(])(-?z-(?:\d+|\[[^\]]*\]|auto))(?![\w-])/gm;
-// `[z-index:…]` arbitrary properties and any stray CSS-in-JS `zIndex`.
-const Z_PROPERTY = /\bz-index\s*:|\bzIndex\b/g;
+// The `(…)` alternative is Tailwind v4's custom-property shorthand: `z-(--stack)` is the same
+// utility as `z-[var(--stack)]`, and that shorthand is already used inside these files.
+const Z_UTILITY =
+  /(?<=^|[\s'"`:{[(])(-?z-(?:\d+|\[[^\]]*\]|\([^)]*\)|auto))(?![\w-])/gm;
+// `[z-index:…]` arbitrary properties and any stray CSS-in-JS `zIndex`. Both require the value
+// to follow, so prose that merely names `zIndex` — a comment explaining why one is absent, say
+// — does not trip the guard.
+const Z_PROPERTY = /\bz-index\s*:|\bzIndex\s*[:=]/g;
 
 const errors = [];
 
 const lineOf = (source, index) => source.slice(0, index).split('\n').length;
 
-for (const file of globSync('**/*.styles.ts', {
+for (const file of globSync('**/*.styles.{ts,tsx}', {
   cwd: root,
   exclude: name => name === 'node_modules' || name === 'dist',
 })) {
@@ -69,5 +80,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  '✅ theme z-index guard passed: no z-index in any *.styles.ts — components own stacking order.'
+  '✅ theme z-index guard passed: no z-index in any *.styles.{ts,tsx} — components own stacking order.'
 );

--- a/scripts/check-theme-zindex.mjs
+++ b/scripts/check-theme-zindex.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Fails when a `*.styles.ts` theme file carries a z-index utility.
+ *
+ * Stacking order is a component guarantee, not a theme opinion: a toast has to sit above a
+ * modal, a tooltip below it, and those relationships hold across every theme. Leaving the
+ * value in a theme means a theme can silently reorder the layers. `CLAUDE.md` → "Z-Index
+ * Management" carries the rule and the scale; this only enforces where the values live.
+ *
+ * DST-1547 moved the utilities into the component implementations. DST-1597 then put one
+ * back into `ToggleButton.styles.ts`, duplicating the class the component already applied —
+ * harmless on the day, drift bait afterwards, and nothing noticed for two tickets. That is
+ * the argument for a guard rather than a third cleanup.
+ *
+ * Deliberately not covered: `themes/theme-rui/src/ui.css`. Its `z-100` sits on the
+ * `ui-touch-hitbox` pseudo-element, which has no component to own it. That is the one
+ * sanctioned exception, and it is a `.css` file rather than a `*.styles.ts`, so the glob
+ * excludes it structurally rather than by a special case.
+ *
+ * Run locally: `pnpm check:theme-zindex`
+ */
+import { globSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// A z-index utility starts a class, so it follows a quote, whitespace, a backtick, or a
+// variant's `:` — never a letter. Anchoring on that is what keeps Tailwind's 3D transforms
+// (`translate-z-10`, `rotate-z-45`) out of the match; a bare `\bz-[0-9]` flags those, because
+// the hyphen before `z` is a word boundary too.
+// The trailing lookahead rather than `\b`: an arbitrary value ends in `]`, and `\b` cannot
+// match between `]` and the closing quote, so `z-[100]` would slip through.
+const Z_UTILITY = /(?<=^|[\s'"`:{[(])(-?z-(?:\d+|\[[^\]]*\]|auto))(?![\w-])/gm;
+// `[z-index:…]` arbitrary properties and any stray CSS-in-JS `zIndex`.
+const Z_PROPERTY = /\bz-index\s*:|\bzIndex\b/g;
+
+const errors = [];
+
+const lineOf = (source, index) => source.slice(0, index).split('\n').length;
+
+for (const file of globSync('**/*.styles.ts', {
+  cwd: root,
+  exclude: name => name === 'node_modules' || name === 'dist',
+})) {
+  const source = readFileSync(resolve(root, file), 'utf8');
+
+  for (const match of source.matchAll(Z_UTILITY)) {
+    errors.push(
+      `${file}:${lineOf(source, match.index)}: carries \`${match[1]}\`. Move it to the ` +
+        'component that renders this slot — stacking order is a guarantee the component ' +
+        'makes, and a theme must not be able to change it.'
+    );
+  }
+
+  for (const match of source.matchAll(Z_PROPERTY)) {
+    errors.push(
+      `${file}:${lineOf(source, match.index)}: sets a z-index directly. Same rule: the ` +
+        'component owns stacking order, not the theme.'
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error('❌ theme z-index guard failed:\n');
+  for (const e of errors) console.error(`  • ${e}\n`);
+  console.error('The scale and the rule: CLAUDE.md → "Z-Index Management".');
+  process.exit(1);
+}
+
+console.log(
+  '✅ theme z-index guard passed: no z-index in any *.styles.ts — components own stacking order.'
+);

--- a/themes/theme-rui/src/components/ToggleButton.styles.ts
+++ b/themes/theme-rui/src/components/ToggleButton.styles.ts
@@ -36,10 +36,6 @@ export const ToggleButton: ThemeComponent<'ToggleButton'> = {
       // so the group needs no overflow clip. Border lives here, not
       // ui-button-base.
       'in-[.group]:rounded-none in-[.group]:first:rounded-l-surface in-[.group]:last:rounded-r-surface in-[.group]:ring-0 in-[.group]:shadow-none in-[.group]:border-r in-[.group]:border-r-border in-[.group]:last:border-r-0 in-[.group]:hover:[--ui-border-color:initial]',
-      // Focus. With the group no longer clipping, the standard ui-state-focus
-      // outline (from ui-button-base) renders unclipped. Lift it above the
-      // neighbouring segments so the full ring shows. (DST-1597)
-      'in-[.group]:focus-visible:z-10',
     ],
     variants: {
       size: {


### PR DESCRIPTION
# Description

Stacking order is a guarantee the component makes — a toast above a modal, a tooltip below one — and it has to hold across every theme. `CLAUDE.md` says z-index utilities live in component implementations, never in `*.styles.ts`. DST-1547 enforced that by hand; DST-1597 put one back.

Three things, all from the same root cause: the rule had no enforcement and the documentation of it had quietly stopped being true.

**1. The duplicate is gone.** `in-[.group]:focus-visible:z-10` sat in both `ToggleButton.styles.ts` and `ToggleButton.tsx`. The deletion is provably inert rather than merely low-risk: the theme's `button` slot has exactly one consumer, and it appends the identical class unconditionally. `ToggleButtonGroup` reads a different slot; `SegmentedControl` has its own theme component. The component's full-class-string inline snapshots pass **without being updated**, so the rendered `class` attribute is byte-identical — `cn()` had been collapsing the pair all along. The explanatory comment moved to the class that survives.

**2. A guard, so this is the last cleanup.** `pnpm check:theme-zindex` fails on any z-index in a `*.styles.ts`.

It does not use the `z-[0-9]` grep the ticket suggested, because that also matches Tailwind v4's 3D transforms — `translate-z-10` and `rotate-z-45` both contain a word boundary before `z`. The guard anchors on a class boundary instead. It also uses a trailing `(?![\w-])` rather than `\b`: an arbitrary value ends in `]`, and `\b` cannot match between `]` and the closing quote, so `z-[100]` escaped.

Review then found three more bypasses, all now closed and covered by the suite: Tailwind v4's `z-(--stack)` custom-property shorthand (not hypothetical — `Checkbox.styles.ts` already uses `border-(--ui-border-color)`), a `.styles.tsx` file falling outside the glob, and a comment merely naming `zIndex` being reported as an error.

Two limits are stated in the header rather than left implied. A class assembled at runtime (`'z-' + level`) is invisible to a text-level check; closing that needs a TypeScript AST, which is more machinery than a convention guard earns. And plain `.css` in a theme is not scanned at all — that is what makes `ui.css`'s `z-100` exempt, and it means a z-index in any other theme `.css` would also go unseen.

**3. The scale now describes the code.** Every rung had drifted, not just the `z-20` the ticket named:

| Rung | Documented | Actually |
| --- | --- | --- |
| `z-1` | Table, Accordion, ListBox | + TopNavigation, ListBoxItem, legacy Table |
| `z-10` | "Focus states (Calendar)" | CalendarGrid, MobileAutocomplete, SegmentedControl, TableDropIndicator, ToggleButton |
| `z-20` | Dropdowns (Select, ComboBox) | **unused** |
| `z-50` | Modal, Drawer, Underlay | + Tray, SidebarModal |
| `z-0` | *absent* | SegmentedControl indicator |

Re-listing the components correctly would just reset the same clock, so each rung now states its **role** and points at a grep for today's members.

**`z-20` is deleted rather than populated.** The ticket suggested moving Select/ComboBox onto it, but told me to verify first — and both render their list through the shared `Popover`, which already carries `z-30`. They do not lack a z-index; the Popover owns it. Giving dropdowns their own rung would move them below other popovers, a stacking-order change the ticket explicitly excludes. The absence is now recorded so nobody re-adds it.

The `ui.css` `z-100` exception is stated explicitly: the `ui-touch-hitbox` pseudo-element has no component to own it, and being a `.css` file it falls outside the guard's glob structurally rather than by a special case.

Closes DST-1730

## Test Instructions

1. `pnpm check:theme-zindex` — passes.
2. Reintroduce the exact regression and confirm it fails with an accurate `file:line`:
   ```sh
   echo "export const X = { a: cva({ base: ['in-[.group]:focus-visible:z-10'] }) };" \
     > themes/theme-rui/src/components/__Probe.styles.ts
   pnpm check:theme-zindex   # exits 1
   rm themes/theme-rui/src/components/__Probe.styles.ts
   ```
3. Confirm it leaves 3D transforms alone (swap the class for `translate-z-10` above — exits 0).
4. `pnpm test:unit --run ToggleButton SegmentedControl` — 23 pass, snapshots unmodified.

## Breaking Changes

No.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable) — N/A
- [ ] Unit tests added/updated — N/A; the existing class snapshots are the proof, and they were not touched
- [ ] Component documentation added/updated (if it exists) — N/A
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components) — N/A
- [ ] Visual regression tests updated (for UI changes) — no rendered change; see the snapshot argument above
- [x] Changeset added (`pnpm changeset`)
