### PR TITLE
fix(DST-1675): treat `collapsed` as axis-less when resolving inset padding

### DIFF
--- a/.changeset/dst-1675_axisless-collapsed-token.md
+++ b/.changeset/dst-1675_axisless-collapsed-token.md
@@ -14,4 +14,4 @@ That variable went undeclared until it was added to `@marigold/theme-rui`, so th
 
 `isScale` is unchanged: `collapsed` stays non-numeric there, because `createWidthVar`, `createHeightVar` and `createSpacingVar` depend on that classification.
 
-**Theme:** `--spacing-collapsed-x` and `--spacing-collapsed-y` are removed from `@marigold/theme-rui`. They existed only to satisfy the suffix that is no longer generated, and nothing else referenced them.
+**Theme:** `--spacing-collapsed-x` and `--spacing-collapsed-y` are removed from `@marigold/theme-rui`. They shipped in `theme-rui` 6.0.0 stable but existed only to satisfy the suffix that is no longer generated — nothing else referenced them, and the documented token has always been `collapsed`.

--- a/.changeset/dst-1675_axisless-collapsed-token.md
+++ b/.changeset/dst-1675_axisless-collapsed-token.md
@@ -1,0 +1,17 @@
+---
+'@marigold/system': patch
+'@marigold/components': patch
+'@marigold/theme-rui': patch
+---
+
+fix(DST-1675): treat `collapsed` as axis-less when resolving inset padding
+
+`resolveInsetAxes` appended an axis suffix to every non-numeric inset token, including `collapsed` — the one token where an axis split is meaningless, since it means "no spacing" on both axes. So `<Panel p="collapsed">` resolved to `var(--spacing-collapsed-x)` rather than `var(--spacing-collapsed)`.
+
+That variable went undeclared until it was added to `@marigold/theme-rui`, so the declaration was invalid at computed-value time and `padding` fell back to its initial value of `0` — the right answer for the wrong reason. The cost was that every theme implementing this API had to ship three variables that all mean `0` (`--spacing-collapsed`, `-x`, `-y`) to make one documented prop value work, with nothing to tell it so.
+
+`collapsed` is now recognised as axis-less and passed through unsuffixed, so a theme declares `--spacing-collapsed` only. The same guard is applied to the deliberately-divergent copy of the axis logic in `SelectList`, which had the identical bug on its `p` prop. A new `isAxislessToken` predicate is exported from `@marigold/system` so the concept has one home instead of being inlined at both call sites.
+
+`isScale` is unchanged: `collapsed` stays non-numeric there, because `createWidthVar`, `createHeightVar` and `createSpacingVar` depend on that classification.
+
+**Theme:** `--spacing-collapsed-x` and `--spacing-collapsed-y` are removed from `@marigold/theme-rui`. They existed only to satisfy the suffix that is no longer generated, and nothing else referenced them.

--- a/packages/components/src/Panel/Panel.stories.tsx
+++ b/packages/components/src/Panel/Panel.stories.tsx
@@ -903,5 +903,21 @@ export const CustomPadding = meta.story(() => (
         <Button>Action</Button>
       </Panel.Footer>
     </Panel>
+
+    <Panel p="collapsed">
+      <Panel.Header>
+        <Title>No padding</Title>
+        <Description>
+          Using <code>p="collapsed"</code> — the universal no-spacing token, for
+          wrappers that should render edge to edge.
+        </Description>
+      </Panel.Header>
+      <Panel.Content>
+        <Text>Every section sits flush against the panel edge.</Text>
+      </Panel.Content>
+      <Panel.Footer>
+        <Button>Action</Button>
+      </Panel.Footer>
+    </Panel>
   </Stack>
 ));

--- a/packages/components/src/Panel/Panel.test.tsx
+++ b/packages/components/src/Panel/Panel.test.tsx
@@ -138,6 +138,22 @@ describe('Panel', () => {
       );
     });
 
+    test('`p="collapsed"` writes the unsuffixed token on both axes', () => {
+      render(<CustomPadding.Component />);
+
+      const collapsedRegion = screen.getByRole('region', {
+        name: 'No padding',
+      });
+
+      // No `-x` / `-y` suffix: a theme only declares `--spacing-collapsed`.
+      expect(collapsedRegion.style.getPropertyValue('--panel-px')).toBe(
+        'var(--spacing-collapsed)'
+      );
+      expect(collapsedRegion.style.getPropertyValue('--panel-py')).toBe(
+        'var(--spacing-collapsed)'
+      );
+    });
+
     test('`px` / `py` set the axes independently', () => {
       render(<CustomPadding.Component />);
 

--- a/packages/components/src/SelectList/SelectList.stories.tsx
+++ b/packages/components/src/SelectList/SelectList.stories.tsx
@@ -755,10 +755,11 @@ WithCustomPadding.test(
       'var(--spacing-collapsed)'
     );
 
-    // And it resolves, rather than falling back to 0 because it is undefined.
-    const styles = getComputedStyle(standardRow);
-    expect(styles.paddingLeft).toBe('0px');
-    expect(styles.paddingTop).toBe('0px');
+    // Resolution, not fallback: a failed substitution would compute to the
+    // guaranteed-invalid value, which reads back as ''.
+    const listStyles = getComputedStyle(list);
+    expect(listStyles.getPropertyValue('--selectlist-item-px')).not.toBe('');
+    expect(listStyles.getPropertyValue('--selectlist-item-py')).not.toBe('');
   }
 );
 

--- a/packages/components/src/SelectList/SelectList.stories.tsx
+++ b/packages/components/src/SelectList/SelectList.stories.tsx
@@ -737,6 +737,31 @@ WithCustomPadding.test(
   }
 );
 
+WithCustomPadding.test(
+  'resolves the axis-less `collapsed` token to zero padding',
+  {
+    parameters: { chromatic: { disableSnapshot: true } },
+    args: { p: 'collapsed' },
+  },
+  async ({ canvas }) => {
+    const standardRow = await canvas.findByRole('row', { name: /standard/i });
+    const list = standardRow.closest('[role="grid"]') as HTMLElement;
+
+    // No `-x` / `-y` suffix: a theme only declares `--spacing-collapsed`.
+    expect(list.style.getPropertyValue('--selectlist-item-px')).toBe(
+      'var(--spacing-collapsed)'
+    );
+    expect(list.style.getPropertyValue('--selectlist-item-py')).toBe(
+      'var(--spacing-collapsed)'
+    );
+
+    // And it resolves, rather than falling back to 0 because it is undefined.
+    const styles = getComputedStyle(standardRow);
+    expect(styles.paddingLeft).toBe('0px');
+    expect(styles.paddingTop).toBe('0px');
+  }
+);
+
 export const EmptyState = meta.story({
   args: {
     items: [],

--- a/packages/components/src/SelectList/SelectList.stories.tsx
+++ b/packages/components/src/SelectList/SelectList.stories.tsx
@@ -17,6 +17,7 @@ import { SelectList } from './SelectList';
 // it back to `undefined` so the component falls through to the theme's
 // variant-based fallback.
 const insetTokens = [
+  'collapsed',
   'square-tight',
   'square-snug',
   'square-regular',

--- a/packages/components/src/SelectList/SelectList.test.tsx
+++ b/packages/components/src/SelectList/SelectList.test.tsx
@@ -458,6 +458,21 @@ describe('SelectList', () => {
       );
     });
 
+    test('`p="collapsed"` writes the unsuffixed token on both axes', () => {
+      render(<Basic.Component p="collapsed" />);
+
+      const grid = screen.getByRole('grid') as HTMLElement;
+
+      // `collapsed` means "no spacing" on both axes, so there is no
+      // `--spacing-collapsed-x` / `-y` for a theme to declare.
+      expect(grid.style.getPropertyValue('--selectlist-item-px')).toBe(
+        'var(--spacing-collapsed)'
+      );
+      expect(grid.style.getPropertyValue('--selectlist-item-py')).toBe(
+        'var(--spacing-collapsed)'
+      );
+    });
+
     test('axis-specific `px` / `py` write only the matching axis var inline', () => {
       render(<Basic.Component px="padding-relaxed" py="padding-tight" />);
 

--- a/packages/components/src/SelectList/SelectList.tsx
+++ b/packages/components/src/SelectList/SelectList.tsx
@@ -21,7 +21,13 @@ import type {
   SpaceProp,
   WidthProp,
 } from '@marigold/system';
-import { cn, createSpacingVar, isScale, useClassNames } from '@marigold/system';
+import {
+  cn,
+  createSpacingVar,
+  isAxislessToken,
+  isScale,
+  useClassNames,
+} from '@marigold/system';
 import { FieldBase } from '../FieldBase/FieldBase';
 import { HiddenSelection } from '../HiddenSelection/HiddenSelection';
 import { SelectListContext } from './Context';
@@ -252,12 +258,20 @@ const SelectList = <Mode extends SelectionMode = 'single'>({
     // 3. Partial-axis overrides are valid — px and py are applied independently,
     //    letting the theme fill in whichever axis the consumer leaves unset.
     // Don't "consolidate" this with resolveInsetAxes without accounting for all three.
+    // The axis-suffix rule itself is shared, though: both paths must skip the
+    // suffix for scale values and axis-less tokens.
     if (p !== undefined) {
       const inset = `${p}`;
-      const scale = isScale(inset);
+      const unsuffixed = isScale(inset) || isAxislessToken(inset);
       return {
-        ...createSpacingVar('selectlist-item-px', scale ? inset : `${inset}-x`),
-        ...createSpacingVar('selectlist-item-py', scale ? inset : `${inset}-y`),
+        ...createSpacingVar(
+          'selectlist-item-px',
+          unsuffixed ? inset : `${inset}-x`
+        ),
+        ...createSpacingVar(
+          'selectlist-item-py',
+          unsuffixed ? inset : `${inset}-y`
+        ),
       };
     }
     return {

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -97,6 +97,7 @@ export {
   createWidthVar,
   createHeightVar,
   ensureCssVar,
+  isAxislessToken,
   isFraction,
   isScale,
   isValidCssCustomPropertyName,

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -38,6 +38,11 @@ describe('isScale', () => {
   ])('should return %s for "%s"', (input, expected) => {
     expect(isScale(input)).toBe(expected);
   });
+
+  it('does not classify the no-spacing token as a scale value', () => {
+    // createWidthVar / createHeightVar / createSpacingVar depend on this.
+    expect(isScale('collapsed')).toBe(false);
+  });
 });
 
 describe('isFraction', () => {
@@ -238,10 +243,12 @@ describe('isAxislessToken', () => {
     }
   );
 
-  it('does not classify the no-spacing token as a scale value', () => {
-    // createWidthVar / createHeightVar / createSpacingVar depend on this.
-    expect(isScale('collapsed')).toBe(false);
-  });
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'does not resolve inherited Object property "%s" as axis-less',
+    value => {
+      expect(isAxislessToken(value)).toBe(false);
+    }
+  );
 });
 
 describe('createWidthVar', () => {

--- a/packages/system/src/utils/css-variables.utils.test.ts
+++ b/packages/system/src/utils/css-variables.utils.test.ts
@@ -5,6 +5,7 @@ import {
   createVar,
   createWidthVar,
   ensureCssVar,
+  isAxislessToken,
   isFraction,
   isScale,
   isValidCssCustomPropertyName,
@@ -204,6 +205,42 @@ describe('resolveInsetAxes', () => {
       px: 'square-relaxed-x',
       py: 'square-relaxed-y',
     });
+  });
+
+  it('leaves the axis-less "collapsed" token unsuffixed on both axes', () => {
+    // An axis split is meaningless for "no spacing" — suffixing it would force
+    // every theme to declare --spacing-collapsed-x / -y as aliases of 0.
+    expect(
+      resolveInsetAxes({ p: 'collapsed', defaultInset: 'square-regular' })
+    ).toEqual({
+      px: 'collapsed',
+      py: 'collapsed',
+    });
+  });
+
+  it('leaves "collapsed" unsuffixed when it comes from the default inset', () => {
+    expect(resolveInsetAxes({ defaultInset: 'collapsed' })).toEqual({
+      px: 'collapsed',
+      py: 'collapsed',
+    });
+  });
+});
+
+describe('isAxislessToken', () => {
+  it('reports the no-spacing token as axis-less', () => {
+    expect(isAxislessToken('collapsed')).toBe(true);
+  });
+
+  it.each(['square-regular', 'squish-tight', 'padding-loose', '4', ''])(
+    'reports "%s" as having per-axis forms',
+    token => {
+      expect(isAxislessToken(token)).toBe(false);
+    }
+  );
+
+  it('does not classify the no-spacing token as a scale value', () => {
+    // createWidthVar / createHeightVar / createSpacingVar depend on this.
+    expect(isScale('collapsed')).toBe(false);
   });
 });
 

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -2,8 +2,6 @@ import type { CSSProperties } from 'react';
 import type { NoSpacingToken } from '../types/tokens';
 
 /**
- * The one spacing token that has no per-axis form.
- *
  * Kept in sync with `NoSpacingToken` by the annotation: adding a member to that
  * type is a type error here until it is listed.
  */

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -1,4 +1,31 @@
 import type { CSSProperties } from 'react';
+import type { NoSpacingToken } from '../types/tokens';
+
+/**
+ * The one spacing token that has no per-axis form.
+ *
+ * Kept in sync with `NoSpacingToken` by the annotation: adding a member to that
+ * type is a type error here until it is listed.
+ */
+const AXISLESS_TOKENS: readonly NoSpacingToken[] = ['collapsed'];
+
+/**
+ * Checks whether a spacing token is axis-less, i.e. splitting it into `-x` /
+ * `-y` variants would be meaningless.
+ *
+ * `collapsed` means "no spacing" on both axes, so there is nothing for an axis
+ * suffix to distinguish. Treating it as axis-less keeps themes from having to
+ * declare three variables (`--spacing-collapsed{,-x,-y}`) that all mean `0`.
+ *
+ * Note this is deliberately *not* folded into {@link isScale}: `collapsed` is
+ * not numeric, and `createWidthVar` / `createHeightVar` / `createSpacingVar`
+ * rely on it being classified that way.
+ *
+ * @param value - The token to test.
+ * @returns `true` if the token has no per-axis form, otherwise `false`.
+ */
+export const isAxislessToken = (value: string) =>
+  (AXISLESS_TOKENS as readonly string[]).includes(value);
 
 /**
  * Checks if the provided string represents a numeric scale value.
@@ -146,7 +173,9 @@ const makeDimensionVar =
  * When `p` is a numeric scale value (e.g. `"4"`) the same value is used on
  * both axes (`calc(var(--spacing) * 4)`). When it is a named token (e.g.
  * `"square-regular"`) the conventional `-x` / `-y` suffixes are appended so
- * the right axis-specific spacing variable is referenced.
+ * the right axis-specific spacing variable is referenced. Axis-less tokens
+ * (see {@link isAxislessToken}) are passed through unsuffixed — `collapsed`
+ * means `0` on both axes, so there is no per-axis variable to reference.
  *
  * @param options - Destructured options object.
  * @param options.p - The shorthand padding prop (`InsetSpacingTokens` or a scale number).
@@ -166,10 +195,10 @@ export const resolveInsetAxes = ({
   defaultInset: string;
 }): { px: string; py: string } => {
   const inset = `${p ?? defaultInset}`;
-  const scale = isScale(inset);
+  const unsuffixed = isScale(inset) || isAxislessToken(inset);
   return {
-    px: `${px ?? (scale ? inset : `${inset}-x`)}`,
-    py: `${py ?? (scale ? inset : `${inset}-y`)}`,
+    px: `${px ?? (unsuffixed ? inset : `${inset}-x`)}`,
+    py: `${py ?? (unsuffixed ? inset : `${inset}-y`)}`,
   };
 };
 

--- a/packages/system/src/utils/css-variables.utils.ts
+++ b/packages/system/src/utils/css-variables.utils.ts
@@ -7,7 +7,7 @@ import type { NoSpacingToken } from '../types/tokens';
  * Kept in sync with `NoSpacingToken` by the annotation: adding a member to that
  * type is a type error here until it is listed.
  */
-const AXISLESS_TOKENS: readonly NoSpacingToken[] = ['collapsed'];
+const AXISLESS_TOKENS: Record<NoSpacingToken, true> = { collapsed: true };
 
 /**
  * Checks whether a spacing token is axis-less, i.e. splitting it into `-x` /
@@ -25,7 +25,7 @@ const AXISLESS_TOKENS: readonly NoSpacingToken[] = ['collapsed'];
  * @returns `true` if the token has no per-axis form, otherwise `false`.
  */
 export const isAxislessToken = (value: string) =>
-  (AXISLESS_TOKENS as readonly string[]).includes(value);
+  Object.hasOwn(AXISLESS_TOKENS, value);
 
 /**
  * Checks if the provided string represents a numeric scale value.

--- a/themes/theme-rui/src/tokens.css
+++ b/themes/theme-rui/src/tokens.css
@@ -291,13 +291,10 @@
 
   /* Universal: no spacing (works for gap, padding, and inset recipes).
    *
-   * The `-x` / `-y` variants are required, not redundant: `collapsed` is a
-   * member of `InsetSpacingTokens`, and `resolveInsetAxes` appends the axis
-   * suffix to every non-numeric token — so `<Panel p="collapsed">` resolves to
-   * `var(--spacing-collapsed-x)` and would otherwise be undefined. */
+   * One variable is enough: `resolveInsetAxes` treats `collapsed` as axis-less
+   * and skips the `-x` / `-y` suffix, so `<Panel p="collapsed">` resolves to
+   * `var(--spacing-collapsed)` directly. */
   --spacing-collapsed: --spacing(0);
-  --spacing-collapsed-x: --spacing(0);
-  --spacing-collapsed-y: --spacing(0);
 
   /* Relational spacing */
   --spacing-tight: --spacing(1.5);


### PR DESCRIPTION
# Description

`resolveInsetAxes` appended an axis suffix to **every** non-numeric inset token, including `collapsed` — the one token where an axis split is meaningless, since it means "no spacing" on both axes. So `<Panel p="collapsed">` resolved to `var(--spacing-collapsed-x)` rather than `var(--spacing-collapsed)`.

That variable went undeclared until DST-1672 (#5693) added it, so the declaration was invalid at computed-value time and — `padding` not being inherited — fell back to its initial value of `0`. The right answer for entirely the wrong reason. The cost was that every theme implementing this API had to ship three variables that all mean `0` to make one documented prop value work, with nothing to tell it so.

**Current → new behaviour:** `<Panel p="collapsed">` still computes `padding: 0px`, but now because `var(--spacing-collapsed)` *resolves*, not because the reference fails. A theme declares one token instead of three.

Three things worth a reviewer's attention:

- **`isAxislessToken` is a new export from `@marigold/system`**, sitting next to `isScale`. It's backed by a `readonly NoSpacingToken[]`, so adding a member to that type is a type error until it's listed here — the concept gets one home rather than a string check inlined at two call sites.
- **`SelectList` got the same guard applied in place, not consolidated.** `SelectList.tsx` hand-rolls the same axis logic and had the identical bug on its `p` prop. The existing comment documents three deliberate divergences from `resolveInsetAxes`, so merging the two functions would be wrong; I left that comment intact and added a line noting that the axis-suffix rule specifically *is* shared.
- **`isScale` is untouched, deliberately.** `collapsed` must stay non-numeric there because `createWidthVar`, `createHeightVar` and `createSpacingVar` all depend on that classification. A test now pins it.

Closes DST-1675

## Screenshots / Preview

This is a "nothing should look different" change — the point is that `p="collapsed"` already rendered at `0`, just for the wrong reason. Rather than a before/after image, here is the computed-style evidence from Storybook after rebuilding `@marigold/system` and `@marigold/theme-rui`, with `--spacing-collapsed-x` / `-y` genuinely absent from the document:

| Panel (`Components/Panel/CustomPadding`) | inline `--panel-px` | computed | section padding |
| ---------------------------------------- | ------------------- | -------- | --------------- |
| `p="square-loose"` | `var(--spacing-square-loose-x)` | `calc(0.25rem * 6)` | `24px` |
| `px="padding-relaxed" py="padding-snug"` | `var(--spacing-padding-relaxed)` | `calc(0.25rem * 4)` | `16px` |
| **`p="collapsed"`** | **`var(--spacing-collapsed)`** | **`0px`** | **`0px`** |

The first two rows are the unchanged control cases. The third is the fix.

<!-- Chromatic will still diff the new `p="collapsed"` Panel example; no visual delta is expected on the existing two. -->

## Test Instructions

1. `pnpm install && pnpm build` (the system + theme packages must be rebuilt — Storybook resolves `@marigold/system` from `dist/`).
2. `pnpm test:unit` — new `resolveInsetAxes` cases for `collapsed` via both `p` and `defaultInset`, a new `isAxislessToken` block, and a `SelectList` case for the inline vars.
3. `pnpm test:sb` — `SelectList/WithCustomPadding` gains a `.test()` that asserts computed `paddingLeft`/`paddingTop` are `0px` in a real browser. This is the assertion the unit suite structurally *cannot* make, and the reason the original defect was invisible: a CSS custom-property declaration can't be checked from jsdom.
4. `pnpm sb` → `Components/Panel/CustomPadding`. The third panel (`p="collapsed"`) should sit flush to its edges; the first two should be unchanged.
5. To confirm the fix is load-bearing: re-add `--spacing-collapsed-x`/`-y` to `themes/theme-rui/src/tokens.css` and note that nothing changes — they are genuinely dead now.

## Breaking Changes

No — but flagging one judgment call for the reviewer.

`--spacing-collapsed-x` and `--spacing-collapsed-y` are **removed** from `@marigold/theme-rui`. They are CSS custom properties that did ship in a released version (they came in with the v18 changes, #5304), so by a strict reading this is a public removal.

I've treated it as a patch because they existed *only* to satisfy a suffix the resolver no longer generates: nothing in the repo referenced them, they were never documented, and the documented token has always been `collapsed`. A consumer would have had to hand-write `var(--spacing-collapsed-x)` against an internal workaround to be affected. Migration in that unlikely case is a one-word edit to `var(--spacing-collapsed)`.

Happy to bump this to a minor and add the 🚨 label if you read it the other way — I didn't want a breaking-change label sitting on a patch changeset without agreement.

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)