### PR TITLE
fix(DST-1673): keep example tables readable at narrow widths

### DIFF
--- a/.changeset/example-table-narrow-width.md
+++ b/.changeset/example-table-narrow-width.md
@@ -11,13 +11,17 @@ the sidebar 352px, leaving 401px for content, which pinned all five columns of
 146px over the Title column.
 
 Columns now carry widths (a fraction plus a floor for the flexible ones, a
-fixed width for the predictable ones), and the users, dashboard, report and
-picker tables sit in `Scrollable`, so they scroll instead of overlapping. On
-the dashboard that also stops the activity table inflating its panel, which is
-what could wrap the 2:1 pair before `collapseAt` asked for it.
+fixed width for the predictable ones), and the users, dashboard and report
+tables sit in `Scrollable`, so they scroll instead of overlapping. The picker
+dialog's table already scrolled and only gains the widths. On the dashboard
+that scroll container also stops the activity table inflating its panel, which
+is what could wrap the 2:1 pair before `collapseAt` asked for it.
 
-The filter table keeps the widths but no `Scrollable`: its `actionBar` overlay
-renders inside `Table` as `sticky bottom-…`, so wrapping the component from
-outside would re-anchor it. Its cells no longer overlap, but the columns past
-the container edge stay unreachable until `Table` can own that scroll
-container itself.
+The filter table gets fraction-only widths and no floors. It cannot have a
+`Scrollable` of its own yet, because its `actionBar` overlay renders inside
+`Table` as `sticky bottom-…` and an outer wrapper would re-anchor it. Since a
+static width also becomes that column's floor, floors on eleven columns would
+push the table past its container at 1440px with nothing to scroll. Fractions
+leave the floor where it already was, so the table keeps filling its container
+at desktop width, where the name cell no longer overlaps, and narrow viewports
+stay as they are until `Table` can own that scroll container itself.

--- a/.changeset/example-table-narrow-width.md
+++ b/.changeset/example-table-narrow-width.md
@@ -1,0 +1,23 @@
+---
+'@marigold/docs': patch
+---
+
+fix(DST-1673): keep example tables readable when they outgrow their container
+
+Example tables declared no column widths, so every column fell back to
+react-aria's 75px default. In the examples shell a 768px viewport still gives
+the sidebar 352px, leaving 401px for content, which pinned all five columns of
+`/examples/users` at that floor and let the nowrap name-and-email cell paint
+146px over the Title column.
+
+Columns now carry widths (a fraction plus a floor for the flexible ones, a
+fixed width for the predictable ones), and the users, dashboard, report and
+picker tables sit in `Scrollable`, so they scroll instead of overlapping. On
+the dashboard that also stops the activity table inflating its panel, which is
+what could wrap the 2:1 pair before `collapseAt` asked for it.
+
+The filter table keeps the widths but no `Scrollable`: its `actionBar` overlay
+renders inside `Table` as `sticky bottom-…`, so wrapping the component from
+outside would re-anchor it. Its cells no longer overlap, but the columns past
+the container edge stay unreachable until `Table` can own that scroll
+container itself.

--- a/docs/app/(examples)/examples/filter/VenuesTable.tsx
+++ b/docs/app/(examples)/examples/filter/VenuesTable.tsx
@@ -242,25 +242,48 @@ export const VenuesTable = () => {
           )}
         >
           <Table.Header>
-            <Table.Column id="name" rowHeader allowsSorting>
+            <Table.Column
+              id="name"
+              rowHeader
+              allowsSorting
+              width="2fr"
+              minWidth={200}
+            >
               Name
             </Table.Column>
-            <Table.Column id="type">Type</Table.Column>
-            <Table.Column id="address">Address</Table.Column>
-            <Table.Column id="capacity" alignX="right" allowsSorting>
+            <Table.Column id="type" width={130}>
+              Type
+            </Table.Column>
+            <Table.Column id="address" width="1fr" minWidth={190}>
+              Address
+            </Table.Column>
+            <Table.Column
+              id="capacity"
+              alignX="right"
+              allowsSorting
+              width={110}
+            >
               Capacity
             </Table.Column>
-            <Table.Column id="price" alignX="right" allowsSorting>
+            <Table.Column id="price" alignX="right" allowsSorting width={120}>
               Max. Price
             </Table.Column>
-            <Table.Column id="traits">Traits</Table.Column>
-            <Table.Column id="amenities">Amenities</Table.Column>
-            <Table.Column id="parking">Parking</Table.Column>
-            <Table.Column id="rating" alignX="right">
+            <Table.Column id="traits" width="1fr" minWidth={160}>
+              Traits
+            </Table.Column>
+            <Table.Column id="amenities" width="1fr" minWidth={160}>
+              Amenities
+            </Table.Column>
+            <Table.Column id="parking" width={140}>
+              Parking
+            </Table.Column>
+            <Table.Column id="rating" alignX="right" width={100}>
               Rating
             </Table.Column>
-            <Table.Column id="available">Available</Table.Column>
-            <Table.Column id="actions">
+            <Table.Column id="available" width={120}>
+              Available
+            </Table.Column>
+            <Table.Column id="actions" width={72}>
               <VisuallyHidden>Actions</VisuallyHidden>
             </Table.Column>
           </Table.Header>

--- a/docs/app/(examples)/examples/filter/VenuesTable.tsx
+++ b/docs/app/(examples)/examples/filter/VenuesTable.tsx
@@ -241,9 +241,6 @@ export const VenuesTable = () => {
             </ActionBar>
           )}
         >
-          {/* Fraction-only widths. A static width becomes the column's floor
-              too, and eleven floors do not fit this container, which has no
-              scroll container of its own to fall back on. */}
           <Table.Header>
             <Table.Column id="name" rowHeader allowsSorting width="2fr">
               Name

--- a/docs/app/(examples)/examples/filter/VenuesTable.tsx
+++ b/docs/app/(examples)/examples/filter/VenuesTable.tsx
@@ -241,49 +241,46 @@ export const VenuesTable = () => {
             </ActionBar>
           )}
         >
+          {/* Fraction-only widths. A static width becomes the column's floor
+              too, and eleven floors do not fit this container, which has no
+              scroll container of its own to fall back on. */}
           <Table.Header>
-            <Table.Column
-              id="name"
-              rowHeader
-              allowsSorting
-              width="2fr"
-              minWidth={200}
-            >
+            <Table.Column id="name" rowHeader allowsSorting width="2fr">
               Name
             </Table.Column>
-            <Table.Column id="type" width={130}>
+            <Table.Column id="type" width="1fr">
               Type
             </Table.Column>
-            <Table.Column id="address" width="1fr" minWidth={190}>
+            <Table.Column id="address" width="2fr">
               Address
             </Table.Column>
             <Table.Column
               id="capacity"
               alignX="right"
               allowsSorting
-              width={110}
+              width="1fr"
             >
               Capacity
             </Table.Column>
-            <Table.Column id="price" alignX="right" allowsSorting width={120}>
+            <Table.Column id="price" alignX="right" allowsSorting width="1fr">
               Max. Price
             </Table.Column>
-            <Table.Column id="traits" width="1fr" minWidth={160}>
+            <Table.Column id="traits" width="1.5fr">
               Traits
             </Table.Column>
-            <Table.Column id="amenities" width="1fr" minWidth={160}>
+            <Table.Column id="amenities" width="1.5fr">
               Amenities
             </Table.Column>
-            <Table.Column id="parking" width={140}>
+            <Table.Column id="parking" width="1fr">
               Parking
             </Table.Column>
-            <Table.Column id="rating" alignX="right" width={100}>
+            <Table.Column id="rating" alignX="right" width="1fr">
               Rating
             </Table.Column>
-            <Table.Column id="available" width={120}>
+            <Table.Column id="available" width="1fr">
               Available
             </Table.Column>
-            <Table.Column id="actions" width={72}>
+            <Table.Column id="actions" width="1fr">
               <VisuallyHidden>Actions</VisuallyHidden>
             </Table.Column>
           </Table.Header>

--- a/docs/app/(examples)/examples/page.tsx
+++ b/docs/app/(examples)/examples/page.tsx
@@ -12,6 +12,7 @@ import {
   LinkButton,
   Page,
   Panel,
+  Scrollable,
   Stack,
   Table,
   Text,
@@ -105,27 +106,37 @@ const DashboardPage = () => (
           <Description>What your team has been up to.</Description>
         </Panel.Header>
         <Panel.Content bleed>
-          <Table aria-label="Recent activity">
-            <Table.Header>
-              <Table.Column rowHeader>Member</Table.Column>
-              <Table.Column>Activity</Table.Column>
-              <Table.Column>When</Table.Column>
-            </Table.Header>
-            <Table.Body>
-              {activity.map(entry => (
-                <Table.Row key={entry.id}>
-                  <Table.Cell>{byId(entry.who)?.name}</Table.Cell>
-                  <Table.Cell>{entry.action}</Table.Cell>
-                  <Table.Cell>
-                    <DateFormat
-                      value={new Date(entry.date)}
-                      dateStyle="medium"
-                    />
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table>
+          {/* `Scrollable` earns its place twice here: it gives the table
+              somewhere to go below the column widths' sum, and its own
+              min-content is zero, so the table can no longer inflate this
+              panel and wrap the 2:1 pair before `collapseAt` says to. */}
+          <Scrollable>
+            <Table aria-label="Recent activity">
+              <Table.Header>
+                <Table.Column rowHeader width="1fr" minWidth={150}>
+                  Member
+                </Table.Column>
+                <Table.Column width="2fr" minWidth={200}>
+                  Activity
+                </Table.Column>
+                <Table.Column width={130}>When</Table.Column>
+              </Table.Header>
+              <Table.Body>
+                {activity.map(entry => (
+                  <Table.Row key={entry.id}>
+                    <Table.Cell>{byId(entry.who)?.name}</Table.Cell>
+                    <Table.Cell>{entry.action}</Table.Cell>
+                    <Table.Cell>
+                      <DateFormat
+                        value={new Date(entry.date)}
+                        dateStyle="medium"
+                      />
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table>
+          </Scrollable>
         </Panel.Content>
       </Panel>
 

--- a/docs/app/(examples)/examples/page.tsx
+++ b/docs/app/(examples)/examples/page.tsx
@@ -106,10 +106,6 @@ const DashboardPage = () => (
           <Description>What your team has been up to.</Description>
         </Panel.Header>
         <Panel.Content bleed>
-          {/* `Scrollable` earns its place twice here: it gives the table
-              somewhere to go below the column widths' sum, and its own
-              min-content is zero, so the table can no longer inflate this
-              panel and wrap the 2:1 pair before `collapseAt` says to. */}
           <Scrollable>
             <Table aria-label="Recent activity">
               <Table.Header>

--- a/docs/app/(examples)/examples/pick/PickVenuesDialog.tsx
+++ b/docs/app/(examples)/examples/pick/PickVenuesDialog.tsx
@@ -18,7 +18,7 @@ import {
   Tag,
   Text,
 } from '@marigold/components';
-import { type Venue, statusVariant, venues } from './venues';
+import { type Venue, statusVariant, venueColumnWidths, venues } from './venues';
 
 // Type and region options are derived from the data so they never drift from
 // it: every option maps to real venues, and every venue value is selectable.
@@ -297,17 +297,35 @@ const PickBody = ({
               onSelectionChange={onSelectionChange}
             >
               <Table.Header sticky>
-                <Table.Column rowHeader>Venue</Table.Column>
-                <Table.Column>City</Table.Column>
-                <Table.Column>Region</Table.Column>
-                <Table.Column>Country</Table.Column>
-                <Table.Column>Type</Table.Column>
-                <Table.Column>Setting</Table.Column>
-                <Table.Column alignX="right">Capacity</Table.Column>
-                <Table.Column alignX="right">Rating</Table.Column>
-                <Table.Column alignX="right">Upcoming</Table.Column>
-                <Table.Column>Status</Table.Column>
-                <Table.Column alignX="right">Day rate</Table.Column>
+                <Table.Column rowHeader {...venueColumnWidths.name}>
+                  Venue
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.city}>City</Table.Column>
+                <Table.Column {...venueColumnWidths.region}>
+                  Region
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.country}>
+                  Country
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.type}>Type</Table.Column>
+                <Table.Column {...venueColumnWidths.setting}>
+                  Setting
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.capacity}>
+                  Capacity
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.rating}>
+                  Rating
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.upcoming}>
+                  Upcoming
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.status}>
+                  Status
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.rate}>
+                  Day rate
+                </Table.Column>
               </Table.Header>
               <Table.Body
                 items={results}

--- a/docs/app/(examples)/examples/pick/ReportVenues.tsx
+++ b/docs/app/(examples)/examples/pick/ReportVenues.tsx
@@ -6,11 +6,12 @@ import {
   EmptyState,
   Inline,
   Panel,
+  Scrollable,
   Table,
   Text,
 } from '@marigold/components';
 import { PickVenuesDialog } from './PickVenuesDialog';
-import { statusVariant, venues } from './venues';
+import { statusVariant, venueColumnWidths, venues } from './venues';
 
 export const ReportVenues = () => {
   // The report starts empty; picking builds the committed set, which then lives
@@ -43,42 +44,64 @@ export const ReportVenues = () => {
         </Panel.Content>
       ) : (
         <Panel.Content bleed>
-          <Table aria-label="Report venues">
-            <Table.Header>
-              <Table.Column rowHeader>Venue</Table.Column>
-              <Table.Column>City</Table.Column>
-              <Table.Column>Region</Table.Column>
-              <Table.Column>Country</Table.Column>
-              <Table.Column>Type</Table.Column>
-              <Table.Column>Setting</Table.Column>
-              <Table.Column alignX="right">Capacity</Table.Column>
-              <Table.Column alignX="right">Rating</Table.Column>
-              <Table.Column alignX="right">Upcoming</Table.Column>
-              <Table.Column>Status</Table.Column>
-              <Table.Column alignX="right">Day rate</Table.Column>
-            </Table.Header>
-            <Table.Body items={chosen}>
-              {venue => (
-                <Table.Row id={venue.id}>
-                  <Table.Cell>{venue.name}</Table.Cell>
-                  <Table.Cell>{venue.city}</Table.Cell>
-                  <Table.Cell>{venue.region}</Table.Cell>
-                  <Table.Cell>{venue.country}</Table.Cell>
-                  <Table.Cell>{venue.type}</Table.Cell>
-                  <Table.Cell>{venue.setting}</Table.Cell>
-                  <Table.Cell alignX="right">{venue.capacity}</Table.Cell>
-                  <Table.Cell alignX="right">{venue.rating}</Table.Cell>
-                  <Table.Cell alignX="right">{venue.events}</Table.Cell>
-                  <Table.Cell>
-                    <Badge variant={statusVariant[venue.status]}>
-                      {venue.status}
-                    </Badge>
-                  </Table.Cell>
-                  <Table.Cell alignX="right">{venue.rate}</Table.Cell>
-                </Table.Row>
-              )}
-            </Table.Body>
-          </Table>
+          {/* Eleven columns never fit a narrow panel, so the table scrolls
+              inside `Scrollable` rather than being clipped by the page. */}
+          <Scrollable>
+            <Table aria-label="Report venues">
+              <Table.Header>
+                <Table.Column rowHeader {...venueColumnWidths.name}>
+                  Venue
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.city}>City</Table.Column>
+                <Table.Column {...venueColumnWidths.region}>
+                  Region
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.country}>
+                  Country
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.type}>Type</Table.Column>
+                <Table.Column {...venueColumnWidths.setting}>
+                  Setting
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.capacity}>
+                  Capacity
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.rating}>
+                  Rating
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.upcoming}>
+                  Upcoming
+                </Table.Column>
+                <Table.Column {...venueColumnWidths.status}>
+                  Status
+                </Table.Column>
+                <Table.Column alignX="right" {...venueColumnWidths.rate}>
+                  Day rate
+                </Table.Column>
+              </Table.Header>
+              <Table.Body items={chosen}>
+                {venue => (
+                  <Table.Row id={venue.id}>
+                    <Table.Cell>{venue.name}</Table.Cell>
+                    <Table.Cell>{venue.city}</Table.Cell>
+                    <Table.Cell>{venue.region}</Table.Cell>
+                    <Table.Cell>{venue.country}</Table.Cell>
+                    <Table.Cell>{venue.type}</Table.Cell>
+                    <Table.Cell>{venue.setting}</Table.Cell>
+                    <Table.Cell alignX="right">{venue.capacity}</Table.Cell>
+                    <Table.Cell alignX="right">{venue.rating}</Table.Cell>
+                    <Table.Cell alignX="right">{venue.events}</Table.Cell>
+                    <Table.Cell>
+                      <Badge variant={statusVariant[venue.status]}>
+                        {venue.status}
+                      </Badge>
+                    </Table.Cell>
+                    <Table.Cell alignX="right">{venue.rate}</Table.Cell>
+                  </Table.Row>
+                )}
+              </Table.Body>
+            </Table>
+          </Scrollable>
         </Panel.Content>
       )}
     </Panel>

--- a/docs/app/(examples)/examples/pick/ReportVenues.tsx
+++ b/docs/app/(examples)/examples/pick/ReportVenues.tsx
@@ -44,8 +44,6 @@ export const ReportVenues = () => {
         </Panel.Content>
       ) : (
         <Panel.Content bleed>
-          {/* Eleven columns never fit a narrow panel, so the table scrolls
-              inside `Scrollable` rather than being clipped by the page. */}
           <Scrollable>
             <Table aria-label="Report venues">
               <Table.Header>

--- a/docs/app/(examples)/examples/pick/venues.ts
+++ b/docs/app/(examples)/examples/pick/venues.ts
@@ -724,3 +724,22 @@ export const statusVariant: Record<string, 'success' | 'warning' | 'default'> =
     Held: 'warning',
     Booked: 'default',
   };
+
+// Column widths for the venue tables, shared so the picker and the committed
+// report stay in step. Set at all because a column without a width falls back
+// to react-aria's 75px default, which squeezes every column under its content
+// until neighbouring cells paint over each other. The flexible columns take a
+// fraction plus a floor, the predictable ones a fixed width.
+export const venueColumnWidths = {
+  name: { width: '2fr', minWidth: 200 },
+  city: { width: 130 },
+  region: { width: 150 },
+  country: { width: 120 },
+  type: { width: 130 },
+  setting: { width: 110 },
+  capacity: { width: 110 },
+  rating: { width: 100 },
+  upcoming: { width: 110 },
+  status: { width: 120 },
+  rate: { width: 110 },
+} as const;

--- a/docs/app/(examples)/examples/pick/venues.ts
+++ b/docs/app/(examples)/examples/pick/venues.ts
@@ -728,8 +728,7 @@ export const statusVariant: Record<string, 'success' | 'warning' | 'default'> =
 // Column widths for the venue tables, shared so the picker and the committed
 // report stay in step. Set at all because a column without a width falls back
 // to react-aria's 75px default, which squeezes every column under its content
-// until neighbouring cells paint over each other. The flexible columns take a
-// fraction plus a floor, the predictable ones a fixed width.
+// until neighbouring cells paint over each other.
 export const venueColumnWidths = {
   name: { width: '2fr', minWidth: 200 },
   city: { width: 130 },

--- a/docs/app/(examples)/examples/users/page.tsx
+++ b/docs/app/(examples)/examples/users/page.tsx
@@ -10,6 +10,7 @@ import {
   Inline,
   Page,
   Panel,
+  Scrollable,
   Stack,
   Table,
   Text,
@@ -36,49 +37,62 @@ const UsersPage = () => (
     </Page.Header>
     <Panel aria-label="Members">
       <Panel.Content bleed>
-        <Table aria-label="Members">
-          <Table.Header>
-            <Table.Column rowHeader>Name</Table.Column>
-            <Table.Column>Title</Table.Column>
-            <Table.Column>Role</Table.Column>
-            <Table.Column>Status</Table.Column>
-            <Table.Column>Joined</Table.Column>
-          </Table.Header>
-          <Table.Body>
-            {people.map(person => (
-              <Table.Row key={person.id} href={`/examples/users/${person.id}`}>
-                <Table.Cell>
-                  <Inline space="related" alignY="center" noWrap>
-                    <img
-                      src={person.avatar}
-                      alt=""
-                      className="block size-8 shrink-0 rounded-full"
+        {/* Columns carry widths so they never fall back to the 75px default,
+            which squeezes them under their content and lets the name cell
+            paint over its neighbour. `Scrollable` then gives the table
+            somewhere to go when the sum no longer fits. */}
+        <Scrollable>
+          <Table aria-label="Members">
+            <Table.Header>
+              <Table.Column rowHeader width="2fr" minWidth={240}>
+                Name
+              </Table.Column>
+              <Table.Column width="1fr" minWidth={170}>
+                Title
+              </Table.Column>
+              <Table.Column width={110}>Role</Table.Column>
+              <Table.Column width={110}>Status</Table.Column>
+              <Table.Column width={120}>Joined</Table.Column>
+            </Table.Header>
+            <Table.Body>
+              {people.map(person => (
+                <Table.Row
+                  key={person.id}
+                  href={`/examples/users/${person.id}`}
+                >
+                  <Table.Cell>
+                    <Inline space="related" alignY="center" noWrap>
+                      <img
+                        src={person.avatar}
+                        alt=""
+                        className="block size-8 shrink-0 rounded-full"
+                      />
+                      <Stack space="collapsed">
+                        <Text weight="semibold">{person.name}</Text>
+                        <Text variant="muted" fontSize="xs">
+                          {person.email}
+                        </Text>
+                      </Stack>
+                    </Inline>
+                  </Table.Cell>
+                  <Table.Cell>{person.position}</Table.Cell>
+                  <Table.Cell>{person.role}</Table.Cell>
+                  <Table.Cell>
+                    <Badge variant={statusVariant[person.status]}>
+                      {person.status}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <DateFormat
+                      value={new Date(person.joined)}
+                      dateStyle="medium"
                     />
-                    <Stack space="collapsed">
-                      <Text weight="semibold">{person.name}</Text>
-                      <Text variant="muted" fontSize="xs">
-                        {person.email}
-                      </Text>
-                    </Stack>
-                  </Inline>
-                </Table.Cell>
-                <Table.Cell>{person.position}</Table.Cell>
-                <Table.Cell>{person.role}</Table.Cell>
-                <Table.Cell>
-                  <Badge variant={statusVariant[person.status]}>
-                    {person.status}
-                  </Badge>
-                </Table.Cell>
-                <Table.Cell>
-                  <DateFormat
-                    value={new Date(person.joined)}
-                    dateStyle="medium"
-                  />
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Scrollable>
       </Panel.Content>
     </Panel>
   </Page>

--- a/docs/app/(examples)/examples/users/page.tsx
+++ b/docs/app/(examples)/examples/users/page.tsx
@@ -44,7 +44,7 @@ const UsersPage = () => (
         <Scrollable>
           <Table aria-label="Members">
             <Table.Header>
-              <Table.Column rowHeader width="2fr" minWidth={240}>
+              <Table.Column rowHeader width="2fr" minWidth={280}>
                 Name
               </Table.Column>
               <Table.Column width="1fr" minWidth={170}>

--- a/docs/app/(examples)/examples/users/page.tsx
+++ b/docs/app/(examples)/examples/users/page.tsx
@@ -37,10 +37,6 @@ const UsersPage = () => (
     </Page.Header>
     <Panel aria-label="Members">
       <Panel.Content bleed>
-        {/* Columns carry widths so they never fall back to the 75px default,
-            which squeezes them under their content and lets the name cell
-            paint over its neighbour. `Scrollable` then gives the table
-            somewhere to go when the sum no longer fits. */}
         <Scrollable>
           <Table aria-label="Members">
             <Table.Header>

--- a/docs/content/components/collection/table/index.mdx
+++ b/docs/content/components/collection/table/index.mdx
@@ -101,6 +101,20 @@ Proper alignment makes data easier to scan and compare. Different data types ben
 
 <ComponentDemo name="table-cell-alignment" />
 
+### Column widths
+
+A column without a `width` falls back to react-aria's 75px minimum, so a narrow container squeezes every column down to that floor. Cell content that cannot shrink then paints outside its own cell, because cells do not clip. Give columns a width to keep the table a predictable size:
+
+- **A fraction (`2fr`, `1.5fr`)** for text columns that should absorb the space left over, like names, addresses or descriptions.
+- **A number** for columns whose content has a predictable size, like a badge, a date or a row action.
+- **`minWidth`** on fraction columns, to set the width at which the column stops shrinking. A static `width` is its own floor already and needs no `minWidth`.
+
+Those floors added together are the smallest width the table can take. Where that can exceed the space available, wrap the table in a [`<Scrollable>`](/components/layout/scrollable) so the columns stay reachable instead of being clipped by the page.
+
+<ComponentDemo name="table-column-widths" />
+
+A table without a scroll container has to fit its container at every width, so keep its floors low: fraction widths on their own divide up the available space without raising the minimum.
+
 ### Selecting rows
 
 When users need to perform actions on multiple items at once, enable row selection. This allows users to select individual rows or all rows, then perform bulk operations like delete, export, or modify. The [Bulk Actions pattern](/patterns/user-input/bulk-actions) describes the complete flow from selection to result feedback, including the [`<ActionBar>`](/components/collection/actionbar) that carries the actions.

--- a/docs/content/components/collection/table/table-column-widths.demo.tsx
+++ b/docs/content/components/collection/table/table-column-widths.demo.tsx
@@ -1,0 +1,49 @@
+import { venues } from '@/lib/data/venues';
+import { NumericFormat, Scrollable, Table, Text } from '@marigold/components';
+
+export default () => {
+  return (
+    <Scrollable>
+      <Table aria-label="Venues by capacity">
+        <Table.Header>
+          <Table.Column rowHeader width="2fr" minWidth={220}>
+            Venue
+          </Table.Column>
+          <Table.Column width="1fr" minWidth={180}>
+            Address
+          </Table.Column>
+          <Table.Column width={140}>City</Table.Column>
+          <Table.Column width={120} alignX="right">
+            Capacity
+          </Table.Column>
+          <Table.Column width={120} alignX="right">
+            Rating
+          </Table.Column>
+        </Table.Header>
+        <Table.Body>
+          {venues.slice(0, 5).map(venue => (
+            <Table.Row key={venue.id}>
+              <Table.Cell>
+                <Text weight="medium">{venue.name}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                {venue.street}, {venue.postcode}
+              </Table.Cell>
+              <Table.Cell>{venue.city}</Table.Cell>
+              <Table.Cell>
+                <NumericFormat value={venue.capacity} />
+              </Table.Cell>
+              <Table.Cell>
+                <NumericFormat
+                  value={venue.rating}
+                  minimumFractionDigits={1}
+                  maximumFractionDigits={1}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </Scrollable>
+  );
+};


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Examples:
  feat(DST-1234): add loading state to Button
  fix(DST-5678): correct focus ring on Select
  chore(DST-9012): bump react-aria to 1.5.0

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

`/examples/users` kept all five columns below roughly 800px of viewport width instead of scrolling, squeezing them under their content until the name cell's text lay on top of the Title column.

Two gaps cause it, and they only bite together. A `Table.Column` without a `width` falls back to react-aria's default `minWidth` of 75px, and the examples shell still gives the sidebar 352px at a 768px viewport, leaving 401px for content. Five columns at 75px do not fit, so every column pins at that floor. The Name cell then holds an `Inline noWrap` (avatar, name, email) that cannot shrink, and because cells are `overflow: visible` it paints 146px past its own edge. Measured identically at 768px and 420px, and on production as well as the beta deployment named in the ticket.

Columns now carry widths (a fraction plus a floor for the flexible ones, a fixed width for the predictable ones) and the tables sit in `Scrollable`. The users table becomes 790px inside a 369px slot and scrolls, with every cell's content back inside its own box.

Auditing the rest turned up no example table that gets this right. Nine had no widths at all, and `bulk-actions/EventsTable` had widths but no scroll container, so 329px of it was clipped by `body { overflow-x: clip }` with no scrollbar at all. This PR covers the two pages named in the ticket plus the three worst of the remainder.

**One thing a reviewer should know.**

`filter/VenuesTable` gets fraction-only widths and no floors, because it is the one table here that gets no `Scrollable`. Its `actionBar` overlay renders *inside* `Table` as `sticky bottom-…`, so wrapping the component from outside would re-anchor that sticky to the wrapper. That matters for the widths, because a static `width` also becomes the column's `minWidth` (`TableColumn.tsx`, `ensureWidth`). Floors on eleven columns put the table's minimum at 1538px inside a 1289px container with nothing to scroll, which is 249px unreachable at 1440px where `main` fits all twelve. Fractions leave the floor at react-aria's 75px per column, exactly where `main` has it, so the table fills its container at 1440px with the name cells no longer overlapping, and narrow viewports clip no more than they already do.

`bulk-actions/EventsTable` has the same shape. Both wait on the same follow-up, whether `Table` should own horizontal scroll, with one caveat for whoever takes it. Putting `overflow-x-auto` on `ResizableTableContainer` makes `overflow-y` compute to `auto` as well, which would break `Table.Header sticky` inside a consumer's `Scrollable`.

**The second half of the ticket does not reproduce.** The dashboard at 1440x900 renders the two panels side by side at exactly 2:1 (662px and 331px, 48px gap), with nothing crossing the viewport edge, on the same Chromium and the same deployment the ticket names. Production renders it the same way, without this PR.

Two commits landed after the 2026-07-31 report and are plausible causes: `bb2318685` `feat(DST-1700): make --bleed-px the documented container spacing contract` (#5726, 2026-08-11), whose own message says it rewrote how `Table` derives edge padding, and `b7122c0b7` `chore: Marigold v18 changes` (#5304, 2026-08-04). Worth checking with the reporter against those two before treating that half as done. The dashboard's new `Scrollable` guards the symptom either way, because its own min-content is zero, so the activity table can no longer inflate its panel and wrap the pair before `collapseAt` asks for it.

Closes DST-1673

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the docs preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

Measured on `/examples/users` at a 768px viewport, which leaves a 369px content area:

|                     | Before                     | After                        |
| ------------------- | -------------------------- | ---------------------------- |
| Column widths       | 75 / 75 / 75 / 75 / 75     | 280 / 170 / 110 / 110 / 120  |
| Table width         | 375px                      | 790px                        |
| Scrolls?            | no (`overflow-x: visible`) | yes                          |
| Worst cell overhang | **+146px**                 | none, inside its own cell    |

And on `/examples/filter` at 1440x900, which gives the table a 1289px container:

|                     | `main`  | This PR |
| ------------------- | ------- | ------- |
| Table minimum width | 861px   | 861px   |
| Table width         | 1289px  | 1289px  |
| Clipped             | 0px     | 0px     |

## Test Instructions

1. `pnpm build && pnpm start`, then open http://localhost:3000/examples/users
2. Set the viewport to 768px wide, then to 420px. The table scrolls horizontally inside its panel and no cell's text overlaps its neighbour.
3. Open `/examples` at 1440x900. "Recent activity" and "Your team" stay side by side at 2:1 with nothing running past the right edge.
4. Open `/examples/filter` at 1440x900. All twelve columns are reachable and the table fills its container, with the Name column wider than it is on `main`. At 768px it clips as much as `main` does, which is what the `Table` follow-up will fix.
5. Open `/examples/pick` at 768px and check the same as step 2 for those tables.
6. Open http://localhost:3000/components/collection/table and read the new "Column widths" section. Its demo scrolls horizontally when the container is narrower than the columns' floors.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [x] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)

On the unticked items: this PR adds no stories and no unit tests. A narrow-container `Table` story with an overhang assertion was written and then dropped on request, so the new "Column widths" section on the Table docs page is what stands in its place: it records that a static `width` is also the column's floor, that the floors added together are the table's minimum, and that a table whose minimum can outgrow its container needs a `Scrollable`. Visual regression does not apply here. `visual-regression-tests.yml` carries `paths-ignore: ['docs/**', '.changeset/**']`, which is this entire diff.
