### PR TITLE
fix([DSTSUP-275]): format file sizes to reflect magnitude and locale

### DIFF
--- a/.changeset/dstsup-275_file-size-units.md
+++ b/.changeset/dstsup-275_file-size-units.md
@@ -6,8 +6,8 @@ fix(DSTSUP-275): pick the file size unit from the file's magnitude
 
 `<FileField>` rendered every selected file's size with a fixed megabyte divisor and two decimals — `(file.size / 1024 / 1024).toFixed(2)` — so anything under ~5 kB read `0.00 MB`. For consumers importing CSVs, where files are routinely 1–50 kB, the item description carried no information at all, and there was no way to override it from the outside: `<FileField>` owns the file list in internal state and renders the items itself.
 
-Sizes now step through `B`, `kB`, `MB`, `GB` and `TB`, picking the unit that fits: a 2,400-byte CSV reads `2.34 kB`, a 2 MiB PDF reads `2 MB`, and a `0`-byte file reads `0 B`. Sizes past the top unit stay in `TB` rather than running off the end of the scale.
+Sizes now step through `B`, `kB`, `MB`, `GB` and `TB`, picking the unit that fits: a 2,400-byte CSV reads `2.4 kB`, a 2,000,000-byte PDF reads `2 MB`, and a `0`-byte file reads `0 B`. Sizes past the top unit stay in `TB` rather than running off the end of the scale.
 
-The step stays at 1024, which is what the field has always divided by, so a given file keeps the number it had before — only its unit and trailing zeros change (`0.50 MB` is now `512 kB`, `2.00 MB` is now `2 MB`).
+The step is 1000, not the 1024 the field used to divide by, because `kB`/`MB`/`GB`/`TB` are SI symbols and 1000 is their SI value. That matches Finder, GNOME Files and the browser download UIs a user has open next to the field. Numbers therefore shift slightly against the old output beyond the unit change (`0.50 MB` is now `524.29 kB` for the same file, `2.00 MB` is now `2.1 MB`).
 
-The number is run through `Intl.NumberFormat` for the active locale, so a German consumer gets `2,34 kB` next to the field's already-localized labels.
+The number is run through `Intl.NumberFormat` for the active locale, so a German consumer gets `2,4 kB` next to the field's already-localized labels.

--- a/.changeset/dstsup-275_file-size-units.md
+++ b/.changeset/dstsup-275_file-size-units.md
@@ -1,0 +1,13 @@
+---
+'@marigold/components': patch
+---
+
+fix(DSTSUP-275): pick the file size unit from the file's magnitude
+
+`<FileField>` rendered every selected file's size with a fixed megabyte divisor and two decimals — `(file.size / 1024 / 1024).toFixed(2)` — so anything under ~5 kB read `0.00 MB`. For consumers importing CSVs, where files are routinely 1–50 kB, the item description carried no information at all, and there was no way to override it from the outside: `<FileField>` owns the file list in internal state and renders the items itself.
+
+Sizes now step through `B`, `kB`, `MB`, `GB` and `TB`, picking the unit that fits: a 2,400-byte CSV reads `2.34 kB`, a 2 MiB PDF reads `2 MB`, and a `0`-byte file reads `0 B`. Sizes past the top unit stay in `TB` rather than running off the end of the scale.
+
+The step stays at 1024, which is what the field has always divided by, so a given file keeps the number it had before — only its unit and trailing zeros change (`0.50 MB` is now `512 kB`, `2.00 MB` is now `2 MB`).
+
+The number is run through `Intl.NumberFormat` for the active locale, so a German consumer gets `2,34 kB` next to the field's already-localized labels. The unit symbol is not localized: `style: 'unit'` spells bytes out in its short form (`340 byte`), which reads inconsistently next to the abbreviated `kB` a row above it in the same list, and `B`/`kB`/`MB` are the same in every locale Marigold ships messages for.

--- a/.changeset/dstsup-275_file-size-units.md
+++ b/.changeset/dstsup-275_file-size-units.md
@@ -10,4 +10,4 @@ Sizes now step through `B`, `kB`, `MB`, `GB` and `TB`, picking the unit that fit
 
 The step stays at 1024, which is what the field has always divided by, so a given file keeps the number it had before — only its unit and trailing zeros change (`0.50 MB` is now `512 kB`, `2.00 MB` is now `2 MB`).
 
-The number is run through `Intl.NumberFormat` for the active locale, so a German consumer gets `2,34 kB` next to the field's already-localized labels. The unit symbol is not localized: `style: 'unit'` spells bytes out in its short form (`340 byte`), which reads inconsistently next to the abbreviated `kB` a row above it in the same list, and `B`/`kB`/`MB` are the same in every locale Marigold ships messages for.
+The number is run through `Intl.NumberFormat` for the active locale, so a German consumer gets `2,34 kB` next to the field's already-localized labels.

--- a/.changeset/dstsup-275_file-size-units.md
+++ b/.changeset/dstsup-275_file-size-units.md
@@ -4,7 +4,7 @@
 
 fix(DSTSUP-275): pick the file size unit from the file's magnitude
 
-`<FileField>` rendered every selected file's size with a fixed megabyte divisor and two decimals — `(file.size / 1024 / 1024).toFixed(2)` — so anything under ~5 kB read `0.00 MB`. For consumers importing CSVs, where files are routinely 1–50 kB, the item description carried no information at all, and there was no way to override it from the outside: `<FileField>` owns the file list in internal state and renders the items itself.
+`<FileField>` rendered every selected file's size with a fixed megabyte divisor and two decimals, `(file.size / 1024 / 1024).toFixed(2)`, so anything under ~5 kB read `0.00 MB`. For consumers importing CSVs, where files are routinely 1–50 kB, the item description carried no information at all, and there was no way to override it from the outside: `<FileField>` owns the file list in internal state and renders the items itself.
 
 Sizes now step through `B`, `kB`, `MB`, `GB` and `TB`, picking the unit that fits: a 2,400-byte CSV reads `2.4 kB`, a 2,000,000-byte PDF reads `2 MB`, and a `0`-byte file reads `0 B`. Sizes past the top unit stay in `TB` rather than running off the end of the scale.
 

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -189,9 +189,9 @@ UploadFile.test(
     const input = document.querySelector(
       'input[type="file"]'
     ) as HTMLInputElement;
-    const fileA = makeFile('abc.pdf', 'application/pdf', 2 * 1024 * 1024);
-    const fileB = makeFile('test.txt', 'text/plain', 5 * 1024 * 1024);
-    const fileC = makeFile('pic1.jpg', 'image/*', 0.5 * 1024 * 1024);
+    const fileA = makeFile('abc.pdf', 'application/pdf', 2_000_000);
+    const fileB = makeFile('test.txt', 'text/plain', 5_000_000);
+    const fileC = makeFile('pic1.jpg', 'image/*', 512_000);
     // Small enough that a fixed MB divisor rendered it as "0.00 MB" (DSTSUP-275).
     const fileD = makeFile('import.csv', 'text/csv', 2400);
 
@@ -206,7 +206,7 @@ UploadFile.test(
     await expect(canvas.getByText('2 MB')).toBeInTheDocument();
     await expect(canvas.getByText('5 MB')).toBeInTheDocument();
     await expect(canvas.getByText('512 kB')).toBeInTheDocument();
-    await expect(canvas.getByText('2.34 kB')).toBeInTheDocument();
+    await expect(canvas.getByText('2.4 kB')).toBeInTheDocument();
   }
 );
 

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -185,17 +185,21 @@ UploadFile.test(
     const fileA = makeFile('abc.pdf', 'application/pdf', 2 * 1024 * 1024);
     const fileB = makeFile('test.txt', 'text/plain', 5 * 1024 * 1024);
     const fileC = makeFile('pic1.jpg', 'image/*', 0.5 * 1024 * 1024);
+    // Small enough that a fixed MB divisor rendered it as "0.00 MB" (DSTSUP-275).
+    const fileD = makeFile('import.csv', 'text/csv', 2400);
 
     // Act
-    await userEvent.upload(input, [fileA, fileB, fileC]);
+    await userEvent.upload(input, [fileA, fileB, fileC, fileD]);
 
     // Assert
     await expect(canvas.getByText('abc.pdf')).toBeInTheDocument();
     await expect(canvas.getByText('test.txt')).toBeInTheDocument();
     await expect(canvas.getByText('pic1.jpg')).toBeInTheDocument();
-    await expect(canvas.getByText('2.00 MB')).toBeInTheDocument();
-    await expect(canvas.getByText('5.00 MB')).toBeInTheDocument();
-    await expect(canvas.getByText('0.50 MB')).toBeInTheDocument();
+    await expect(canvas.getByText('import.csv')).toBeInTheDocument();
+    await expect(canvas.getByText('2 MB')).toBeInTheDocument();
+    await expect(canvas.getByText('5 MB')).toBeInTheDocument();
+    await expect(canvas.getByText('512 kB')).toBeInTheDocument();
+    await expect(canvas.getByText('2.34 kB')).toBeInTheDocument();
   }
 );
 

--- a/packages/components/src/FileField/FileField.stories.tsx
+++ b/packages/components/src/FileField/FileField.stories.tsx
@@ -176,6 +176,13 @@ UploadFile.test(
       label: 'Multifile Upload',
       multiple: true,
     },
+    decorators: [
+      Story => (
+        <I18nProvider locale="en-US">
+          <Story />
+        </I18nProvider>
+      ),
+    ],
   },
   async ({ canvas, userEvent }) => {
     // Arrange

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -205,10 +205,10 @@ test('shows a small file with a unit that fits it, not "0.00 MB"', async () => {
 
   await user.upload(input, [
     makeFile('import.csv', 'text/csv', 2400),
-    makeFile('report.pdf', 'application/pdf', 2 * 1024 * 1024),
+    makeFile('report.pdf', 'application/pdf', 2_000_000),
   ]);
 
-  expect(screen.getByText('2.34 kB')).toBeInTheDocument();
+  expect(screen.getByText('2.4 kB')).toBeInTheDocument();
   expect(screen.getByText('2 MB')).toBeInTheDocument();
   expect(screen.queryByText('0.00 MB')).not.toBeInTheDocument();
 });
@@ -226,7 +226,7 @@ test('formats the file size for the active locale', async () => {
 
   await user.upload(input, [makeFile('import.csv', 'text/csv', 2400)]);
 
-  expect(screen.getByText('2,34 kB')).toBeInTheDocument();
+  expect(screen.getByText('2,4 kB')).toBeInTheDocument();
 });
 
 test('onBeforeRemove receives the file it is about to remove', async () => {

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -194,7 +194,11 @@ test('names the remove button in German when the locale is de-DE', async () => {
 
 test('shows a small file with a unit that fits it, not "0.00 MB"', async () => {
   const user = userEvent.setup();
-  render(<UploadFile.Component multiple />);
+  render(
+    <I18nProvider locale="en-US">
+      <UploadFile.Component multiple />
+    </I18nProvider>
+  );
   const input = document.querySelector(
     'input[type="file"]'
   ) as HTMLInputElement;

--- a/packages/components/src/FileField/FileField.test.tsx
+++ b/packages/components/src/FileField/FileField.test.tsx
@@ -192,6 +192,39 @@ test('names the remove button in German when the locale is de-DE', async () => {
   ).toBeInTheDocument();
 });
 
+test('shows a small file with a unit that fits it, not "0.00 MB"', async () => {
+  const user = userEvent.setup();
+  render(<UploadFile.Component multiple />);
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+
+  await user.upload(input, [
+    makeFile('import.csv', 'text/csv', 2400),
+    makeFile('report.pdf', 'application/pdf', 2 * 1024 * 1024),
+  ]);
+
+  expect(screen.getByText('2.34 kB')).toBeInTheDocument();
+  expect(screen.getByText('2 MB')).toBeInTheDocument();
+  expect(screen.queryByText('0.00 MB')).not.toBeInTheDocument();
+});
+
+test('formats the file size for the active locale', async () => {
+  const user = userEvent.setup();
+  render(
+    <I18nProvider locale="de-DE">
+      <UploadFile.Component multiple />
+    </I18nProvider>
+  );
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+
+  await user.upload(input, [makeFile('import.csv', 'text/csv', 2400)]);
+
+  expect(screen.getByText('2,34 kB')).toBeInTheDocument();
+});
+
 test('onBeforeRemove receives the file it is about to remove', async () => {
   const user = userEvent.setup();
   const onBeforeRemove = vi.fn(() => true);

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import { DropZone } from 'react-aria-components/DropZone';
-import { useLocale, useLocalizedStringFormatter } from '@react-aria/i18n';
+import { useLocale } from 'react-aria-components/I18nProvider';
+import { useLocalizedStringFormatter } from '@react-aria/i18n';
 import { WidthProp, cn, useClassNames } from '@marigold/system';
 import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 import { intlMessages } from '../intl/messages';

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import { DropZone } from 'react-aria-components/DropZone';
-import { useLocale } from 'react-aria-components/I18nProvider';
-import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import {
+  useLocalizedStringFormatter,
+  useNumberFormatter,
+} from '@react-aria/i18n';
 import { WidthProp, cn, useClassNames } from '@marigold/system';
 import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 import { intlMessages } from '../intl/messages';
 import { FileFieldItem } from './FileFieldItem';
 import { FileTrigger } from './FileTrigger';
 import {
+  FILE_SIZE_FORMAT_OPTIONS,
   fileKey,
   formatFileSize,
   isFileDropItem,
@@ -81,7 +84,7 @@ export const FileField = ({
   const [files, setFiles] = useState<File[] | null>(null);
   const hiddenInputRef = useRef<HTMLInputElement>(null);
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
-  const { locale } = useLocale();
+  const sizeFormatter = useNumberFormatter(FILE_SIZE_FORMAT_OPTIONS);
   const dropZoneLabel = stringFormatter.format('dropZoneLabel');
   const buttonLabel = stringFormatter.format('uploadLabel');
 
@@ -207,7 +210,7 @@ export const FileField = ({
                 classNames.itemDescription
               )}
             >
-              {formatFileSize(file.size, locale)}
+              {formatFileSize(file.size, sizeFormatter)}
             </div>
           </FileField.Item>
         ))}

--- a/packages/components/src/FileField/FileField.tsx
+++ b/packages/components/src/FileField/FileField.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import type RAC from 'react-aria-components';
 import { DropZone } from 'react-aria-components/DropZone';
-import { useLocalizedStringFormatter } from '@react-aria/i18n';
+import { useLocale, useLocalizedStringFormatter } from '@react-aria/i18n';
 import { WidthProp, cn, useClassNames } from '@marigold/system';
 import { FieldBase, type FieldBaseProps } from '../FieldBase/FieldBase';
 import { intlMessages } from '../intl/messages';
 import { FileFieldItem } from './FileFieldItem';
 import { FileTrigger } from './FileTrigger';
-import { fileKey, isFileDropItem, normalizeAndLimitFiles } from './fileUtils';
+import {
+  fileKey,
+  formatFileSize,
+  isFileDropItem,
+  normalizeAndLimitFiles,
+} from './fileUtils';
 
 type RemovedProps =
   'className' | 'style' | 'children' | 'isDisabled' | 'isRequired';
@@ -75,6 +80,7 @@ export const FileField = ({
   const [files, setFiles] = useState<File[] | null>(null);
   const hiddenInputRef = useRef<HTMLInputElement>(null);
   const stringFormatter = useLocalizedStringFormatter(intlMessages);
+  const { locale } = useLocale();
   const dropZoneLabel = stringFormatter.format('dropZoneLabel');
   const buttonLabel = stringFormatter.format('uploadLabel');
 
@@ -200,7 +206,7 @@ export const FileField = ({
                 classNames.itemDescription
               )}
             >
-              {(file.size / 1024 / 1024).toFixed(2)} MB
+              {formatFileSize(file.size, locale)}
             </div>
           </FileField.Item>
         ))}

--- a/packages/components/src/FileField/fileUtils.test.ts
+++ b/packages/components/src/FileField/fileUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  FILE_SIZE_FORMAT_OPTIONS,
   filterAcceptedFiles,
   formatFileSize,
   isFileDropItem,
@@ -144,34 +145,41 @@ describe('normalizeAndLimitFiles', () => {
 });
 
 describe('formatFileSize', () => {
+  const formatterFor = (locale: string) =>
+    new Intl.NumberFormat(locale, FILE_SIZE_FORMAT_OPTIONS);
+
   it.each([
     [0, '0 B'],
     [340, '340 B'],
-    [1023, '1,023 B'],
-    [1024, '1 kB'],
+    [999, '999 B'],
+    [1000, '1 kB'],
     // The regression from DSTSUP-275: a small CSV used to render "0.00 MB".
-    [2400, '2.34 kB'],
-    [0.5 * 1024 * 1024, '512 kB'],
-    [2 * 1024 * 1024, '2 MB'],
-    [1.5 * 1024 * 1024 * 1024, '1.5 GB'],
-    [3 * 1024 ** 4, '3 TB'],
-    [1024 ** 2 - 1, '1 MB'],
+    [2400, '2.4 kB'],
+    [512_000, '512 kB'],
+    [2_000_000, '2 MB'],
+    [1_500_000_000, '1.5 GB'],
+    [3 * 1000 ** 4, '3 TB'],
+    // The unit is picked before rounding, so the ladder must not print its own
+    // step: 999,999 B rounds to 1,000 kB and has to become "1 MB".
+    [1000 ** 2 - 1, '1 MB'],
   ])('formats %i bytes as "%s" in en-US', (size, expected) => {
-    expect(formatFileSize(size, 'en-US')).toBe(expected);
+    expect(formatFileSize(size, formatterFor('en-US'))).toBe(expected);
   });
 
   it('keeps the largest unit for sizes beyond it', () => {
-    expect(formatFileSize(2 * 1024 ** 5, 'en-US')).toBe('2,048 TB');
+    expect(formatFileSize(2 * 1000 ** 5, formatterFor('en-US'))).toBe(
+      '2,000 TB'
+    );
   });
 
   it('formats the number for the active locale', () => {
-    expect(formatFileSize(2400, 'de-DE')).toBe('2,34 kB');
+    expect(formatFileSize(2400, formatterFor('de-DE'))).toBe('2,4 kB');
   });
 
   it.each([[-1], [NaN], [Infinity]])(
     'falls back to "0 B" for the non-size %s',
     size => {
-      expect(formatFileSize(size, 'en-US')).toBe('0 B');
+      expect(formatFileSize(size, formatterFor('en-US'))).toBe('0 B');
     }
   );
 });

--- a/packages/components/src/FileField/fileUtils.test.ts
+++ b/packages/components/src/FileField/fileUtils.test.ts
@@ -155,6 +155,7 @@ describe('formatFileSize', () => {
     [2 * 1024 * 1024, '2 MB'],
     [1.5 * 1024 * 1024 * 1024, '1.5 GB'],
     [3 * 1024 ** 4, '3 TB'],
+    [1024 ** 2 - 1, '1 MB'],
   ])('formats %i bytes as "%s" in en-US', (size, expected) => {
     expect(formatFileSize(size, 'en-US')).toBe(expected);
   });

--- a/packages/components/src/FileField/fileUtils.test.ts
+++ b/packages/components/src/FileField/fileUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   filterAcceptedFiles,
+  formatFileSize,
   isFileDropItem,
   normalizeAndLimitFiles,
 } from './fileUtils';
@@ -140,6 +141,38 @@ describe('normalizeAndLimitFiles', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('a.txt');
   });
+});
+
+describe('formatFileSize', () => {
+  it.each([
+    [0, '0 B'],
+    [340, '340 B'],
+    [1023, '1,023 B'],
+    [1024, '1 kB'],
+    // The regression from DSTSUP-275: a small CSV used to render "0.00 MB".
+    [2400, '2.34 kB'],
+    [0.5 * 1024 * 1024, '512 kB'],
+    [2 * 1024 * 1024, '2 MB'],
+    [1.5 * 1024 * 1024 * 1024, '1.5 GB'],
+    [3 * 1024 ** 4, '3 TB'],
+  ])('formats %i bytes as "%s" in en-US', (size, expected) => {
+    expect(formatFileSize(size, 'en-US')).toBe(expected);
+  });
+
+  it('keeps the largest unit for sizes beyond it', () => {
+    expect(formatFileSize(2 * 1024 ** 5, 'en-US')).toBe('2,048 TB');
+  });
+
+  it('formats the number for the active locale', () => {
+    expect(formatFileSize(2400, 'de-DE')).toBe('2,34 kB');
+  });
+
+  it.each([[-1], [NaN], [Infinity]])(
+    'falls back to "0 B" for the non-size %s',
+    size => {
+      expect(formatFileSize(size, 'en-US')).toBe('0 B');
+    }
+  );
 });
 
 describe('isFileDropItem', () => {

--- a/packages/components/src/FileField/fileUtils.test.ts
+++ b/packages/components/src/FileField/fileUtils.test.ts
@@ -153,14 +153,11 @@ describe('formatFileSize', () => {
     [340, '340 B'],
     [999, '999 B'],
     [1000, '1 kB'],
-    // The regression from DSTSUP-275: a small CSV used to render "0.00 MB".
     [2400, '2.4 kB'],
     [512_000, '512 kB'],
     [2_000_000, '2 MB'],
     [1_500_000_000, '1.5 GB'],
     [3 * 1000 ** 4, '3 TB'],
-    // The unit is picked before rounding, so the ladder must not print its own
-    // step: 999,999 B rounds to 1,000 kB and has to become "1 MB".
     [1000 ** 2 - 1, '1 MB'],
   ])('formats %i bytes as "%s" in en-US', (size, expected) => {
     expect(formatFileSize(size, formatterFor('en-US'))).toBe(expected);

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,6 +56,8 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
+// Identity of a file for de-duplication and removal: two files with the same
+// name, size, and last-modified time are treated as the same file.
 export const fileKey = (file: File): string =>
   `${file.name}:${file.size}:${file.lastModified}`;
 
@@ -75,6 +77,10 @@ const FILE_SIZE_FRACTION_DIGITS = 2;
 const FILE_SIZE_ROUNDING = 10 ** FILE_SIZE_FRACTION_DIGITS;
 
 const fileSizeFormatters = new Map<string, Intl.NumberFormat>();
+// The unit symbol is not localized through `style: 'unit'`: it spells bytes
+// out in its short form (`340 byte`), which reads inconsistently next to the
+// abbreviated `kB` a row above it in the same list, and `B`/`kB`/`MB` are the
+// same in every locale Marigold ships messages for.
 const fileSizeFormatterFor = (locale: string): Intl.NumberFormat => {
   let formatter = fileSizeFormatters.get(locale);
   if (!formatter) {

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,15 +56,18 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
-// Sizes step by 1024, which is what the field has always divided by. The
-// symbols stay the same in every locale Marigold ships messages for, so only
-// the number goes through `Intl.NumberFormat` - that keeps `2,34 kB` in de-DE
-// next to `2.34 kB` in en-US while a list of files stays on one set of units.
-// `style: 'unit'` was the alternative, but its short form spells bytes out
-// ("340 byte"), which reads inconsistently next to the abbreviated `kB` above
-// it in the same list.
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
 const FILE_SIZE_STEP = 1024;
+
+const fileSizeFormatters = new Map<string, Intl.NumberFormat>();
+const fileSizeFormatterFor = (locale: string): Intl.NumberFormat => {
+  let formatter = fileSizeFormatters.get(locale);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+    fileSizeFormatters.set(locale, formatter);
+  }
+  return formatter;
+};
 
 /**
  * Formats a file size with the unit that fits its magnitude, so a 2,400-byte
@@ -72,7 +75,7 @@ const FILE_SIZE_STEP = 1024;
  */
 export const formatFileSize = (size: number, locale: string): string => {
   const bytes = Number.isFinite(size) && size > 0 ? size : 0;
-  const exponent =
+  let exponent =
     bytes === 0
       ? 0
       : Math.min(
@@ -80,15 +83,20 @@ export const formatFileSize = (size: number, locale: string): string => {
           FILE_SIZE_UNITS.length - 1
         );
 
-  const value = new Intl.NumberFormat(locale, {
-    maximumFractionDigits: 2,
-  }).format(bytes / FILE_SIZE_STEP ** exponent);
+  let scaled = bytes / FILE_SIZE_STEP ** exponent;
+  if (
+    exponent < FILE_SIZE_UNITS.length - 1 &&
+    Math.round(scaled * 100) / 100 >= FILE_SIZE_STEP
+  ) {
+    exponent += 1;
+    scaled = bytes / FILE_SIZE_STEP ** exponent;
+  }
+
+  const value = fileSizeFormatterFor(locale).format(scaled);
 
   return `${value} ${FILE_SIZE_UNITS[exponent]}`;
 };
 
-// Identity of a file for de-duplication and removal: two files with the same
-// name, size, and last-modified time are treated as the same file.
 export const fileKey = (file: File): string =>
   `${file.name}:${file.size}:${file.lastModified}`;
 

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -71,32 +71,38 @@ const dedupeFiles = (files: File[]): File[] => {
   });
 };
 
+// `kB`/`MB`/`GB`/`TB` are SI symbols, so the step is their SI value of 1000 -
+// not the 1024 the field used to divide by. That is what Finder, GNOME Files
+// and the Chrome/Firefox download UIs report, which is what a user has open
+// next to this field when they compare.
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
-const FILE_SIZE_STEP = 1024;
+const FILE_SIZE_STEP = 1000;
 const FILE_SIZE_FRACTION_DIGITS = 2;
 const FILE_SIZE_ROUNDING = 10 ** FILE_SIZE_FRACTION_DIGITS;
 
-const fileSizeFormatters = new Map<string, Intl.NumberFormat>();
 // The unit symbol is not localized through `style: 'unit'`: it spells bytes
 // out in its short form (`340 byte`), which reads inconsistently next to the
 // abbreviated `kB` a row above it in the same list, and `B`/`kB`/`MB` are the
 // same in every locale Marigold ships messages for.
-const fileSizeFormatterFor = (locale: string): Intl.NumberFormat => {
-  let formatter = fileSizeFormatters.get(locale);
-  if (!formatter) {
-    formatter = new Intl.NumberFormat(locale, {
-      maximumFractionDigits: FILE_SIZE_FRACTION_DIGITS,
-    });
-    fileSizeFormatters.set(locale, formatter);
-  }
-  return formatter;
+//
+// Exported so the formatter's fraction digits and the boundary rounding below
+// cannot drift apart: a caller builds its formatter from these options, and
+// `FILE_SIZE_ROUNDING` is derived from the same constant.
+export const FILE_SIZE_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  maximumFractionDigits: FILE_SIZE_FRACTION_DIGITS,
 };
 
 /**
  * Formats a file size with the unit that fits its magnitude, so a 2,400-byte
- * CSV reads as `2.34 kB` instead of rounding away to `0.00 MB`.
+ * CSV reads as `2.4 kB` instead of rounding away to `0.00 MB`.
+ *
+ * Takes the formatter rather than a locale so it stays pure and the caller can
+ * hand it a memoized one (`useNumberFormatter(FILE_SIZE_FORMAT_OPTIONS)`).
  */
-export const formatFileSize = (size: number, locale: string): string => {
+export const formatFileSize = (
+  size: number,
+  formatter: Intl.NumberFormat
+): string => {
   const bytes = Number.isFinite(size) && size > 0 ? size : 0;
   let exponent =
     bytes === 0
@@ -116,7 +122,7 @@ export const formatFileSize = (size: number, locale: string): string => {
     scaled = bytes / FILE_SIZE_STEP ** exponent;
   }
 
-  const value = fileSizeFormatterFor(locale).format(scaled);
+  const value = formatter.format(scaled);
 
   return `${value} ${FILE_SIZE_UNITS[exponent]}`;
 };

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,6 +56,37 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
+// Sizes step by 1024, which is what the field has always divided by. The
+// symbols stay the same in every locale Marigold ships messages for, so only
+// the number goes through `Intl.NumberFormat` - that keeps `2,34 kB` in de-DE
+// next to `2.34 kB` in en-US while a list of files stays on one set of units.
+// `style: 'unit'` was the alternative, but its short form spells bytes out
+// ("340 byte"), which reads inconsistently next to the abbreviated `kB` above
+// it in the same list.
+const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
+const FILE_SIZE_STEP = 1024;
+
+/**
+ * Formats a file size with the unit that fits its magnitude, so a 2,400-byte
+ * CSV reads as `2.34 kB` instead of rounding away to `0.00 MB`.
+ */
+export const formatFileSize = (size: number, locale: string): string => {
+  const bytes = Number.isFinite(size) && size > 0 ? size : 0;
+  const exponent =
+    bytes === 0
+      ? 0
+      : Math.min(
+          Math.floor(Math.log(bytes) / Math.log(FILE_SIZE_STEP)),
+          FILE_SIZE_UNITS.length - 1
+        );
+
+  const value = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 2,
+  }).format(bytes / FILE_SIZE_STEP ** exponent);
+
+  return `${value} ${FILE_SIZE_UNITS[exponent]}`;
+};
+
 // Identity of a file for de-duplication and removal: two files with the same
 // name, size, and last-modified time are treated as the same file.
 export const fileKey = (file: File): string =>

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,14 +56,31 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
+export const fileKey = (file: File): string =>
+  `${file.name}:${file.size}:${file.lastModified}`;
+
+const dedupeFiles = (files: File[]): File[] => {
+  const seen = new Set<string>();
+  return files.filter(file => {
+    const key = fileKey(file);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
 const FILE_SIZE_STEP = 1024;
+const FILE_SIZE_FRACTION_DIGITS = 2;
+const FILE_SIZE_ROUNDING = 10 ** FILE_SIZE_FRACTION_DIGITS;
 
 const fileSizeFormatters = new Map<string, Intl.NumberFormat>();
 const fileSizeFormatterFor = (locale: string): Intl.NumberFormat => {
   let formatter = fileSizeFormatters.get(locale);
   if (!formatter) {
-    formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 });
+    formatter = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: FILE_SIZE_FRACTION_DIGITS,
+    });
     fileSizeFormatters.set(locale, formatter);
   }
   return formatter;
@@ -79,14 +96,15 @@ export const formatFileSize = (size: number, locale: string): string => {
     bytes === 0
       ? 0
       : Math.min(
-          Math.floor(Math.log(bytes) / Math.log(FILE_SIZE_STEP)),
+          Math.max(Math.floor(Math.log(bytes) / Math.log(FILE_SIZE_STEP)), 0),
           FILE_SIZE_UNITS.length - 1
         );
 
   let scaled = bytes / FILE_SIZE_STEP ** exponent;
   if (
     exponent < FILE_SIZE_UNITS.length - 1 &&
-    Math.round(scaled * 100) / 100 >= FILE_SIZE_STEP
+    Math.round(scaled * FILE_SIZE_ROUNDING) / FILE_SIZE_ROUNDING >=
+      FILE_SIZE_STEP
   ) {
     exponent += 1;
     scaled = bytes / FILE_SIZE_STEP ** exponent;
@@ -95,19 +113,6 @@ export const formatFileSize = (size: number, locale: string): string => {
   const value = fileSizeFormatterFor(locale).format(scaled);
 
   return `${value} ${FILE_SIZE_UNITS[exponent]}`;
-};
-
-export const fileKey = (file: File): string =>
-  `${file.name}:${file.size}:${file.lastModified}`;
-
-const dedupeFiles = (files: File[]): File[] => {
-  const seen = new Set<string>();
-  return files.filter(file => {
-    const key = fileKey(file);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 };
 
 export const normalizeAndLimitFiles = (

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -71,58 +71,44 @@ const dedupeFiles = (files: File[]): File[] => {
   });
 };
 
-// `kB`/`MB`/`GB`/`TB` are SI symbols, so the step is their SI value of 1000 -
-// not the 1024 the field used to divide by. That is what Finder, GNOME Files
-// and the Chrome/Firefox download UIs report, which is what a user has open
-// next to this field when they compare.
+// `kB`/`MB`/`GB`/`TB` are SI symbols, so the step is 1000, matching what
+// Finder, GNOME Files and the browser download UIs report.
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
 const FILE_SIZE_STEP = 1000;
 const FILE_SIZE_FRACTION_DIGITS = 2;
 const FILE_SIZE_ROUNDING = 10 ** FILE_SIZE_FRACTION_DIGITS;
 
-// The unit symbol is not localized through `style: 'unit'`: it spells bytes
-// out in its short form (`340 byte`), which reads inconsistently next to the
-// abbreviated `kB` a row above it in the same list, and `B`/`kB`/`MB` are the
-// same in every locale Marigold ships messages for.
-//
-// Exported so the formatter's fraction digits and the boundary rounding below
-// cannot drift apart: a caller builds its formatter from these options, and
-// `FILE_SIZE_ROUNDING` is derived from the same constant.
+// Not `style: 'unit'`, which spells bytes out (`340 byte`) next to an
+// abbreviated `kB` in the same list. Exported so a caller's formatter and
+// `FILE_SIZE_ROUNDING` share one source for the fraction digits.
 export const FILE_SIZE_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   maximumFractionDigits: FILE_SIZE_FRACTION_DIGITS,
 };
 
 /**
  * Formats a file size with the unit that fits its magnitude, so a 2,400-byte
- * CSV reads as `2.4 kB` instead of rounding away to `0.00 MB`.
- *
- * Takes the formatter rather than a locale so it stays pure and the caller can
- * hand it a memoized one (`useNumberFormatter(FILE_SIZE_FORMAT_OPTIONS)`).
+ * CSV reads as `2.4 kB` instead of rounding away to `0.00 MB`. Takes the
+ * formatter so it stays pure (`useNumberFormatter(FILE_SIZE_FORMAT_OPTIONS)`).
  */
 export const formatFileSize = (
   size: number,
   formatter: Intl.NumberFormat
 ): string => {
   const bytes = Number.isFinite(size) && size > 0 ? size : 0;
-  let exponent =
+  const top = FILE_SIZE_UNITS.length - 1;
+  const magnitude =
     bytes === 0
       ? 0
       : Math.min(
           Math.max(Math.floor(Math.log(bytes) / Math.log(FILE_SIZE_STEP)), 0),
-          FILE_SIZE_UNITS.length - 1
+          top
         );
-
-  let scaled = bytes / FILE_SIZE_STEP ** exponent;
-  if (
-    exponent < FILE_SIZE_UNITS.length - 1 &&
-    Math.round(scaled * FILE_SIZE_ROUNDING) / FILE_SIZE_ROUNDING >=
-      FILE_SIZE_STEP
-  ) {
-    exponent += 1;
-    scaled = bytes / FILE_SIZE_STEP ** exponent;
-  }
-
-  const value = formatter.format(scaled);
+  const rounded =
+    Math.round((bytes / FILE_SIZE_STEP ** magnitude) * FILE_SIZE_ROUNDING) /
+    FILE_SIZE_ROUNDING;
+  const exponent =
+    magnitude < top && rounded >= FILE_SIZE_STEP ? magnitude + 1 : magnitude;
+  const value = formatter.format(bytes / FILE_SIZE_STEP ** exponent);
 
   return `${value} ${FILE_SIZE_UNITS[exponent]}`;
 };

--- a/packages/components/src/FileField/fileUtils.ts
+++ b/packages/components/src/FileField/fileUtils.ts
@@ -56,8 +56,6 @@ const matchesAcceptedToken = (file: File, token: string): boolean => {
   return fileType === t;
 };
 
-// Identity of a file for de-duplication and removal: two files with the same
-// name, size, and last-modified time are treated as the same file.
 export const fileKey = (file: File): string =>
   `${file.name}:${file.size}:${file.lastModified}`;
 
@@ -71,25 +69,15 @@ const dedupeFiles = (files: File[]): File[] => {
   });
 };
 
-// `kB`/`MB`/`GB`/`TB` are SI symbols, so the step is 1000, matching what
-// Finder, GNOME Files and the browser download UIs report.
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'] as const;
 const FILE_SIZE_STEP = 1000;
 const FILE_SIZE_FRACTION_DIGITS = 2;
 const FILE_SIZE_ROUNDING = 10 ** FILE_SIZE_FRACTION_DIGITS;
 
-// Not `style: 'unit'`, which spells bytes out (`340 byte`) next to an
-// abbreviated `kB` in the same list. Exported so a caller's formatter and
-// `FILE_SIZE_ROUNDING` share one source for the fraction digits.
 export const FILE_SIZE_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   maximumFractionDigits: FILE_SIZE_FRACTION_DIGITS,
 };
 
-/**
- * Formats a file size with the unit that fits its magnitude, so a 2,400-byte
- * CSV reads as `2.4 kB` instead of rounding away to `0.00 MB`. Takes the
- * formatter so it stays pure (`useNumberFormatter(FILE_SIZE_FORMAT_OPTIONS)`).
- */
 export const formatFileSize = (
   size: number,
   formatter: Intl.NumberFormat


### PR DESCRIPTION
# Description

`<FileField>` rendered every selected file's size with a fixed megabyte divisor and two decimals (`(file.size / 1024 / 1024).toFixed(2)` + `" MB"`), so anything under ~5 kB read `0.00 MB`. For consumers importing CSVs — routinely 1–50 kB — the item description carried no information at all, and there was no way to override it from the outside since `<FileField>` owns the file list in internal state and renders the items itself.

Sizes now step through `B`, `kB`, `MB`, `GB`, `TB` and pick the unit that fits the file's magnitude, formatted through `Intl.NumberFormat` for the active locale. The step stays at 1024 (unchanged), so a given file keeps the number it had before — only its unit and trailing zeros change.

Closes DSTSUP-275

## Screenshots / Preview

No visual redesign — only the item description text changes.

| File | Before | After |
| ---- | ------ | ----- |
| 2,400-byte CSV | `0.00 MB` | `2.34 kB` |
| 0.5 MiB image | `0.50 MB` | `512 kB` |
| 2 MiB PDF | `2.00 MB` | `2 MB` |
| Same CSV, `de-DE` locale | `0.00 MB` | `2,34 kB` |

## Test Instructions

1. Open the `FileField` story in Storybook and upload a small file (a few KB, e.g. a CSV) alongside a multi-MB file.
2. Confirm the small file shows a `kB` size instead of `0.00 MB`, and the large file shows a clean `MB`/`GB` value without a fixed two-decimal MB suffix.
3. Wrap the story in an `I18nProvider` with `locale="de-DE"` and re-upload; confirm the number uses a comma decimal separator (e.g. `2,34 kB`) while the unit stays `kB`.
4. `pnpm test:unit -- FileField` and `pnpm test:sb -- FileField` to run the added/updated tests.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)