### PR TITLE
fix(DST-1740): give the Checkbox and Switch labels a containing block

### DIFF
--- a/.changeset/dst-1740_boolean-control-containing-block.md
+++ b/.changeset/dst-1740_boolean-control-containing-block.md
@@ -1,0 +1,15 @@
+---
+'@marigold/components': patch
+---
+
+fix(DST-1740): give `Checkbox` and `Switch` labels a containing block for their hidden input
+
+React Aria renders the real `<input>` inside the control's `<label>` wrapped in `VisuallyHidden`, which is `position: absolute` with no offsets. The label was `position: static`, so the input anchored to whatever positioned ancestor the consumer happened to have. In a list inside a dialog that is the dialog itself, a dozen static elements up.
+
+An absolutely positioned box laid out against an ancestor outside a scroll container is not part of that container's scrolled content, so the input stopped travelling with the row it belongs to. Clicking a row far down the list focused an input the browser believed was over a thousand pixels away, and it scrolled the dialog to reveal it. In the reported case the dialog also set `overflow: hidden`, so there was no scrollbar to get back and it ended up blank.
+
+Both labels are now `relative`. React Aria's own docs name this as a precondition of `VisuallyHidden` ("it must have a `position: relative` or `position: absolute` ancestor"), citing stray scrollbars — the focus jump is the sharper consequence, which is probably why it went unnoticed.
+
+`Radio` already positioned its label and is unchanged. `Switch` looked like it did too, but its `relative` sat on the wrapper around the track, a sibling of the input rather than an ancestor, so it never reached it. That class moves up to the label, where it was meant to be. `Checkbox.Group` renders `Checkbox` children and needs no change of its own.
+
+Consumers who worked around this by setting `position: relative` on their own scroll containers can drop it, though leaving it in place is harmless.

--- a/.changeset/dst-1740_boolean-control-containing-block.md
+++ b/.changeset/dst-1740_boolean-control-containing-block.md
@@ -10,6 +10,6 @@ An absolutely positioned box laid out against an ancestor outside a scroll conta
 
 Both labels are now `relative`. React Aria's own docs name this as a precondition of `VisuallyHidden` ("it must have a `position: relative` or `position: absolute` ancestor"), citing stray scrollbars — the focus jump is the sharper consequence, which is probably why it went unnoticed.
 
-`Radio` already positioned its label and is unchanged. `Switch` looked like it did too, but its `relative` sat on the wrapper around the track, a sibling of the input rather than an ancestor, so it never reached it. That class moves up to the label, where it was meant to be. `Checkbox.Group` renders `Checkbox` children and needs no change of its own.
+`Radio` already positioned its label and is unchanged. `Switch` looked like it did too, but its `relative` sat on a wrapper around the track, a sibling of the input rather than an ancestor, so it never reached it. That wrapper is gone and the track is now a direct child of the label, which carries the `relative`. `Checkbox.Group` renders `Checkbox` children and needs no change of its own.
 
 Consumers who worked around this by setting `position: relative` on their own scroll containers can drop it, though leaving it in place is harmless.

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -286,3 +286,54 @@ WithError.test(
     );
   }
 );
+
+// Without a containing block on the label, React Aria's absolute input stops
+// travelling with the row and focusing it scrolls the wrong ancestor.
+Basic.test(
+  'Hidden input travels with the control inside a scroll container',
+  {
+    parameters: { surface: false, chromatic: { disableSnapshot: true } },
+    render: () => (
+      <div className="border-border h-32 w-64 overflow-auto rounded border p-3">
+        <div className="flex flex-col gap-2">
+          <Checkbox label="View events" />
+          <Checkbox label="Create events" />
+          <Checkbox label="Edit events" />
+          <Checkbox label="Delete events" />
+          <Checkbox label="Manage users" />
+          <Checkbox label="Manage roles" />
+          <Checkbox label="Export reports" />
+          <Checkbox label="Manage billing" />
+        </div>
+      </div>
+    ),
+  },
+  async ({ canvas }) => {
+    // The last row, the one you have to scroll down to reach.
+    const input = await canvas.findByRole('checkbox', {
+      name: 'Manage billing',
+    });
+    const label = input.closest('label')!;
+    const scroller = label.closest('.overflow-auto')!;
+
+    const before = {
+      input: input.getBoundingClientRect().top,
+      label: label.getBoundingClientRect().top,
+    };
+
+    scroller.scrollTop = scroller.scrollHeight;
+
+    // Read back the real offset instead of assuming how far the list overflows.
+    const scrolled = scroller.scrollTop;
+
+    const after = {
+      input: input.getBoundingClientRect().top,
+      label: label.getBoundingClientRect().top,
+    };
+
+    // Guard: without a real scroll, the comparison is two zeroes agreeing.
+    expect(scrolled).toBeGreaterThan(0);
+    expect(after.label - before.label).toBe(-scrolled);
+    expect(after.input - before.input).toBe(after.label - before.label);
+  }
+);

--- a/packages/components/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/Checkbox.test.tsx
@@ -41,7 +41,7 @@ test('check if all slot class names are applied correctly', () => {
   const label = screen.getByText('With Label');
 
   expect(label.parentElement?.className).toMatchInlineSnapshot(
-    `"group/checkbox data-disabled:cursor-not-allowed grid grid-cols-[auto_1fr] gap-x-2 items-start cursor-pointer read-only:cursor-default group-data-[booleanfield]/booleanfield:grid-cols-subgrid group-data-[booleanfield]/booleanfield:col-span-full group-data-[orientation=vertical]/checkboxgroup:py-1 group-data-[orientation=horizontal]/checkboxgroup:px-1.5"`
+    `"group/checkbox relative data-disabled:cursor-not-allowed grid grid-cols-[auto_1fr] gap-x-2 items-start cursor-pointer read-only:cursor-default group-data-[booleanfield]/booleanfield:grid-cols-subgrid group-data-[booleanfield]/booleanfield:col-span-full group-data-[orientation=vertical]/checkboxgroup:py-1 group-data-[orientation=horizontal]/checkboxgroup:px-1.5"`
   );
   expect(getVisibleCheckbox()?.className).toMatchInlineSnapshot(
     `"grow-0 basis-4 items-center justify-center p-px border-solid grid size-4 shrink-0 place-content-center rounded border border-[oklch(from_var(--color-control-border)_l_c_h_/_calc(alpha_+_0.06))] bg-surface group-focus-visible/checkbox:ui-state-focus group-focus-visible/checkbox:border-(--ui-border-color) outline-none group-disabled/checkbox:group-selected/checkbox:bg-disabled-surface group-disabled/checkbox:border-disabled-surface! group-disabled/checkbox:text-disabled group-disabled/checkbox:cursor-not-allowed group-selected/checkbox:border-selected-bold group-selected/checkbox:bg-selected-bold group-selected/checkbox:text-selected-bold-foreground group-indeterminate/checkbox:border-selected-bold group-indeterminate/checkbox:bg-selected-bold group-indeterminate/checkbox:text-selected-bold-foreground group-hover/checkbox:group-disabled/checkbox:bg-disabled-surface group-hover/checkbox:not-group-focus-visible/checkbox:not-group-read-only/checkbox:not-group-selected/checkbox:not-group-indeterminate/checkbox:border-[oklch(from_var(--color-control-border)_l_c_h_/_calc(alpha_+_0.18))]"`
@@ -57,7 +57,7 @@ test('correct class name is set on size small', () => {
   const label = screen.getByText('With Label');
 
   expect(label.parentElement?.className).toMatchInlineSnapshot(
-    `"group/checkbox data-disabled:cursor-not-allowed grid grid-cols-[auto_1fr] gap-x-2 items-start cursor-pointer read-only:cursor-default group-data-[booleanfield]/booleanfield:grid-cols-subgrid group-data-[booleanfield]/booleanfield:col-span-full group-data-[orientation=vertical]/checkboxgroup:py-1 group-data-[orientation=horizontal]/checkboxgroup:px-1.5"`
+    `"group/checkbox relative data-disabled:cursor-not-allowed grid grid-cols-[auto_1fr] gap-x-2 items-start cursor-pointer read-only:cursor-default group-data-[booleanfield]/booleanfield:grid-cols-subgrid group-data-[booleanfield]/booleanfield:col-span-full group-data-[orientation=vertical]/checkboxgroup:py-1 group-data-[orientation=horizontal]/checkboxgroup:px-1.5"`
   );
 });
 

--- a/packages/components/src/Checkbox/Checkbox.tsx
+++ b/packages/components/src/Checkbox/Checkbox.tsx
@@ -156,6 +156,8 @@ const _Checkbox = ({
         ref={ref}
         className={cn(
           'group/checkbox',
+          // Containing block for the absolute input React Aria renders here.
+          'relative',
           'data-disabled:cursor-not-allowed',
           classNames.container
         )}

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -150,7 +150,7 @@ Basic.test(
 // also match the thumb, and every assertion here reads `'none'` off a wrong
 // element just as happily as off the right one — so pin the shape instead.
 const getTrack = (switchEl: HTMLElement) => {
-  const track = switchEl.closest('label')?.querySelector('div > div');
+  const track = switchEl.closest('label')?.querySelector(':scope > div');
 
   expect(track).not.toBeNull();
   // The track is the `w-7` box; the thumb is `size-3`. If this ever matches the

--- a/packages/components/src/Switch/Switch.stories.tsx
+++ b/packages/components/src/Switch/Switch.stories.tsx
@@ -328,3 +328,50 @@ WithError.test(
     );
   }
 );
+
+Basic.test(
+  'Hidden input travels with the control inside a scroll container',
+  {
+    parameters: { surface: false, chromatic: { disableSnapshot: true } },
+    render: () => (
+      <div className="border-border h-32 w-64 overflow-auto rounded border p-3">
+        <div className="flex flex-col gap-2">
+          <Switch label="Email digest" />
+          <Switch label="Push alerts" />
+          <Switch label="Weekly report" />
+          <Switch label="Beta features" />
+          <Switch label="Developer mode" />
+          <Switch label="Auto-refresh" />
+          <Switch label="Compact rows" />
+          <Switch label="Sound effects" />
+        </div>
+      </div>
+    ),
+  },
+  async ({ canvas }) => {
+    // The last row, the one you have to scroll down to reach.
+    const input = await canvas.findByRole('switch', { name: 'Sound effects' });
+    const label = input.closest('label')!;
+    const scroller = label.closest('.overflow-auto')!;
+
+    const before = {
+      input: input.getBoundingClientRect().top,
+      label: label.getBoundingClientRect().top,
+    };
+
+    scroller.scrollTop = scroller.scrollHeight;
+
+    // Read back the real offset instead of assuming how far the list overflows.
+    const scrolled = scroller.scrollTop;
+
+    const after = {
+      input: input.getBoundingClientRect().top,
+      label: label.getBoundingClientRect().top,
+    };
+
+    // Guard: without a real scroll, the comparison is two zeroes agreeing.
+    expect(scrolled).toBeGreaterThan(0);
+    expect(after.label - before.label).toBe(-scrolled);
+    expect(after.input - before.input).toBe(after.label - before.label);
+  }
+);

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -105,13 +105,16 @@ const _Switch = ({
     >
       <SwitchButton
         ref={ref}
-        className={cn('group/switch w-(--width)', classNames.container)}
+        className={cn(
+          'group/switch relative w-(--width)',
+          classNames.container
+        )}
         style={createWidthVar('width', width)}
       >
         {variant === 'settings' && label && (
           <Label elementType="span">{label}</Label>
         )}
-        <div className="relative">
+        <div>
           <div className={classNames.track}>
             <div className={classNames.thumb} />
           </div>

--- a/packages/components/src/Switch/Switch.tsx
+++ b/packages/components/src/Switch/Switch.tsx
@@ -114,10 +114,8 @@ const _Switch = ({
         {variant === 'settings' && label && (
           <Label elementType="span">{label}</Label>
         )}
-        <div>
-          <div className={classNames.track}>
-            <div className={classNames.thumb} />
-          </div>
+        <div className={classNames.track}>
+          <div className={classNames.thumb} />
         </div>
         {variant !== 'settings' && label && (
           <Label elementType="span">{label}</Label>


### PR DESCRIPTION
# Description

React Aria renders the real `<input>` inside the control's `<label>` wrapped in `VisuallyHidden`, which is `position: absolute` with no offsets. Both the `Checkbox` and `Switch` labels were `position: static`, so the input anchored to whatever positioned ancestor the consumer happened to have. In a list inside a dialog that is the dialog itself, a dozen static elements up.

An absolutely positioned box laid out against an ancestor outside a scroll container is not part of that container's scrolled content, so the input stopped travelling with the row it belongs to. Clicking a row far down the list focused an input the browser believed was over a thousand pixels away, and it scrolled the dialog to reveal it. In the reported case the dialog also set `overflow: hidden`, so there was no scrollbar to get back and it ended up blank.

Both labels are now `relative`. React Aria's [own docs](https://react-aria.adobe.com/VisuallyHidden) name this as a precondition of `VisuallyHidden` ("it must have a `position: relative` or `position: absolute` ancestor"), citing stray scrollbars. The focus jump is the sharper consequence, which is probably why it went unnoticed.

**On the scope.** The ticket describes this as a `Checkbox`-only oversight, on the grounds that `Radio` and `Switch` already position their labels. `Radio` does. `Switch` only looked like it did: its `relative` sat on a wrapper `<div>` around the track, a sibling of the hidden input rather than an ancestor, so it never reached it. Reproduced identically for both controls, so both are fixed here. That wrapper had no other job (the thumb translates rather than absolutely positioning, and `ui-state-focus` is an outline), so it is gone and the track is now a direct child of the label.

`Checkbox.Group` renders `Checkbox` children and needs no change of its own.

Consumers who worked around this by setting `position: relative` on their own scroll containers can drop it, though leaving it in place is harmless.

Closes DST-1740

## Screenshots / Preview

<!-- Paste screenshots/GIFs above, or link the Storybook preview once it's built. -->

| Before | After |
| ------ | ----- |
|        |       |

## Test Instructions

1. Open Storybook → `Components/Checkbox` → the `Hidden input travels with the control inside a scroll container` test, and the same one under `Components/Switch`. Each renders a fixed-height list with rows below the fold and every ancestor `static`, and asserts the hidden input travels exactly as far as its row. Both fail on `main` (the row moves 82px, the input moves 0).
2. `pnpm test:sb` and `pnpm test:unit` — 581 story tests and 1583 unit tests pass.
3. Visual check on `Components/Switch`: the track wrapper `<div>` was removed, so confirm the track and thumb are unchanged at both `default` and `settings` variants. Chromatic is the real gate here.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [x] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [x] Changeset added (`pnpm changeset`)