### PR TITLE
test(DST-1688): pin Home/End focus in cell number fields

### DIFF
--- a/packages/components/src/Table/Table.stories.tsx
+++ b/packages/components/src/Table/Table.stories.tsx
@@ -2033,8 +2033,6 @@ DataEntryGrid.test(
       }
     );
 
-    // Asserted for the TextField only: Home inside the NumberField still
-    // reaches the grid, which looks like an upstream useSpinButton issue.
     await step('Home and End keep focus inside a text field', async () => {
       await userEvent.click(first);
       first.setSelectionRange(2, 2);
@@ -2058,6 +2056,14 @@ DataEntryGrid.test(
       await userEvent.keyboard('{ArrowRight}');
       await userEvent.keyboard('{Tab}');
 
+      expect(document.activeElement).toBe(balance);
+    });
+
+    await step('Home and End keep focus inside a number field', async () => {
+      await userEvent.keyboard('{Home}');
+      expect(document.activeElement).toBe(balance);
+
+      await userEvent.keyboard('{End}');
       expect(document.activeElement).toBe(balance);
     });
 
@@ -2114,6 +2120,16 @@ DataEntryGridDefaultNavigation.test(
       await userEvent.keyboard('{Home}');
 
       expect(document.activeElement).not.toBe(first);
+    });
+
+    await step('Home stays put in a number field', async () => {
+      const balance = canvas.getByLabelText(`Balance for ${users[0].name}`);
+
+      await userEvent.click(balance);
+
+      await userEvent.keyboard('{Home}');
+
+      expect(document.activeElement).toBe(balance);
     });
   }
 );

--- a/packages/components/src/Table/Table.stories.tsx
+++ b/packages/components/src/Table/Table.stories.tsx
@@ -2059,6 +2059,9 @@ DataEntryGrid.test(
       expect(document.activeElement).toBe(balance);
     });
 
+    // The field has no minValue or maxValue, so useSpinButton claims both keys
+    // and they no-op. Focus is all there is to assert. Give the field a bound
+    // and they start jumping the value while these assertions still pass.
     await step('Home and End keep focus inside a number field', async () => {
       await userEvent.keyboard('{Home}');
       expect(document.activeElement).toBe(balance);
@@ -2122,6 +2125,8 @@ DataEntryGridDefaultNavigation.test(
       expect(document.activeElement).not.toBe(first);
     });
 
+    // Unlike the TextField above, useSpinButton claims Home before the grid
+    // sees it, so the number field keeps focus under arrow navigation too.
     await step('Home stays put in a number field', async () => {
       const balance = canvas.getByLabelText(`Balance for ${users[0].name}`);
 


### PR DESCRIPTION
# Description

`Home` and `End` inside a `NumberField` in a `<Table keyboardNavigationBehavior="tab">` used to push focus onto the row instead of staying in the field. It is fixed upstream, so this adds the assertions that would have caught it and drops a stale comment claiming it is still broken.

Verified by rendering the same table against react-aria-components 1.19.0 and 1.20.0 side by side. The escape was never `NumberField`-specific and was never `useSpinButton`: `useGridCell` had no bubble-phase `onKeyDown`, so any key from any focusable child of a cell reached `useSelectableCollection`, which owns `Home` and `End`. A `TextField` in the same table escaped just as readily. adobe/react-spectrum#10159 added the guard that stops keys originating inside a cell, and it shipped in 1.20.0, which we picked up in #5699.

Two steps added:

- `DataEntryGrid` asserts `Home` and `End` keep focus in the `NumberField`.
- `DataEntryGridDefaultNavigation` pins the remaining asymmetry: under arrow navigation a `TextField` loses focus to `Home` but a `NumberField` does not, because `useSpinButton` claims the key first.

No product code changes, so no changeset and no VRT — story-only, matching #5608.

Closes DST-1688

## Test Instructions

1. `pnpm exec vitest run --config vite.config.ts --project=storybook-tests packages/components/src/Table/Table.stories.tsx` — 62 tests pass.
2. Optional sanity check: invert either new assertion to `.not.toBe(balance)` and confirm it fails, so the steps are not vacuous.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [x] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)