### PR TITLE
chore(DST-1598): mark internal-only barrel exports with @internal

### DIFF
--- a/.memory/CONTEXT.md
+++ b/.memory/CONTEXT.md
@@ -38,6 +38,12 @@ A named region of a container's `grid-template-areas`, which a part claims with 
 
 Not to be confused with the `<Grid>` component's `areas` prop, which exposes the same CSS feature as a public layout API. Grid areas in this sense are internal to a container's own composition.
 
+### Internal export
+
+A runtime export kept in a package barrel (`packages/*/src/index.ts`) for composition by other Marigold packages rather than for consumers: the field parts, the overlay primitives, the slot contexts, the style-prop maps and the CSS-variable helpers. It carries a bare `/** @internal */` on the barrel line, which the Insights scanner reads from the barrel source to keep these out of the "unused" metrics and to flag direct consumer usage. The tag says nothing about stability and does not survive the build: tsdown collapses the barrel into one export statement, so the published package is unchanged.
+
+Not to be confused with a deprecated export, which is public API on its way out and documented as such.
+
 ### RAC-first imports
 
 The principle that when `react-aria-components` re-exports an API, we import it from there rather than from the `@react-aria/*` shell packages — because RAC pins its internals exactly while the shells keep caret ranges, so the shells can resolve to a second `react-aria` copy and split a context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ The CLI fetches from the Marigold docs site, caches for 24h, and works offline (
 - Use the `useClassNames` hook from `@marigold/system` for theming
 - Rename react-aria props: `isDisabled` → `disabled`, `isPending` → `loading`
 - Export components with named exports
+- **Barrel exports**: public only if the export has a docs page. Everything else in `packages/*/src/index.ts` gets a bare `/** @internal */` on the line above, one export per tagged statement. The Insights scanner reads the tag from the barrel source, so do not add it to component files (see `.memory/CONTEXT.md` → Internal export)
 - Use React Context for component composition (see `AccordionContext` patterns)
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The CLI fetches from the Marigold docs site, caches for 24h, and works offline (
 - Use the `useClassNames` hook from `@marigold/system` for theming
 - Rename react-aria props: `isDisabled` → `disabled`, `isPending` → `loading`
 - Export components with named exports
-- **Barrel exports**: public only if the export has a docs page. Everything else in `packages/*/src/index.ts` gets a bare `/** @internal */` on the line above, one export per tagged statement. The Insights scanner reads the tag from the barrel source, so do not add it to component files (see `.memory/CONTEXT.md` → Internal export)
+- **Barrel exports**: an export is internal when it exists for composition by other Marigold packages rather than for consumers. Documented exports (own page, or an API on a parent page) are public; consumer-facing exports that still lack docs stay public with a docs ticket (DST-1758). Internal exports get a bare `/** @internal */` on the line above, one export per tagged statement. The Insights scanner reads the tag from the barrel source, so do not add it to component files (see `.memory/CONTEXT.md` → Internal export)
 - Use React Context for component composition (see `AccordionContext` patterns)
 
 ## Testing

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -79,8 +79,10 @@ export type { CheckboxGroupProps } from './Checkbox/CheckboxGroup';
 export { Checkbox } from './Checkbox/Checkbox';
 export type { CheckboxProps } from './Checkbox/Checkbox';
 
+/** @internal */
 export { CloseButton } from './CloseButton/CloseButton';
 
+/** @internal */
 export { Collapsible } from './Collapsible/Collapsible';
 export type { CollapsibleProps } from './Collapsible/Collapsible';
 
@@ -112,11 +114,11 @@ export { Dialog } from './Dialog/Dialog';
 export type { DialogProps } from './Dialog/Dialog';
 export { ConfirmationDialog } from './Dialog/ConfirmationDialog';
 export type { ConfirmationDialogProps } from './Dialog/ConfirmationDialog';
-export {
-  useConfirmation,
-  ConfirmationProvider,
-  ConfirmationContext,
-} from './Dialog/useConfirmation';
+export { useConfirmation } from './Dialog/useConfirmation';
+/** @internal */
+export { ConfirmationProvider } from './Dialog/useConfirmation';
+/** @internal */
+export { ConfirmationContext } from './Dialog/useConfirmation';
 export type {
   ConfirmationResult,
   ConfirmationConfig,
@@ -135,6 +137,7 @@ export type { EmptyStateProps } from './EmptyState/EmptyState';
 export { ErrorState } from './ErrorState/ErrorState';
 export type { ErrorStateProps } from './ErrorState/ErrorState';
 
+/** @internal */
 export { FieldBase } from './FieldBase/FieldBase';
 export type { FieldBaseProps } from './FieldBase/FieldBase';
 
@@ -157,6 +160,7 @@ export type { GridProps } from './Grid/Grid';
 export { Headline } from './Headline/Headline';
 export type { HeadlineProps } from './Headline/Headline';
 
+/** @internal */
 export { HelpText } from './HelpText/HelpText';
 export type { HelpTextProps } from './HelpText/HelpText';
 
@@ -165,8 +169,10 @@ export { IconButton } from './IconButton/IconButton';
 export { Inline } from './Inline/Inline';
 export type { InlineProps } from './Inline/Inline';
 
+/** @internal */
 export { Input } from './Input/Input';
 export type { InputProps } from './Input/Input';
+/** @internal */
 export { SearchInput } from './Input/SearchInput';
 export type { SearchInputProps } from './Input/SearchInput';
 
@@ -176,6 +182,7 @@ export type { InsetProps } from './Inset/Inset';
 export { Keyboard } from './Keyboard/Keyboard';
 export type { KeyboardProps } from './Keyboard/Keyboard';
 
+/** @internal */
 export { Label } from './Label/Label';
 export type { LabelProps } from './Label/Label';
 
@@ -188,6 +195,7 @@ export type { LinkButtonProps } from './LinkButton/LinkButton';
 export { List } from './List/List';
 export type { ListProps } from './List/List';
 
+/** @internal */
 export { ListBox } from './ListBox/ListBox';
 export type { ListBoxProps } from './ListBox/ListBox';
 
@@ -197,6 +205,7 @@ export type { ListViewItemProps } from './ListView/ListViewItem';
 
 export { ActionMenu } from './Menu/ActionMenu';
 export type { ActionMenuProps } from './Menu/ActionMenu';
+/** @internal */
 export { ActionMenuContext } from './Menu/ActionMenuContext';
 
 export { Menu } from './Menu/Menu';
@@ -205,15 +214,19 @@ export type { MenuProps } from './Menu/Menu';
 export { NumberField } from './NumberField/NumberField';
 export type { NumberFieldProps } from './NumberField/NumberField';
 
+/** @internal */
 export { Popover } from './Overlay/Popover';
 export type { PopoverProps } from './Overlay/Popover';
 
+/** @internal */
 export { Modal } from './Overlay/Modal';
 export type { ModalProps } from './Overlay/Modal';
 
+/** @internal */
 export { NonModal } from './Overlay/NonModal';
 export type { NonModalProps } from './Overlay/NonModal';
 
+/** @internal */
 export { Underlay } from './Overlay/Underlay';
 export type { UnderlayProps } from './Overlay/Underlay';
 
@@ -232,8 +245,11 @@ export type { PaginationProps } from './Pagination/Pagination';
 export { ProgressCircle } from './ProgressCircle/ProgressCircle';
 export type { ProgressCircleProps } from './ProgressCircle/ProgressCircle';
 
+/** @internal */
 export { HeadingContext } from 'react-aria-components/Heading';
+/** @internal */
 export { TextContext } from 'react-aria-components/Text';
+/** @internal */
 export { Provider } from 'react-aria-components/slots';
 // Re-exported from react-aria-components (NOT `@react-aria/i18n`) so the
 // provider writes the same `I18nContext` instance that RAC-based components
@@ -377,6 +393,7 @@ export type { SegmentedControlProps } from './SegmentedControl/SegmentedControl'
 export { SegmentedControlOption } from './SegmentedControl/SegmentedControl';
 export type { SegmentedControlOptionProps } from './SegmentedControl/SegmentedControl';
 
+/** @internal */
 export { Tray } from './Tray/Tray';
 export type { TrayProps } from './Tray/Tray';
 

--- a/packages/system/src/index.ts
+++ b/packages/system/src/index.ts
@@ -8,12 +8,14 @@ export type { NumericFormatProps } from './components/Formatters/NumericFormat';
 export type { NumerFormatterOptions } from './components/Formatters/NumericFormat';
 
 // Hooks
+/** @internal */
 export { useClassNames } from './hooks/useClassNames';
 export type {
   UseClassNamesProps,
   ComponentClassNames,
 } from './hooks/useClassNames';
 export { useResponsiveValue } from './hooks/useResponsiveValue';
+/** @internal */
 export { useStateProps } from './hooks/useStateProps';
 export type {
   ComponentState,
@@ -46,20 +48,30 @@ export type {
 export { defaultTheme } from './defaultTheme';
 
 // Style Props - only export what exists
-export {
-  fontWeight,
-  textSize,
-  textStyle,
-  textWrap,
-  whiteSpace,
-  lineHeight,
-  alignment,
-  placeItems,
-  textAlign,
-  verticalAlign,
-  aspect,
-  cursorStyle,
-} from './style-props';
+/** @internal */
+export { fontWeight } from './style-props';
+/** @internal */
+export { textSize } from './style-props';
+/** @internal */
+export { textStyle } from './style-props';
+/** @internal */
+export { textWrap } from './style-props';
+/** @internal */
+export { whiteSpace } from './style-props';
+/** @internal */
+export { lineHeight } from './style-props';
+/** @internal */
+export { alignment } from './style-props';
+/** @internal */
+export { placeItems } from './style-props';
+/** @internal */
+export { textAlign } from './style-props';
+/** @internal */
+export { verticalAlign } from './style-props';
+/** @internal */
+export { aspect } from './style-props';
+/** @internal */
+export { cursorStyle } from './style-props';
 export type {
   AspectProp,
   AlignmentProp,
@@ -91,16 +103,25 @@ export type {
 export type { ClassValue, VariantProps } from './utils/className.utils';
 export { cva, cn } from './utils/className.utils';
 export type { Scale, ScaleValue } from './utils/css-variables.utils';
-export {
-  createVar,
-  createSpacingVar,
-  createWidthVar,
-  createHeightVar,
-  ensureCssVar,
-  isAxislessToken,
-  isFraction,
-  isScale,
-  isValidCssCustomPropertyName,
-  resolveInsetAxes,
-} from './utils/css-variables.utils';
+/** @internal */
+export { createVar } from './utils/css-variables.utils';
+/** @internal */
+export { createSpacingVar } from './utils/css-variables.utils';
+/** @internal */
+export { createWidthVar } from './utils/css-variables.utils';
+/** @internal */
+export { createHeightVar } from './utils/css-variables.utils';
+/** @internal */
+export { ensureCssVar } from './utils/css-variables.utils';
+/** @internal */
+export { isAxislessToken } from './utils/css-variables.utils';
+/** @internal */
+export { isFraction } from './utils/css-variables.utils';
+/** @internal */
+export { isScale } from './utils/css-variables.utils';
+/** @internal */
+export { isValidCssCustomPropertyName } from './utils/css-variables.utils';
+/** @internal */
+export { resolveInsetAxes } from './utils/css-variables.utils';
+/** @internal */
 export { get } from './utils/object.utils';


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits with the Jira ticket as the scope:

  <type>(DST-1234): <short description>

Types: feat | fix | chore | docs | refactor | test | style | perf | build | ci | revert
-->

# Description

The Insights scanner treats every runtime export of the package barrels as an official component, so composition internals such as `CloseButton` and `HelpText` show up as "unused" and distort the adoption metrics. This PR tags those exports with a bare `/** @internal */` in the barrel source, which is what the scanner fetches from GitHub. The linked DST-1599 change teaches the classifier to read the tag.

An export is internal when it has no docs page of its own, is not documented as an API on a parent page, and exists to be composed by other Marigold packages. Usage count does not protect an export: `Label` is imported directly 14 times and is still internal, because surfacing that usage is the point.

- `@marigold/components` (19): `FieldBase`, `Label`, `Input`, `SearchInput`, `HelpText`, `Popover`, `Modal`, `NonModal`, `Underlay`, `Tray`, `CloseButton`, `ListBox`, `Collapsible`, `ActionMenuContext`, `ConfirmationProvider`, `ConfirmationContext`, `HeadingContext`, `TextContext`, `Provider`
- `@marigold/system` (25): `useClassNames`, `useStateProps`, the 12 style-prop maps, the 10 CSS-variable helpers, `get`
- `@marigold/icons`: nothing, every runtime export is an icon

Kept public despite missing docs because they were built for consumers: `IconButton`, `useDatePresets`, `useDateRangePresets`, `OverlayContainerProvider`. DST-1758 tracks their documentation.

Tagged exports sit one per statement because the classifier attributes a leading comment to every specifier in the statement. The rule is recorded in `CLAUDE.md` (Code Style) and the term "Internal export" in `.memory/CONTEXT.md`.

No changeset on purpose: tsdown collapses the barrel into a single export statement, so `dist/index.mjs` and `dist/index.d.mts` of both packages are byte-identical before and after this change (verified by hash). No UI change, so no screenshots or VRT.

Closes DST-1598

## Test Instructions

1. `pnpm typecheck:only` and `pnpm --filter @marigold/system --filter @marigold/components build` pass.
2. Compare `shasum packages/{components,system}/dist/index.{mjs,d.mts}` against a build from `main`: the hashes are identical.
3. In `packages/components/src/index.ts` and `packages/system/src/index.ts`, confirm every `/** @internal */` sits directly above a statement exporting exactly one name.
4. `pnpm check:memory` passes for the new glossary term.

## Breaking Changes

No

## Checklist

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
