### PR TITLE
chore: keep versioning @marigold/docs under Changesets v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,6 @@
     "@changesets/changelog-git",
     { "repo": "marigold-ui/marigold" }
   ],
-  "fixed": [["@marigold/system", "@marigold/components", "@marigold/docs"]]
+  "fixed": [["@marigold/system", "@marigold/components", "@marigold/docs"]],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
# Description

Changesets v3 stops versioning private packages by default. `@marigold/docs` is
private and shares a `fixed` group with `@marigold/system` and
`@marigold/components`, so under v3 every changeset that names docs alongside a
public package becomes a "mixed" changeset and `changeset version` exits 1:

```
Error: Found mixed changeset dst-1607_boolean-fields-badge-slot
Found ignored packages: @marigold/docs
Found not ignored packages: @marigold/components @marigold/theme-rui @marigold/system
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

Three of the nine pending changesets are in that shape, so the Release job would
fail on the first push to `main` after #5811 lands. Opting private packages back
into versioning, without tagging them, keeps today's behavior.

Verified by running the real `@changesets/cli@3.0.2` against a copy of this
repo's manifests and pending changesets. With this key the versioning output is
byte-for-byte identical to `2.31.1`, with one exception that belongs to the CLI
bump rather than to this change: `@marigold/cli` bumps patch (2.0.1) instead of
major (3.0.0), because v3 no longer forces a major on a package whose peer
dependency bumped. `2.31.1` accepts the key unchanged and behaves exactly as
before, so this is safe to land ahead of the bump.

Unblocks #5811.

## Test Instructions

1. No manual testing required. On the current CLI (`2.31.1`) the key is a no-op:
   `pnpm changeset status` reports the same release plan as before.
2. After #5811 merges, the first `changeset version` on `main` should version
   `@marigold/docs` as part of the fixed group, exactly as it does today, and
   should not tag it.

## Breaking Changes

No

## Checklist

Release tooling config only. No package source, docs or UI is touched, so the
component-facing items below are N/A and no changeset is needed.

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
