### PR TITLE
ci: update changesets/action to v2 and migrate its inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,18 +33,17 @@ jobs:
         run: pnpm build
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2.1.2
         with:
-          title: 'release: version packages'
-          publish: pnpm changeset publish
+          pr-title: 'release: version packages'
+          publish-script: pnpm changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       # Send Slack Notification
       - name: Create release notification
         if: steps.changesets.outputs.published == 'true'
-        run: pnpm release:notification --packages '${{ steps.changesets.outputs.publishedPackages }}'
+        run: pnpm release:notification --packages '${{ steps.changesets.outputs.published-packages }}'
       - name: Slack Notification
         if: steps.changesets.outputs.published == 'true'
         uses: slackapi/slack-github-action@v4.0.0


### PR DESCRIPTION
# Description

Moves the release workflow to `changesets/action@v2.1.2` and migrates the
inputs and outputs that v2 renamed. Renovate's #5813 bumped only the `uses:`
line, which would have failed the Release job, so this replaces it.

Stacked on #5815, which is stacked on #5814. This one must not merge before
the CLI bump: v2 reads the root `package.json` and throws
*"Changesets CLI v2 is not supported, use Changesets action v1 instead"* if
`@changesets/cli` is still in the 2.x range.

**Why it has to be more than a version bump**, all read from the action's
source at `v2.1.2`:

- `throwOnRenamedInputs` errors on `title` and `publish`. They are now
  `pr-title` and `publish-script`.
- The `publishedPackages` output is now `published-packages`. This is the
  quiet one: a stale output reference is not an error, it resolves to an
  empty string, so `pnpm release:notification --packages ''` would have run
  with nothing.
- `github-token` now defaults to `${{ github.token }}`, and v2 throws if the
  `GITHUB_TOKEN` env var is set to a different value, so the env entry is
  removed.

**What this fixes.** CLI v3 moves consumed prerelease changesets into a new
`.changeset/pre/` folder. The `@changesets/read@0.6.7` bundled in v1 reads
that folder as a legacy v1-format changeset directory and throws
`ENOENT .changeset/pre/changes.md`, which would take down the Release job for
a whole prerelease cycle, and keep it down after `pre exit` until the stable
version run consumes the folder. v2 bundles `@changesets/read@1`, which reads
the new layout, and its `readChangesetState` filters ids prefixed with `pre/`
in place of the old `pre.json` id list.

**Unchanged by design.** npm auth still runs through OIDC provenance with no
token, which is what v2 expects after it dropped its `.npmrc` handling.
`create-github-releases` still defaults to true. Release commits now push
through the GitHub API rather than the git CLI, which is v2's default and
means they are signed with GitHub's key and attributed to the token owner.
Set `push-with-git-cli: true` if we want the old push behavior back.

## Test Instructions

There is no way to exercise a release workflow from a PR, so this is verified
by reading the action source rather than by running it. The first real run is
the Release job on the next push to `main` after this merges. Two things to
watch on that run:

1. The "release: version packages" PR is created or updated as usual, with the
   same title.
2. If it publishes, the Slack notification lists the published packages rather
   than arriving empty.

## Breaking Changes

No

## Checklist

CI configuration only. No package source, docs or UI is touched, so the
component-facing items are N/A and no changeset is needed.

- [ ] Storybook preview and Marigold docs preview are available
- [ ] Stories added/updated (with `component-test` tag where applicable)
- [ ] Unit tests added/updated
- [ ] Component documentation added/updated (if it exists)
- [ ] Accessibility reviewed against [ARIA APG](https://www.w3.org/WAI/ARIA/apg/) (for new/changed interactive components)
- [ ] Visual regression tests updated (for UI changes)
- [ ] Changeset added (`pnpm changeset`)
